### PR TITLE
Enhance Javadoc documentation and remove unused code

### DIFF
--- a/misc/COMPLETE_DOCUMENTATION_PRIORITIES_BREAKDOWN.md
+++ b/misc/COMPLETE_DOCUMENTATION_PRIORITIES_BREAKDOWN.md
@@ -1,0 +1,590 @@
+# PDC-2018Q35 Complete Documentation Priorities - All Classes Breakdown
+
+## Priority Legend
+- **P0 - Critical**: Core algorithms, hot paths, performance-critical operations, complex logic essential for understanding
+- **P1 - High**: Public APIs, important algorithms, threading coordination, complex private methods  
+- **P2 - Medium**: Configuration methods, validation logic, format conversions, helper methods
+- **P3 - Low**: Simple getters/setters, obvious utility methods, basic operations
+
+---
+
+# TIER 1 CLASSES - Core Architecture (P0 Priority)
+
+## 1. Grid.java (767 lines) - Core Hexagonal Grid System
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields (Document First)**
+```java
+ADJACENCY_MASKS (line 56)               - Pre-computed bitmasks for O(1) click operations
+gridState (line 50)                     - Core bitmask state representation (long[2])
+ROW_OFFSETS (line 46)                   - Hexagonal grid layout mapping  
+NUM_CELLS, NUM_ROWS, EVEN_NUM_COLS, ODD_NUM_COLS (lines 43-47) - Grid structure constants
+```
+
+**P1 - High Fields**
+```java
+trueCellsCount (line 51)                - Cached count for performance
+firstTrueCell (line 52)                 - Optimization for constraint checking
+recalculationNeeded (line 53)           - Lazy evaluation flag
+adjacencyArray (line 59)                - Legacy adjacency support
+ADJACENCY_CACHE (line 60)               - Pre-computed adjacency lookup
+```
+
+**P2 - Medium Fields**
+```java
+PACKED_TO_INDEX_CACHE (line 61)         - Format conversion cache
+ValueFormat enum (lines 35-40)          - Format specification
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods (Document First)**
+```java
+click(short cell)                       - line 458 - Hottest path for workers (ULTRA-HOT)
+click(short[] cells)                    - line 503 - Bulk click optimization (HOT)
+getBit(int index)                       - line 281 - Core bitmask operation (HOT)  
+setBit(int index)                       - line 259 - Core bitmask operation (HOT)
+computeAdjacents(short, ValueFormat, ValueFormat) - line 98 - Hexagonal adjacency algorithm
+static block                            - line 65  - Pre-computation initialization
+findTrueCells()                         - line 331 - Optimized bit scanning
+findFirstTrueCell()                     - line 400 - Bit operation optimization
+```
+
+**P1 - High Methods**
+```java
+findTrueCells(ValueFormat format)       - line 294 - Format-aware version
+findFirstTrueCell(ValueFormat format)   - line 351 - Format-aware version
+click(short, ValueFormat)               - line 430 - Format-aware click
+click(short row, short col)             - line 473 - PackedInt click
+findAdjacents(short, ValueFormat, ValueFormat) - line 168 - Adjacency lookup API
+canAffectFirstTrueCell()               - line 653 - Constraint optimization
+findFirstTrueAdjacentsAfter()          - line 549 - Binary search algorithm
+areAdjacent()                          - line 721 - Adjacency checking
+packedToIndex(short packed)             - line 225 - Hot conversion path
+indexToPacked(short index)              - line 239 - Hot conversion path
+```
+
+**P2 - Medium Methods**
+```java
+initialize()                            - line 256 - Abstract initialization
+Grid() constructor                      - line 251 - Basic constructor
+clone()                                - line 628 - Grid copying
+computeAdjacents(short cell, ValueFormat) - line 157 - Overloaded version
+computeAdjacents(short cell)           - line 162 - Default format version
+findAdjacents(short, ValueFormat)      - line 207 - Overloaded version
+findAdjacents(short cell)              - line 212 - Default format version
+click(long[] bitmask)                  - line 486 - Bitmask click
+```
+
+**P3 - Low Methods**
+```java
+isSolved()                             - line 613 - Simple boolean check
+getTrueCount()                         - line 618 - Simple getter with caching
+getGridState()                         - line 746 - Simple state accessor
+printGrid()                            - line 751 - Debug utility
+findFirstTrueAdjacents(ValueFormat)    - line 521 - Simple delegation
+findFirstTrueAdjacents()               - line 537 - Simple delegation
+areAdjacent(short, short)              - line 740 - Simple overload
+clearBit(int index)                    - line 270 - Simple bitmask operation
+computePackedToIndex(short packed)     - line 218 - Private helper
+```
+
+---
+
+## 2. StartYourMonkeys.java (191 lines) - System Orchestrator
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields**
+```java
+logger (line 11)                        - System-wide logging
+```
+
+**P1 - High Fields**
+```java
+defaultNumClicks, defaultNumThreads, defaultQuestionNumber (lines 17-19) - System configuration
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods (Document First)**
+```java
+main(String[] args)                     - line 13 - Complete system orchestration
+  // Critical sections within main():
+  // Lines 25-38: Argument parsing and configuration
+  // Lines 40-54: Grid selection and initialization  
+  // Lines 56-67: True adjacents calculation
+  // Lines 69-83: Worker thread creation and startup
+  // Lines 85-121: ForkJoinPool setup and coordination
+  // Lines 97-101: Batch flushing coordination
+  // Lines 106-117: Thread synchronization and cleanup
+  // Lines 123-126: Results processing
+  // Lines 158-166: Solution verification
+```
+
+**P2 - Medium Methods**
+```java
+formatElapsedTime(long millis)          - line 172 - Time formatting utility
+```
+
+---
+
+## 3. CombinationGeneratorTask.java (537 lines) - ForkJoin Task Engine
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields (Document First)**
+```java
+context (ThreadLocal<GeneratorContext>) - line 14 - Revolutionary ThreadLocal consolidation
+GeneratorContext class                  - line 18 - Resource consolidation architecture
+cachedAdjacencyState                   - line 61 - Incremental constraint optimization
+TRUE_CELL_ADJACENCY_MASKS              - line 378 - Pre-computed constraint masks  
+SUFFIX_OR_MASKS                        - line 379 - Constraint feasibility optimization
+targetMask                             - line 64 - Cached constraint target
+BATCH_SIZE                             - line 9  - Batching size optimization
+POOL_SIZE                              - line 11 - Pool sizing strategy
+FIRST_TRUE_ADJACENTS, firstTrueCell    - lines 130-131 - Optimization caches
+```
+
+**P1 - High Fields**
+```java
+prefix, prefixLength                    - lines 59-60 - Task state
+skipConstraintsCheck                    - line 62 - Optimization flag
+generatorPool                          - line 66 - Pool management
+numClicks, queueArray, maxFirstClickIndex - lines 54-56 - Global task state
+```
+
+**P2 - Medium Fields**
+```java
+CLICK_ADJACENCY_MATRIX                  - line 380 - Adjacency lookup
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods (Document First)**
+```java
+compute()                              - line 148 - Main task dispatcher (ULTRA-HOT)
+computeLeafCombinations(GeneratorContext) - line 217 - Final combinations generation (ULTRA-HOT)
+computeIntermediateSubtasksConstraintPath() - line 307 - Constraint checking path (HOT)
+computeIntermediateSubtasksSkipPath()  - line 281 - Pure performance path (HOT)
+canPotentiallySatisfyConstraints()     - line 350 - Incremental constraint checking
+ensureTrueCellMasks()                  - line 402 - Pre-computation strategy
+flushBatchFast()                       - line 441 - Backpressure handling
+GeneratorContext.getOrCreateBatch()    - line 24  - Batching strategy
+GeneratorContext.getNewBatchBlocking() - line 35  - Backpressure mechanism
+```
+
+**P1 - High Methods**
+```java
+init()                                 - line 206 - Task initialization
+recycleOwnResources()                  - line 466 - Resource cleanup
+computeRootSubtasks()                  - line 180 - Root task generation
+computeIntermediateSubtasks()          - line 271 - Task dispatch
+computeAdjacencyMaskFast()             - line 133 - Bit manipulation optimization
+initClickAdjacencyMatrix()             - line 383 - Matrix initialization
+flushAllPendingBatches()               - line 479 - Batch cleanup
+```
+
+**P2 - Medium Methods**
+```java
+CombinationGeneratorTask(root constructor) - line 79 - Root task setup
+CombinationGeneratorTask() default     - line 146 - Default constructor
+setForkJoinPool(), getForkJoinPool()   - lines 68, 73 - Pool management
+GeneratorContext.resetBatch()          - line 47 - Batch reset
+```
+
+**P3 - Low Methods**
+```java
+flushBatchHelper()                     - line 501 - Implementation detail
+```
+
+---
+
+## 4. TestClickCombination.java (216 lines) - Worker Thread Engine
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields (Document First)**
+```java
+CLICK_TO_TRUE_CELL_MASK                - line 18 - Bitmask validation cache (ULTRA-CRITICAL)
+EXPECTED_MASK                          - line 19 - Pre-computed target mask (ULTRA-CRITICAL)
+LOG_EVERY_N_FAILURES                   - line 11 - Performance monitoring constant
+```
+
+**P1 - High Fields**
+```java
+combinationQueue, queueArray, puzzleGrid - lines 13-15 - Core worker state
+logger                                 - line 10 - Thread logging
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods (Document First)**
+```java
+run()                                  - line 69  - Main worker loop (ULTRA-HOT)
+satisfiesOddAdjacency()                - line 193 - Ultra-optimized validation (ULTRA-HOT)
+getWork()                              - line 156 - Work-stealing implementation (HOT)
+initializeLookupTable()                - line 35  - Performance optimization setup
+  // Critical sections within run():
+  // Lines 97-130: Batch processing loop (ULTRA-HOT)
+  // Lines 101-128: Combination validation and testing (ULTRA-HOT)
+```
+
+**P1 - High Methods**
+```java
+triggerGeneratorShutdown()             - line 141 - Cross-thread coordination
+allQueuesEmpty()                       - line 180 - Work-stealing helper
+TestClickCombination constructor       - line 21  - Worker initialization
+```
+
+---
+
+# TIER 2 CLASSES - Performance Infrastructure (P1 Priority)
+
+## 5. WorkBatch.java (139 lines) - High-Performance Batching System
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields**
+```java
+buffer                                 - line 12 - Pre-allocated circular buffer
+remainingCapacity                      - line 17 - Deoptimization avoidance
+```
+
+**P1 - High Fields**
+```java
+capacity, numClicks                    - lines 13-14 - Configuration
+head, tail                             - lines 15-16 - Circular buffer pointers
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods**
+```java
+add(short[] prefix, int prefixLength, short lastElement) - line 53 - Hot path optimization (HOT)
+poll()                                 - line 75  - Worker consumption path (HOT)
+```
+
+**P1 - High Methods**
+```java
+add(short[] source)                    - line 37  - Basic addition
+clear()                                - line 107 - Recycling preparation
+```
+
+**P2 - Medium Methods**
+```java
+isEmpty(), size(), isFull()            - lines 91, 99, 135 - State queries
+setNumClicks()                         - line 26  - Configuration
+WorkBatch(int capacity)                - line 19  - Constructor
+```
+
+**P3 - Low Methods**
+```java
+accept(), get()                        - lines 118, 127 - Interface implementation
+```
+
+---
+
+## 6. CombinationQueueArray.java (88 lines) - Queue Management Coordinator
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields**
+```java
+workBatchPool                          - line 13 - Central WorkBatch recycling
+queues                                 - line 9  - Worker queue array
+solutionFound, generationComplete      - lines 17-18 - Coordination flags
+```
+
+**P1 - High Fields**
+```java
+generatorsRemaining                    - line 10 - Thread coordination
+winningMonkey, winningCombination      - lines 14-15 - Solution state
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods (Document First)**
+```java
+CombinationQueueArray(int, int)        - line 20 - Critical initialization with pre-allocation
+getWorkBatchPool()                     - line 46 - Pool access (HOT)
+solutionFound(String, short[])         - line 69 - Solution coordination
+```
+
+**P1 - High Methods**
+```java
+getQueue(int idx)                      - line 51 - Queue access
+getAllQueues()                         - line 56 - Queue array access
+generatorFinished()                    - line 61 - Thread coordination
+```
+
+**P2 - Medium Methods**
+```java
+getWinningMonkey()                     - line 79 - Result accessor
+getWinningCombination()                - line 84 - Result accessor
+```
+
+---
+
+## 7. CombinationQueue.java (46 lines) - Individual Queue Wrapper
+
+### **Fields Priority Breakdown**
+
+**P1 - High Fields**
+```java
+queue                                  - line 11 - JCTools MPMC queue
+QUEUE_SIZE                             - line 10 - Size optimization
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods**
+```java
+add(WorkBatch workBatch)               - line 28 - Producer path (HOT)
+getWorkBatch()                         - line 37 - Consumer path (HOT)
+```
+
+**P1 - High Methods**
+```java
+CombinationQueue()                     - line 13 - Constructor
+isEmpty()                              - line 42 - State query
+```
+
+**P2 - Medium Methods**
+```java
+getCapacity()                          - line 18 - Configuration accessor
+```
+
+---
+
+## 8. ArrayPool.java (88 lines) - High-Performance Array Pooling
+
+### **Fields Priority Breakdown**
+
+**P0 - Critical Fields**
+```java
+arrays                                 - line 10 - Pre-allocated array storage
+numClicks                              - line 9  - Static configuration
+```
+
+**P1 - High Fields**
+```java
+capacity                               - line 11 - Pool sizing
+head, tail, size                       - lines 16-18 - Circular buffer management
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods (Document First)**
+```java
+get()                                  - line 41 - Array retrieval (HOT)
+put(short[] array)                     - line 59 - Array recycling (HOT)
+```
+
+**P1 - High Methods**
+```java
+ArrayPool(int capacity)                - line 20 - Constructor with validation
+setNumClicks(int numClicks)            - line 31 - Static configuration
+```
+
+**P2 - Medium Methods**
+```java
+isEmpty()                              - line 76 - State query
+size()                                 - line 84 - State query
+```
+
+---
+
+## 9. TaskPool.java (64 lines) - Task Object Recycling
+
+### **Fields Priority Breakdown**
+
+**P1 - High Fields**
+```java
+arrays                                 - line 5  - Task storage array
+capacity                               - line 6  - Pool sizing
+head, tail, size                       - lines 7-9 - Circular buffer management
+```
+
+### **Methods Priority Breakdown**
+
+**P0 - Critical Methods**
+```java
+get()                                  - line 20 - Task retrieval (HOT)
+put(CombinationGeneratorTask task)     - line 37 - Task recycling (HOT)
+```
+
+**P1 - High Methods**
+```java
+TaskPool(int capacity)                 - line 11 - Constructor
+```
+
+**P2 - Medium Methods**
+```java
+isEmpty()                              - line 52 - State query
+size()                                 - line 60 - State query
+```
+
+---
+
+# TIER 3 CLASSES - Concrete Implementations (P2 Priority)
+
+## 10. Grid13.java (27 lines) - Q13 Puzzle Configuration
+
+### **Fields Priority Breakdown**
+- No additional fields beyond inherited Grid fields
+
+### **Methods Priority Breakdown**
+
+**P1 - High Methods**
+```java
+initialize()                           - line 6  - Q13-specific initialization with bitmask literals
+```
+
+**Key Documentation Points:**
+- Bitmask literals: `gridState[0] = -6917317925703516160L; gridState[1] = 8191L;`
+- Pre-computed initial state: `firstTrueCell = 32, trueCellsCount = 30`
+- Commented historical clicks for reference
+
+---
+
+## 11. Grid22.java (34 lines) - Q22 Puzzle Configuration
+
+### **Fields Priority Breakdown**
+- No additional fields beyond inherited Grid fields
+
+### **Methods Priority Breakdown**
+
+**P1 - High Methods**
+```java
+initialize()                           - line 5  - Q22-specific initialization with bitmask literals
+```
+
+**Key Documentation Points:**
+- Bitmask literals: `gridState[0] = 3293960916490350006L; gridState[1] = 15078939901952L;`
+- Pre-computed initial state: `firstTrueCell = 1, trueCellsCount = 50`
+- Commented historical clicks for reference
+
+---
+
+## 12. Grid35.java (17 lines) - Q35 Puzzle Configuration
+
+### **Fields Priority Breakdown**
+- No additional fields beyond inherited Grid fields
+
+### **Methods Priority Breakdown**
+
+**P1 - High Methods**
+```java
+initialize()                           - line 5  - Q35-specific initialization with bitmask literals
+```
+
+**Key Documentation Points:**
+- Bitmask literals: `gridState[0] = 45036546029518848L; gridState[1] = 32L;`
+- Pre-computed initial state: `firstTrueCell = 39, trueCellsCount = 4`
+- No commented historical clicks (hardest puzzle)
+
+---
+
+## 13. CombinationMessage.java (119 lines) - Logging Utility
+
+### **Fields Priority Breakdown**
+
+**P2 - Medium Fields**
+```java
+list                                   - line 10 - Combination data
+format                                 - line 11 - Format tracking
+```
+
+### **Methods Priority Breakdown**
+
+**P1 - High Methods (Log4j2 Integration)**
+```java
+formatTo(StringBuilder buffer)         - line 61 - GC-free logging (performance-critical for logging)
+```
+
+**P2 - Medium Methods**
+```java
+CombinationMessage(short[], ValueFormat) - line 13 - Constructor with validation
+convertTo(ValueFormat outputFormat)    - line 23 - Format conversion
+getCombination(ValueFormat outputFormat) - line 89 - Data accessor with conversion
+```
+
+**P3 - Low Methods**
+```java
+getFormattedMessage()                  - line 81 - Legacy fallback
+getFormat(), getParameters(), getThrowable() - lines 103, 109, 115 - Interface compliance
+```
+
+---
+
+# IMPLEMENTATION ROADMAP BY PRIORITY
+
+## **Phase 1: Ultra-Critical Hot Paths (Week 1)**
+**P0 methods called millions of times - highest performance impact**
+
+### Grid.java Ultra-Hot Methods
+- `click(short cell)` (line 458) - Worker hot path
+- `getBit()`, `setBit()` (lines 281, 259) - Core operations
+
+### CombinationGeneratorTask.java Ultra-Hot Methods  
+- `compute()` (line 148) - Task dispatcher
+- `computeLeafCombinations()` (line 217) - Final generation
+
+### TestClickCombination.java Ultra-Hot Methods
+- `run()` main loop (line 69) - Worker execution
+- `satisfiesOddAdjacency()` (line 193) - Validation hot path
+
+### WorkBatch.java Hot Methods
+- `add()` optimized version (line 53) - Batch building
+- `poll()` (line 75) - Batch consumption
+
+**Time Estimate: 20-24 hours**
+
+## **Phase 2: Core Architecture & Algorithms (Week 2)**
+**P0 fields and core algorithms essential for understanding**
+
+### All P0 Fields Across Classes
+- Grid bitmask fields and adjacency masks
+- CombinationGeneratorTask ThreadLocal optimization
+- TestClickCombination lookup tables
+
+### Critical Algorithms  
+- `computeAdjacents()` hexagonal algorithm
+- Constraint checking methods
+- Resource pooling systems
+
+**Time Estimate: 16-20 hours**
+
+## **Phase 3: System Architecture (Week 3)**
+**P1 methods that define system behavior and coordination**
+
+### StartYourMonkeys.java
+- Complete `main()` method orchestration
+- System initialization and coordination
+
+### Threading and Coordination  
+- Queue management methods
+- Pool management systems
+- Thread synchronization logic
+
+**Time Estimate: 12-16 hours**
+
+## **Phase 4: Supporting Infrastructure (Week 4-5)**
+**P2 and P3 methods for completeness**
+
+### Configuration Classes
+- Grid13, Grid22, Grid35 initialization
+- CombinationMessage logging utility
+
+### Utility Methods and Accessors
+- Format conversions
+- State queries  
+- Configuration methods
+
+**Time Estimate: 8-12 hours**
+
+## **Total Documentation Effort: 56-72 hours (7-9 weeks at 8 hours/week)**
+
+This comprehensive breakdown covers all 13 classes with ~150+ methods and ~50+ fields, prioritized by their critical importance to understanding your performance-optimized puzzle solver architecture!

--- a/misc/JAVADOC_DOCUMENTATION_STRATEGY.md
+++ b/misc/JAVADOC_DOCUMENTATION_STRATEGY.md
@@ -1,0 +1,784 @@
+# PDC-2018Q35 Comprehensive Javadoc Documentation Strategy
+
+## Executive Summary
+
+This documentation strategy is designed specifically for the PDC-2018Q35 Lights Out puzzle solver, focusing on **internal development documentation** to help team members understand "what the hell is going on" in this performance-critical, algorithm-heavy codebase. The strategy prioritizes architectural understanding and performance optimization documentation to facilitate team onboarding and maintenance.
+
+## 1. Current State Analysis
+
+### Documentation Coverage Assessment
+- **Overall coverage:** ~20% across the codebase
+- **Best documented:** `WorkBatch.java` (~60%)
+- **Needs urgent attention:** `Grid.java` (~30%), `CombinationGeneratorTask.java` (~15%)
+- **Critical gaps:** No package-level documentation, missing architectural overview, performance rationale undocumented
+
+### Key Issues Identified
+- Inconsistent documentation coverage across classes
+- Missing architectural context for complex algorithms
+- Performance optimizations lack explanation
+- Thread safety documentation absent
+- No build integration for documentation generation
+
+## 2. Prioritization Framework
+
+### Architecture Tiers (Documentation Priority)
+
+**Tier 1 - Core Architecture (P0 - Critical)**
+- `Grid.java` - Abstract hexagonal grid with bitmask operations
+- `StartYourMonkeys.java` - Main orchestrator and entry point
+- `CombinationGeneratorTask.java` - ForkJoin recursive task generation
+- `TestClickCombination.java` - Worker thread combination testing
+
+**Tier 2 - Performance Infrastructure (P1 - High)**
+- `WorkBatch.java` - Batch processing system
+- `CombinationQueueArray.java` - Queue management
+- `CombinationQueue.java` - Individual queue wrapper
+- `ArrayPool.java` & `TaskPool.java` - Memory pooling
+
+**Tier 3 - Concrete Implementations (P2 - Medium)**
+- `Grid13.java`, `Grid22.java`, `Grid35.java` - Puzzle configurations
+- `GridType.java`, `CombinationMessage.java` - Supporting utilities
+
+### Documentation Priority Matrix
+
+| **Element Type** | **P0 - Critical** | **P1 - High** | **P2 - Medium** | **P3 - Low** |
+|------------------|-------------------|---------------|-----------------|--------------|
+| **Classes** | Core algorithms, main orchestration | Performance utilities, threading | Configuration classes | Simple utilities |
+| **Methods** | Complex algorithms, hot paths | Public APIs, threading coordination | Configuration methods | Simple getters/setters |
+| **Fields** | Static caches, performance-critical | Algorithm parameters, instance state | Configuration flags | Basic counters |
+
+### Method-Level Priority Rules
+1. **P0 Methods:** Constructor logic, core algorithms, performance-critical loops
+2. **P1 Methods:** Public methods, complex private methods, thread coordination
+3. **P2 Methods:** Configuration methods, validation logic, format conversions
+4. **P3 Methods:** Simple getters/setters, obvious utility methods
+
+### Field-Level Priority Rules
+1. **P0 Fields:** Static configuration, performance-critical caches, thread synchronization
+2. **P1 Fields:** Instance state, algorithm parameters
+3. **P2 Fields:** Simple flags, counters, basic state tracking
+
+## 3. Javadoc Tag Usage Guidelines
+
+### Standard Tags with Performance Focus
+
+#### **@param** - Parameter Documentation
+Include algorithmic context and performance implications.
+
+**Example for Performance-Critical Code:**
+```java
+/**
+ * Performs ultra-fast click operation using pre-computed bitmasks.
+ * Core hot path for worker threads - optimized for JIT inlining.
+ * 
+ * @param cell The cell to click in Index format (0-108). Must be valid index 
+ *             to avoid array bounds checks. Uses pre-computed ADJACENCY_MASKS
+ *             for O(1) adjacency toggling via XOR operations.
+ */
+public final void click(short cell)
+```
+
+#### **@return** - Return Value with Algorithmic Context
+Explain return values in context of the algorithm and performance implications.
+
+**Example:**
+```java
+/**
+ * Returns true cells using optimized bit scanning.
+ * 
+ * @return Array of true cells in Index format (0-108). Length equals trueCellsCount
+ *         for optimal array sizing. Uses Long.numberOfTrailingZeros() for fast
+ *         bit position finding instead of linear scanning.
+ */
+public final short[] findTrueCells()
+```
+
+#### **@throws** - Exception Documentation with Context
+Document exceptions with architectural reasoning.
+
+**Example:**
+```java
+/**
+ * @throws IllegalArgumentException if numClicks <= 0 or > Grid.NUM_CELLS.
+ *         This validation prevents infinite loops in combination generation
+ *         and ensures mathematical bounds for constraint checking algorithms.
+ */
+public CombinationGeneratorTask(int numClicks, ...)
+```
+
+#### **@since** - Version/Performance Evolution Tracking
+Track when performance optimizations were introduced using **Date + Milestone** format.
+
+**Recommended @since Strategy:**
+- **Option 1 (Recommended):** `@since 2024.11 - Batching Architecture`
+- **Option 2:** `@since 2024.11 - When batching system was introduced`  
+- **Option 3:** `@since Batching-Era - High-performance batch processing`
+
+**Examples:**
+```java
+/**
+ * @since 2024.11 - Batching Architecture
+ *        Revolutionary batching system introduced to reduce queue contention
+ *        by 3-4 orders of magnitude compared to individual combination queuing.
+ */
+public class WorkBatch
+
+/**
+ * @since 2024.12 - ThreadLocal Consolidation  
+ *        Replaced multiple ThreadLocal fields with single GeneratorContext
+ *        to reduce lookup overhead and improve cache locality.
+ */
+private static final ThreadLocal<GeneratorContext> context
+```
+
+### Custom Tags for Performance Documentation
+
+#### **@performance** - Performance Characteristics
+Document performance implications, complexity, and optimization rationale.
+
+**Example:**
+```java
+/**
+ * @performance O(1) click operation using pre-computed adjacency bitmasks.
+ *              Eliminates dynamic adjacency calculation overhead.
+ *              JIT-optimized with final method modifier for inlining.
+ *              Hot path: called millions of times per second by worker threads.
+ */
+public final void click(short cell)
+```
+
+#### **@threading** - Concurrency and Thread Safety
+Document thread safety guarantees and concurrent access patterns.
+
+**Example:**
+```java
+/**
+ * @threading Thread-safe via work-stealing pattern. Each worker owns a queue
+ *            but can steal from others when empty. Uses lock-free JCTools
+ *            MpmcArrayQueue for minimal contention. Producer threads use
+ *            ThreadLocal batching to avoid synchronization in hot paths.
+ */
+public class CombinationQueue
+```
+
+#### **@algorithm** - Algorithm Description and Rationale
+Explain complex algorithms, especially non-obvious optimizations.
+
+**Example:**
+```java
+/**
+ * @algorithm Incremental constraint checking using cached adjacency state.
+ *            Each task tracks XOR of true-cell adjacencies from prefix.
+ *            Child tasks inherit parent state and XOR with new element.
+ *            Avoids O(prefix_length) recalculation at each step.
+ *            Uses pre-computed SUFFIX_OR_MASKS for O(1) feasibility checking.
+ */
+private boolean canPotentiallySatisfyConstraints(int startIdx)
+```
+
+#### **@memory** - Memory Management and Optimization
+Document memory allocation patterns and pooling strategies.
+
+**Example:**
+```java
+/**
+ * @memory Pre-allocated circular buffer eliminates dynamic allocation.
+ *         All arrays created at pool initialization to avoid GC pressure.
+ *         ThreadLocal pools prevent cross-thread synchronization overhead.
+ *         Pool sizing: POOL_SIZE/4 to balance memory vs allocation frequency.
+ */
+public class ArrayPool
+```
+
+#### **@optimization** - Specific Optimization Techniques
+Document specific optimization choices and their rationale.
+
+**Example:**
+```java
+/**
+ * @optimization Replaced multiple ThreadLocal fields with single GeneratorContext.
+ *               Reduces ThreadLocal lookup overhead from O(n) to O(1) per task.
+ *               Context consolidation improves CPU cache locality.
+ *               Single context.get() call per compute() method execution.
+ */
+private static final ThreadLocal<GeneratorContext> context
+```
+
+### Standard Tags with Cross-References
+
+#### **@see** - Cross-References to Related Optimizations
+```java
+/**
+ * @see WorkBatch#add(short[], int, short) - Optimized batch filling
+ * @see CombinationGeneratorTask#flushBatchFast - Backpressure handling  
+ * @see ArrayPool#get() - Memory pool for prefix arrays
+ */
+```
+
+#### **@deprecated** - Performance-Related Deprecations
+```java
+/**
+ * @deprecated As of 2024.11, replaced by batched work distribution.
+ *             Individual combination queuing caused excessive contention
+ *             consuming 30-40% of CPU time. Use WorkBatch-based approach.
+ * @see WorkBatch
+ * @see CombinationQueueArray
+ */
+```
+
+## 4. Documentation Templates
+
+### Core Algorithm Class Template
+```java
+/**
+ * [Class Name] - [Primary Purpose in Algorithm]
+ * 
+ * <p>[Detailed description of role in the overall puzzle-solving architecture.
+ * Explain the "what" and "why" - what problem this class solves and why this 
+ * approach was chosen.]</p>
+ * 
+ * <h2>Architecture Role</h2>
+ * <p>[How this class fits into the overall system. What classes depend on it,
+ * what it depends on, and the data flow.]</p>
+ * 
+ * <h2>Performance Characteristics</h2>
+ * <p>[Key performance properties, bottlenecks, and optimization strategies.
+ * Include complexity analysis for critical methods.]</p>
+ * 
+ * <h2>Thread Safety</h2>
+ * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * 
+ * @performance [Overall performance characteristics]
+ * @threading [Thread safety guarantees]  
+ * @algorithm [High-level algorithm description]
+ * @since [Version when introduced/major changes]
+ * @see [Related classes in the architecture]
+ */
+```
+
+### Performance Utility Class Template
+```java
+/**
+ * [Class Name] - [Performance Purpose - e.g., "High-performance memory pool"]
+ * 
+ * <p>[Detailed description of the performance problem this class solves.
+ * Include before/after metrics where applicable.]</p>
+ * 
+ * <h2>Optimization Strategy</h2>
+ * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
+ * Explain trade-offs made for performance gains.]</p>
+ * 
+ * <h2>Usage Patterns</h2>
+ * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * 
+ * <h2>Memory Management</h2>
+ * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * 
+ * @performance [Specific performance characteristics and measurements]
+ * @memory [Memory usage patterns and optimizations]
+ * @threading [Thread safety model]
+ * @since [When introduced and why]
+ */
+```
+
+### Worker/Task Class Template
+```java
+/**
+ * [Class Name] - [Worker Purpose - e.g., "ForkJoin recursive combination generator"]
+ * 
+ * <p>[High-level description of what this worker does in the algorithm.
+ * Explain its role in the concurrent processing pipeline.]</p>
+ * 
+ * <h2>Execution Model</h2>
+ * <p>[How this task executes - recursive subdivision, work-stealing, etc.
+ * Include task granularity and splitting criteria.]</p>
+ * 
+ * <h2>Resource Management</h2>
+ * <p>[How resources are acquired, used, and cleaned up. Pool usage patterns.]</p>
+ * 
+ * <h2>Performance Critical Paths</h2>
+ * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
+ * 
+ * @algorithm [Detailed algorithm description with complexity analysis]
+ * @threading [Concurrency model and synchronization approach]
+ * @performance [Performance characteristics and bottleneck analysis]
+ * @see [Related worker classes and coordination mechanisms]
+ */
+```
+
+### Configuration/Data Class Template
+```java
+/**
+ * [Class Name] - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * 
+ * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * 
+ * <h2>Configuration Details</h2>
+ * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * 
+ * <h2>Initialization Strategy</h2>
+ * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * 
+ * @algorithm [If complex initialization logic is involved]
+ * @since [When this configuration was introduced]
+ * @see [Related configuration classes]
+ */
+```
+
+### Critical Method Template
+```java
+/**
+ * [Method purpose] - [Performance/algorithmic role]
+ * 
+ * <p>[Detailed description of what the method does, emphasizing non-obvious
+ * algorithmic or performance aspects. Explain the "why" behind the implementation.]</p>
+ * 
+ * <h3>Algorithm Details</h3>
+ * <p>[Step-by-step algorithm description for complex methods. Include
+ * mathematical reasoning where applicable.]</p>
+ * 
+ * <h3>Performance Considerations</h3>
+ * <p>[Why this implementation was chosen. Alternative approaches considered.
+ * JIT optimization hints applied.]</p>
+ * 
+ * @param [param] [Detailed parameter description with constraints and format requirements]
+ * @return [Return value description with performance implications]
+ * @throws [Exception conditions with algorithmic context]
+ * @performance [Complexity analysis and performance characteristics]
+ * @algorithm [Specific algorithm techniques used]
+ * @optimization [Specific optimizations applied]
+ */
+```
+
+## 5. Code Review Checklist for Documentation Quality
+
+### P0 - Critical Documentation Requirements
+
+**Class-Level Documentation:**
+- [ ] **Architecture role clearly explained** - How does this class fit in the overall system?
+- [ ] **Performance characteristics documented** - What are the key performance properties?
+- [ ] **Thread safety model specified** - How does this class handle concurrent access?
+- [ ] **Algorithm overview provided** - What approach does this class take to solve its problem?
+- [ ] **Dependencies and relationships clear** - What other classes does this interact with?
+
+**Method-Level Documentation:**
+- [ ] **Non-obvious logic explained** - Why was this implementation chosen?
+- [ ] **Performance-critical paths identified** - Which methods are hot paths?
+- [ ] **Parameter constraints documented** - What are valid inputs and formats?
+- [ ] **Side effects clearly stated** - What state changes occur?
+- [ ] **Complexity analysis provided** - Big-O notation for algorithmic methods
+
+**Field-Level Documentation:**
+- [ ] **Static caches/optimizations explained** - Why pre-compute these values?
+- [ ] **Threading implications documented** - How is concurrent access handled?
+- [ ] **Memory management rationale** - Why this data structure choice?
+
+### P1 - High Priority Documentation Requirements
+
+**Performance Documentation:**
+- [ ] **@performance tag used** for methods with specific performance characteristics
+- [ ] **@optimization tag used** for optimized implementations with rationale
+- [ ] **@memory tag used** for classes with specific memory management patterns
+- [ ] **JIT optimization hints documented** - final methods, loop patterns, etc.
+
+**Threading Documentation:**
+- [ ] **@threading tag used** for concurrent classes
+- [ ] **Synchronization approach explained** - locks, atomics, lock-free, etc.
+- [ ] **Work-stealing patterns documented** - how tasks coordinate
+- [ ] **ThreadLocal usage rationale** - why per-thread resources needed
+
+**Algorithm Documentation:**
+- [ ] **@algorithm tag used** for complex algorithmic methods
+- [ ] **Mathematical foundations explained** - constraint satisfaction, combinatorics
+- [ ] **Optimization trade-offs documented** - space vs time, accuracy vs speed
+- [ ] **Alternative approaches mentioned** - why this approach chosen over others
+
+### P2 - Medium Priority Documentation Requirements
+
+**Maintainability:**
+- [ ] **@since tags track major changes** - when optimizations introduced
+- [ ] **@deprecated paths clearly marked** - migration guidance provided
+- [ ] **@see cross-references complete** - related classes and methods linked
+- [ ] **Code examples provided** for complex usage patterns
+
+**Formatting Standards:**
+- [ ] **HTML tags used sparingly** - only for essential formatting
+- [ ] **Code snippets in `<code>` tags** - method names, parameters, etc.
+- [ ] **Line length under 100 characters** - readable in IDE panels
+- [ ] **Consistent terminology** - same terms for same concepts throughout
+
+## 6. Build Integration Strategy
+
+### Maven Javadoc Plugin Configuration
+
+Add to `pom.xml`:
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>3.6.3</version>
+    <configuration>
+        <source>21</source>
+        <target>21</target>
+        <encoding>UTF-8</encoding>
+        <doclint>none</doclint> <!-- Disable strict checking for custom tags -->
+        <additionalOptions>-Xdoclint:none</additionalOptions>
+        
+        <!-- Custom tags for performance documentation -->
+        <tags>
+            <tag>
+                <name>performance</name>
+                <placement>a</placement>
+                <head>Performance Characteristics:</head>
+            </tag>
+            <tag>
+                <name>threading</name>
+                <placement>a</placement>
+                <head>Threading Model:</head>
+            </tag>
+            <tag>
+                <name>algorithm</name>
+                <placement>a</placement>
+                <head>Algorithm Details:</head>
+            </tag>
+            <tag>
+                <name>optimization</name>
+                <placement>a</placement>
+                <head>Optimization Strategy:</head>
+            </tag>
+            <tag>
+                <name>memory</name>
+                <placement>a</placement>
+                <head>Memory Management:</head>
+            </tag>
+        </tags>
+        
+        <!-- Include private methods for internal documentation -->
+        <show>private</show>
+        <nohelp>true</nohelp>
+        <windowTitle>PDC-2018Q35 Lights Out Solver - Internal Documentation</windowTitle>
+        <doctitle>PDC-2018Q35 Lights Out Puzzle Solver</doctitle>
+        <bottom>Performance-optimized brute-force solver for hexagonal grid Lights Out puzzles</bottom>
+    </configuration>
+    <executions>
+        <execution>
+            <id>attach-javadocs</id>
+            <goals>
+                <goal>jar</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+### Maven Commands for Documentation
+
+```bash
+# Generate Javadoc (development docs with private methods)
+mvn javadoc:javadoc
+
+# Generate Javadoc JAR
+mvn javadoc:jar
+
+# Generate docs and open in browser (if supported)
+mvn javadoc:javadoc && start target/site/apidocs/index.html
+```
+
+### IDE Configuration
+
+**IntelliJ IDEA Settings:**
+1. `Settings → Tools → Javadoc → Custom tags` - add performance, threading, algorithm, etc.
+2. `Settings → Editor → Code Style → Java → JavaDoc` - enable custom tag formatting
+3. `Settings → Editor → Live Templates` - create templates for common documentation patterns
+
+**VS Code Settings:**
+Add to `.vscode/settings.json`:
+```json
+{
+    "java.completion.includeDecompiledSources": false,
+    "java.codeGeneration.generateComments": true,
+    "java.codeGeneration.useBlocks": true
+}
+```
+
+## 7. Timeline Estimation & Milestone Tracking
+
+### Phase 1: Foundation (Week 1-2)
+**Priority: Tier 1 Classes**
+- [ ] `Grid.java` - Core architecture documentation
+- [ ] `StartYourMonkeys.java` - System orchestration  
+- [ ] Package-level documentation (`package-info.java`)
+- **Deliverable:** Basic architectural understanding for newcomers
+
+**Time Estimate:** 16-20 hours
+- Grid.java: 8-10 hours (743 lines, complex algorithms)
+- StartYourMonkeys.java: 4-5 hours (191 lines, orchestration logic)
+- Package documentation: 2-3 hours
+- Maven configuration: 2 hours
+
+### Phase 2: Core Processing (Week 3-4)  
+**Priority: Tier 1 Continued**
+- [ ] `CombinationGeneratorTask.java` - ForkJoin complexity
+- [ ] `TestClickCombination.java` - Worker thread logic
+- **Deliverable:** Complete understanding of core algorithm execution
+
+**Time Estimate:** 12-16 hours
+- CombinationGeneratorTask.java: 8-10 hours (537 lines, very complex)
+- TestClickCombination.java: 4-6 hours (216 lines, threading complexity)
+
+### Phase 3: Performance Infrastructure (Week 5)
+**Priority: Tier 2 Classes**
+- [ ] `WorkBatch.java` - Already ~60% done
+- [ ] `CombinationQueueArray.java`
+- [ ] `CombinationQueue.java`
+- [ ] `ArrayPool.java` & `TaskPool.java`
+- **Deliverable:** Complete performance optimization understanding
+
+**Time Estimate:** 8-10 hours
+- WorkBatch: 1 hour (already well documented)
+- Queue classes: 3-4 hours
+- Pool classes: 4-5 hours
+
+### Phase 4: Configuration & Cleanup (Week 6)
+**Priority: Tier 3 Classes**
+- [ ] `Grid13.java`, `Grid22.java`, `Grid35.java`
+- [ ] Utility classes
+- [ ] Documentation review and consistency pass
+- **Deliverable:** Complete documentation coverage
+
+**Time Estimate:** 6-8 hours
+
+### Total Estimated Time: 42-54 hours (6-7 weeks at ~8 hours/week)
+
+## 8. Team Collaboration Guidelines
+
+### Single Developer → Team Onboarding Approach
+
+**Documentation Workflow:**
+1. **Document as you understand** - When figuring out complex code sections, immediately document your understanding
+2. **"Rubber duck" documentation** - Write explanations as if explaining to a teammate who just joined
+3. **Progressive enhancement** - Start with basic architectural documentation, then add performance details
+4. **Context preservation** - Document the "why" behind optimizations, not just the "what"
+
+### Documentation Standards for Collaboration
+
+**Before Sharing Code:**
+- [ ] **Architecture overview complete** - High-level system understanding documented
+- [ ] **Core algorithms explained** - Complex methods have detailed explanations
+- [ ] **Performance rationale documented** - Why optimizations were chosen
+- [ ] **Threading model clear** - Concurrency patterns explained
+- [ ] **Setup instructions ready** - How to build, run, and understand output
+
+**Documentation Review Process:**
+1. **Self-review first** - Does the documentation answer "what the hell is going on?"
+2. **Imagine onboarding** - Would a new developer understand this in 30 minutes?
+3. **Check completeness** - Are the complex parts explained adequately?
+4. **Verify examples** - Do code examples actually work?
+
+### Communication Patterns
+
+**For Performance-Critical Code:**
+```java
+/**
+ * CRITICAL OPTIMIZATION: This method is called millions of times per second.
+ * 
+ * <p>Any changes here must be performance-tested. The current implementation
+ * uses [specific technique] because [performance reasoning]. Previous attempts
+ * with [alternative approach] resulted in [performance impact].</p>
+ * 
+ * <p>If modifying, ensure JIT inlining still works (method must stay under
+ * ~35 bytecodes) and preserve the [specific optimization pattern].</p>
+ */
+```
+
+**For Complex Algorithms:**
+```java
+/**
+ * ALGORITHM EXPLANATION: This implements [algorithmic approach] for [problem].
+ * 
+ * <p>The key insight is [mathematical/algorithmic insight]. The approach differs
+ * from obvious solutions because [reasoning]. Each step does [purpose]:</p>
+ * 
+ * <ol>
+ *   <li>Step 1: [purpose and reasoning]</li>
+ *   <li>Step 2: [purpose and reasoning]</li>
+ *   <li>Step 3: [purpose and reasoning]</li>
+ * </ol>
+ */
+```
+
+## 9. Maintenance Procedures
+
+### Documentation Maintenance Triggers
+
+**When to Update Documentation (Priority Order):**
+1. **P0 - Immediate Update Required:**
+   - Performance optimization changes
+   - Algorithm modifications
+   - Thread safety model changes
+   - API signature changes
+
+2. **P1 - Update Within Sprint:**
+   - New public methods added
+   - Significant refactoring
+   - Bug fixes that change behavior
+   - Configuration changes
+
+3. **P2 - Update Next Release:**
+   - Code cleanup
+   - Variable renaming
+   - Minor optimizations
+   - Style improvements
+
+### Documentation Decay Prevention
+
+**Automated Checks:**
+```bash
+#!/bin/bash
+# Add to pre-commit hook or CI
+
+# Check for new public methods without documentation
+grep -n "public.*(" src/**/*.java | grep -v "/**" | grep -B2 -A2 "public"
+
+# Check for TODO markers in documentation
+grep -r "@TODO\|FIXME\|XXX" src/**/*.java
+
+# Validate custom Javadoc tags
+mvn javadoc:javadoc 2>&1 | grep -i "unknown tag"
+```
+
+**Regular Maintenance Schedule:**
+- **Monthly:** Review Tier 1 classes for documentation drift
+- **Quarterly:** Full documentation consistency review
+- **After major performance changes:** Update affected performance documentation immediately
+- **Before sharing code:** Complete documentation review checklist
+
+**Documentation Update Workflow:**
+1. **Identify change scope** - What classes/methods are affected?
+2. **Update primary documentation** - Method/class level changes
+3. **Update cross-references** - @see tags and related documentation
+4. **Update architectural documentation** - If design patterns changed
+5. **Test documentation generation** - `mvn javadoc:javadoc` to verify
+6. **Commit with doc changes** - Include documentation updates in same commit
+
+## 10. Quality Metrics and Validation Rules
+
+### Documentation Coverage Metrics
+
+**Automated Documentation Coverage Tracking:**
+```bash
+#!/bin/bash
+# doc-coverage-check.sh - Add to CI/build process
+
+echo "=== Documentation Coverage Report ==="
+
+# Count methods missing documentation in Tier 1 classes
+TIER1_CLASSES="Grid.java StartYourMonkeys.java CombinationGeneratorTask.java TestClickCombination.java"
+MISSING_DOCS=0
+
+for class in $TIER1_CLASSES; do
+    # Count public methods without /** comments
+    COUNT=$(grep -c "public.*(" src/**/*$class | grep -v "/**" || echo "0")
+    MISSING_DOCS=$((MISSING_DOCS + COUNT))
+    echo "  $class: $COUNT undocumented public methods"
+done
+
+echo "Total Tier 1 undocumented methods: $MISSING_DOCS"
+
+# Quality gates
+if [ $MISSING_DOCS -gt 0 ]; then
+    echo "❌ FAIL: Critical classes have undocumented methods"
+    exit 1
+else
+    echo "✅ PASS: All Tier 1 classes fully documented"
+fi
+```
+
+**Documentation Quality Metrics:**
+- **Coverage Target:** 100% for Tier 1, 80% for Tier 2, 60% for Tier 3
+- **Complexity Documentation:** All methods >50 lines must have algorithm documentation
+- **Performance Documentation:** All methods marked `final` for inlining must document rationale
+- **Threading Documentation:** All classes with concurrent access must document threading model
+
+## 11. Legacy vs New Development Documentation
+
+### Legacy Code Documentation Strategy (Retroactive)
+
+**Phase 1: Archaeological Documentation**
+1. **Understand before documenting** - Run debugger, trace execution paths
+2. **Document discoveries** - As you figure out complex sections, immediately document
+3. **Focus on "why" over "what"** - Code shows what, documentation explains why
+4. **Prioritize by confusion factor** - Document most confusing code first
+
+**Legacy Code Template:**
+```java
+/**
+ * LEGACY ALGORITHM: [Brief description of what this accomplishes]
+ * 
+ * <p>This method implements [algorithm/pattern] to solve [specific problem].
+ * The implementation uses [technique] because [historical reason/constraint].</p>
+ * 
+ * <h3>Historical Context</h3>
+ * <p>[Why was this approach chosen originally? What constraints existed?]</p>
+ * 
+ * <h3>Current Understanding</h3>
+ * <p>[What we now understand about this code's behavior and performance]</p>
+ * 
+ * @algorithm [Best current understanding of the algorithm]
+ * @performance [Measured or estimated performance characteristics]
+ * @since [When this code was originally written, if known]
+ */
+```
+
+### New Development Documentation Strategy (Proactive)
+
+**Documentation-First Development:**
+1. **Write class-level documentation first** - Clarifies design before implementation
+2. **Document complex methods during development** - While algorithm is fresh in mind
+3. **Include performance rationale immediately** - Document optimization decisions as made
+4. **Add threading documentation during concurrent design** - Thread safety decisions documented
+
+**New Code Documentation Requirements:**
+- **All new classes** must have complete class-level documentation
+- **All new public methods** must have complete documentation
+- **All performance optimizations** must include @performance and @optimization tags
+- **All concurrent code** must include @threading documentation
+
+## 12. Formatting Standards
+
+### Line Length and Structure
+- **Maximum line length:** 100 characters (readable in IDE panels)
+- **Indentation:** 4 spaces for continuation lines in Javadoc
+- **Paragraph breaks:** Use `<p>` tags for multiple paragraphs
+
+### Consistent Terminology
+- **"Index format"** - not "index format" or "bit index format"
+- **"PackedInt format"** - not "packed format" or "packed integer"
+- **"Worker thread"** - not "consumer thread" or "monkey thread"
+- **"Hot path"** - for performance-critical code sections
+- **"Batching system"** - for the WorkBatch architecture
+- **"ThreadLocal pooling"** - for per-thread resource management
+
+### HTML Usage Guidelines
+- **Minimal HTML:** Only use for essential structure (`<p>`, `<h3>`, `<ol>`, `<li>`)
+- **Code references:** Use `<code>` tags for method names, class names, parameters
+- **No styling:** Avoid HTML styling attributes; rely on Javadoc CSS
+- **Lists:** Use `<ol>` for ordered steps, `<ul>` for feature lists
+
+### Cross-Reference Standards
+- **@see format:** `@see ClassName#methodName - Brief description`
+- **Inline links:** Use `{@link}` sparingly, only for essential cross-references
+- **Link text:** Keep link descriptions concise and relevant
+
+---
+
+## Implementation Next Steps
+
+1. **Set up Maven Javadoc plugin** with custom tags
+2. **Start with Phase 1** documentation (Grid.java and StartYourMonkeys.java)
+3. **Create architectural milestone timeline** for @since tags
+4. **Establish weekly documentation review process**
+5. **Add documentation coverage checks to build process**
+
+This strategy transforms your performance-critical codebase into a well-documented system that enables effective team onboarding and long-term maintenance while preserving the deep algorithmic and optimization knowledge embedded in the code.

--- a/misc/TAG_ORDERING.md
+++ b/misc/TAG_ORDERING.md
@@ -1,0 +1,37 @@
+# Tag Ordering:
+Based on the guidance in the project documentation markdown files ([COMPLETE](COMPLETE_DOCUMENTATION_PRIORITIES_BREAKDOWN.md), [STRATEGY](JAVADOC_DOCUMENTATION_STRATEGY.md)) and Oracle's [How to Write Doc Comments for the Javadoc Tool](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html) reference
+
+## Ordering for Multiple @see Tags (where a second sorting key is needed, use alphabetical order):
+1. @see #field
+2. @see #Constructor(Type, Type...)
+3. @see #Constructor(Type id, Type id...)
+4. @see #method(Type, Type,...)
+5. @see #method(Type id, Type, id...)
+6. @see Class
+7. @see Class#field
+8. @see Class#Constructor(Type, Type...)
+9. @see Class#Constructor(Type id, Type id)
+10. @see Class#method(Type, Type,...)
+11. @see Class#method(Type id, Type id,...)
+12. @see package.Class
+13. @see package.Class#field
+14. @see package.Class#Constructor(Type, Type...)
+15. @see package.Class#Constructor(Type id, Type id)
+16. @see package.Class#method(Type, Type,...)
+17. @see package.Class#method(Type id, Type, id)
+18. @see package
+
+## Official Tags Order:
+1. @param {listed in argument-declaration order}
+2. @return
+3. @throws (or @exception) {listed in alphabetical order by the exception names}
+4. @see {listed in the order shown above}
+5. @since
+6. @deprecated
+
+## Custom Tags Order:
+7. @performance
+8. @threading
+9. @algorithm
+10. @memory
+11. @optimization

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,9 @@
         <type>pom</type>
       </dependency>
     </dependencies>
-</dependencyManagement>
+  </dependencyManagement>
 
   <dependencies>
-
     <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
@@ -92,6 +91,62 @@
               <includeScope>runtime</includeScope>
             </configuration>
           </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.11.2</version>
+        <configuration>
+            <source>24</source>
+            <target>24</target>
+            <encoding>UTF-8</encoding>
+            <doclint>none</doclint> <!-- Disable strict checking for custom tags -->
+            <additionalOptions>-Xdoclint:none</additionalOptions>
+            
+            <!-- Custom tags for performance documentation -->
+            <tags>
+                <tag>
+                    <name>performance</name>
+                    <placement>a</placement>
+                    <head>Performance Characteristics:</head>
+                </tag>
+                <tag>
+                    <name>threading</name>
+                    <placement>a</placement>
+                    <head>Threading Model:</head>
+                </tag>
+                <tag>
+                    <name>algorithm</name>
+                    <placement>a</placement>
+                    <head>Algorithm Details:</head>
+                </tag>
+                <tag>
+                    <name>optimization</name>
+                    <placement>a</placement>
+                    <head>Optimization Strategy:</head>
+                </tag>
+                <tag>
+                    <name>memory</name>
+                    <placement>a</placement>
+                    <head>Memory Management:</head>
+                </tag>
+            </tags>
+            
+            <!-- Include private methods for internal documentation -->
+            <show>private</show>
+            <nohelp>true</nohelp>
+            <windowTitle>PDC-2018Q35 Lights Out Solver - Internal Documentation</windowTitle>
+            <doctitle>PDC-2018Q35 Lights Out Puzzle Solver</doctitle>
+            <bottom>Performance-optimized brute-force solver for hexagonal grid Lights Out puzzles</bottom>
+        </configuration>
+        <executions>
+            <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                    <goal>jar</goal>
+                </goals>
+            </execution>
         </executions>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -81,50 +81,51 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
-        <configuration>
-            <source>24</source>
-            <target>24</target>
-            <encoding>UTF-8</encoding>
-            <doclint>none</doclint> <!-- Disable strict checking for custom tags -->
-            <additionalOptions>-Xdoclint:none</additionalOptions>
-            
-            <!-- Custom tags for performance documentation -->
-            <tags>
-                <tag>
-                    <name>performance</name>
-                    <placement>a</placement>
-                    <head>Performance Characteristics:</head>
-                </tag>
-                <tag>
-                    <name>threading</name>
-                    <placement>a</placement>
-                    <head>Threading Model:</head>
-                </tag>
-                <tag>
-                    <name>algorithm</name>
-                    <placement>a</placement>
-                    <head>Algorithm Details:</head>
-                </tag>
-                <tag>
-                    <name>memory</name>
-                    <placement>a</placement>
-                    <head>Memory Management:</head>
-                </tag>
-            </tags>
-            
-            <!-- Include private methods for internal documentation -->
-            <show>private</show>
-            <nohelp>true</nohelp>
-            <windowTitle>PDC-2018Q35 Lights Out Solver - Internal Documentation</windowTitle>
-            <doctitle>PDC-2018Q35 Lights Out Puzzle Solver</doctitle>
-            <bottom>Performance-optimized brute-force solver for hexagonal grid Lights Out puzzles</bottom>
-        </configuration>
         <executions>
             <execution>
                 <id>attach-javadocs</id>
                 <goals>
                     <goal>jar</goal>
                 </goals>
+                <configuration>
+                    <source>24</source>
+                    <encoding>UTF-8</encoding>
+                    <doclint>none</doclint>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                    <show>private</show>
+                    <nohelp>true</nohelp>
+                    <windowTitle>PDC-2018Q35 Lights Out Solver - Internal Documentation</windowTitle>
+                    <doctitle>PDC-2018Q35 Lights Out Puzzle Solver</doctitle>
+                    <bottom>Performance-optimized brute-force solver for hexagonal grid Lights Out puzzles</bottom>
+                    <tags>
+                        <tag>
+                            <name>performance</name>
+                            <placement>a</placement>
+                            <head>Performance Characteristics:</head>
+                        </tag>
+                        <tag>
+                            <name>threading</name>
+                            <placement>a</placement>
+                            <head>Threading Model:</head>
+                        </tag>
+                        <tag>
+                            <name>algorithm</name>
+                            <placement>a</placement>
+                            <head>Algorithm Details:</head>
+                        </tag>
+                        <tag>
+                            <name>memory</name>
+                            <placement>a</placement>
+                            <head>Memory Management:</head>
+                        </tag>
+                    </tags>
+                    <links>
+                        <link>https://www.javadoc.io/doc/it.unimi.dsi/fastutil/8.5.16/</link>
+                        <link>https://www.javadoc.io/doc/org.jctools/jctools-core/4.0.5/</link>
+                        <link>https://logging.apache.org/log4j/2.x/javadoc/log4j-api/</link>
+                        <link>https://logging.apache.org/log4j/2.x/javadoc/log4j-core/</link>
+                    </links>
+                </configuration>
             </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -122,14 +122,14 @@
                     <head>Algorithm Details:</head>
                 </tag>
                 <tag>
-                    <name>optimization</name>
-                    <placement>a</placement>
-                    <head>Optimization Strategy:</head>
-                </tag>
-                <tag>
                     <name>memory</name>
                     <placement>a</placement>
                     <head>Memory Management:</head>
+                </tag>
+                <tag>
+                    <name>optimization</name>
+                    <placement>a</placement>
+                    <head>Optimization Strategy:</head>
                 </tag>
             </tags>
             

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
-      <version>8.5.15</version>
+      <version>8.5.16</version>
     </dependency>
 
     <dependency>
@@ -42,34 +42,18 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>com.lmax</groupId>
       <artifactId>disruptor</artifactId>
       <version>4.0.0</version>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
       <version>4.0.5</version>
-    </dependency>
-
-    <!-- JMH dependencies -->
-    <dependency>
-        <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-core</artifactId>
-        <version>1.37</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.openjdk.jmh</groupId>
-        <artifactId>jmh-generator-annprocess</artifactId>
-        <version>1.37</version>
-        <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -78,7 +62,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.8.1</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -96,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
         <configuration>
             <source>24</source>
             <target>24</target>

--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,6 @@
                     <placement>a</placement>
                     <head>Memory Management:</head>
                 </tag>
-                <tag>
-                    <name>optimization</name>
-                    <placement>a</placement>
-                    <head>Optimization Strategy:</head>
-                </tag>
             </tags>
             
             <!-- Include private methods for internal documentation -->

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -1,8 +1,8 @@
 package com.github.mrgarbagegamer;
 
 /**
- * A high performance array pool for pre-allocated combination arrays. Each array is of fixed size
- * {@link #numClicks}
+ * ArrayPool - A high performance array pool for pre-allocated combination arrays. Each array is of
+ * fixed size {@link #numClicks}
  * 
  * <p>
  * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
@@ -43,7 +43,7 @@ package com.github.mrgarbagegamer;
  * using the pool (else an exception will be thrown).
  * </p>
  * 
- * <h3>7/13 - ~53.8% of documentation completed</h3>
+ * <h3>11/13 - ~84.6% of documentation completed</h3>
  * 
  * @since 2025.07.02 - Custom Generator Pools
  * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
@@ -109,13 +109,128 @@ public final class ArrayPool {
      * @see #ArrayPool(int)
      */
     private final short[][] arrays;
+    /**
+     * The maximum number of arrays the pool can hold.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The capacity of the pool is a crucial parameter that determines how many arrays can be
+     * {@link #ArrayPool(int) pre-allocated} and managed by the pool. A larger capacity reduces the
+     * likelihood of contention and improves performance, but it also increases the memory footprint of
+     * the pool. A smaller capacity saves memory but may lead to more frequent allocations and
+     * deallocations, which can degrade performance. The optimal capacity depends on the specific use
+     * case and workload. Try to size the pool appropriately based on the expected number of concurrent
+     * threads and frequency of array usage, and lean towards a larger pool to minimize the risk of
+     * contention.
+     * </p>
+     * 
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) access time, as it's a final field.
+     * @memory The field itself is a primitive int, so it has a negligible memory footprint.
+     * @see #arrays
+     * @see #ArrayPool(int)
+     */
     private final int capacity;
 
-    // OPTIMIZATION: Pre-allocate the entire pool to guarantee non-null returns.
-    // This simplifies the get/put logic and improves performance by avoiding conditional checks.
-
+    /**
+     * The head index for {@link #get()} operations.
+     * 
+     * <p>
+     * The head index tracks where the next available array is located in the circular {@link #arrays
+     * buffer}. It is incremented each time an array is obtained from the pool, wrapping around to the
+     * start of the buffer when it reaches the end, implementing a circular buffer mechanism.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
+     * usage while still allowing for fast {@link #put(short[]) put} and get operations. The head index
+     * is updated in constant time, ensuring that get operations remain efficient even as the pool
+     * fills up and empties out.
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an int avoids potential overflow issues in long-running
+     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
+     * pointer for both head and {@link #tail}, but that would complicate the logic and force an extra
+     * arithmetic operation on each operation, which could impact performance.
+     * </p>
+     * 
+     * @since 2025.07.02 - Custom Generator Pools
+     * @threading The index is not thread-safe, as it is intended to be used within a single thread
+     *            context.
+     * @performance O(1) for get operations.
+     * @memory Minimal additional memory overhead (single int).
+     */
     private int head = 0;
+    /**
+     * The tail index for {@link #put(short[])} operations.
+     * 
+     * <p>
+     * The tail index tracks where the next returned array should be placed in the circular
+     * {@link #arrays buffer}. It is incremented each time an array is returned to the pool, wrapping
+     * around to the start of the buffer when it reaches the end, implementing a circular buffer
+     * mechanism.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
+     * usage while still allowing for fast put and {@link #get() get} operations. The tail index is
+     * updated in constant time, ensuring that put operations remain efficient even as the pool fills
+     * up and empties out.
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an int avoids potential overflow issues in long-running
+     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
+     * pointer for both {@link #head} and tail, but that would complicate the logic and force an extra
+     * arithmetic operation on each operation, which could impact performance.
+     * </p>
+     * 
+     * @since 2025.07.02 - Custom Generator Pools
+     * @threading The index is not thread-safe, as it is intended to be used within a single thread
+     *            context.
+     * @performance O(1) for put operations.
+     * @memory Minimal additional memory overhead (single int).
+     */
     private int tail = 0;
+    /**
+     * The current number of arrays in the pool.
+     * 
+     * <p>
+     * The size field tracks how many arrays are currently stored in the pool. It is incremented each
+     * time an array is returned to the pool via {@link #put(short[]) put} and decremented each time an
+     * array is obtained from the pool via {@link #get() get}. This field is crucial for ensuring that
+     * we do not exceed the pool's {@link #capacity} and for determining if the pool is empty.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The size field is updated in constant time during both put and get operations, ensuring that
+     * these operations remain efficient. It is also used to quickly check if the pool is empty (via
+     * {@link #isEmpty()}).
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the size to save a few bytes of memory, but the performance difference
+     * is negligible and using an int avoids potential overflow issues in long-running applications
+     * (plus, Java treats arithmetic with short values weirdly). We could avoid the size field entirely
+     * by using the {@link #head} and {@link #tail} indices to calculate the size on-the-fly (or by
+     * taking a {@link WorkBatch#remainingCapacity} approach and storing the remaining capacity), but
+     * that would complicate the logic and add extra arithmetic operations to the hot path of both put
+     * and get operations, which could impact performance. We also don't anticipate the size coming down
+     * to 0, so the deoptimization risk is minimal.
+     * </p>
+     * 
+     * @since 2025.07.02 - Custom Generator Pools
+     * @threading The field is not thread-safe, as it is intended to be used within a single thread
+     *            context.
+     * @performance O(1) for both put and get operations.
+     * @memory Minimal additional memory overhead (single int).
+     */
     private int size = 0;
 
     /**

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -275,6 +275,8 @@ public final class ArrayPool {
         
         this.capacity = capacity;
         this.arrays = new short[capacity][numClicks];
+        // Pre-allocated arrays are immediately available
+        this.size = capacity;
     }
 
     /**

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -43,8 +43,6 @@ package com.github.mrgarbagegamer;
  * using the pool (else an exception will be thrown).
  * </p>
  * 
- * <h3>11/13 - ~84.6% of documentation completed</h3>
- * 
  * @since 2025.07.02 - Custom Generator Pools
  * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
  *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
@@ -375,18 +373,33 @@ public final class ArrayPool {
     }
 
     /**
-     * Check if pool is empty.
+     * Checks if the pool is empty.
+     * 
+     * @return <code>true</code> if the pool is empty, <code>false</code> otherwise.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @threading Not thread-safe. Should be used within a single thread context.
+     * @performance O(1) time complexity, as it involves a simple comparison.
+     * @memory No additional memory allocation occurs during this operation.
+     * @see #get()
+     * @see #size()
      */
-    public boolean isEmpty() 
-    {
+    public boolean isEmpty() {
         return size == 0;
     }
 
     /**
-     * Get current pool size.
+     * Gets the current number of arrays in the pool.
+     * 
+     * @return The current number of arrays in the pool.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @threading Not thread-safe. Should be used within a single thread context.
+     * @performance O(1) time complexity, as it involves a simple field access.
+     * @memory No additional memory allocation occurs during this operation.
+     * @see #get()
+     * @see #put(short[])
+     * @see #isEmpty()
      */
-    public int size() 
-    {
+    public int size() {
         return size;
     }
 }

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -1,8 +1,27 @@
 package com.github.mrgarbagegamer;
 
 /**
- * High-performance array pool using simple circular buffer.
- * Eliminates ArrayDeque overhead for array recycling.
+ * ArrayPool - [Performance Purpose - e.g., "High-performance memory pool"]
+ * 
+ * <p>[Detailed description of the performance problem this class solves.
+ * Include before/after metrics where applicable.]</p>
+ * 
+ * <h2>Optimization Strategy</h2>
+ * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
+ * Explain trade-offs made for performance gains.]</p>
+ * 
+ * <h2>Usage Patterns</h2>
+ * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * 
+ * <h2>Memory Management</h2>
+ * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * 
+ * <h3>0/13 - 0% of documentation completed</h3>
+ * 
+ * @performance [Specific performance characteristics and measurements]
+ * @memory [Memory usage patterns and optimizations]
+ * @threading [Thread safety model]
+ * @since [When introduced and why]
  */
 public final class ArrayPool 
 {

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -1,31 +1,114 @@
 package com.github.mrgarbagegamer;
 
 /**
- * ArrayPool - [Performance Purpose - e.g., "High-performance memory pool"]
+ * A high performance array pool for pre-allocated combination arrays. Each array is of fixed size
+ * {@link #numClicks}
  * 
- * <p>[Detailed description of the performance problem this class solves.
- * Include before/after metrics where applicable.]</p>
+ * <p>
+ * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
+ * deallocations are expensive operations that can lead to frequent garbage collection pauses and
+ * performance degradation. {@link CombinationGeneratorTask} is a particularly worrying case, as the
+ * fork/join framework involves creating and destroying many tiny tasks and objects. Prefix arrays
+ * are a prime candidate for pooling, as they are frequently allocated and deallocated during the
+ * process of generation. By pre-allocating and pooling these arrays, we can reduce the number of
+ * allocations on the hot path to zero and amortize the allocation cost over multiple operations,
+ * which significantly improves performance.
+ * </p>
  * 
  * <h2>Optimization Strategy</h2>
- * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
- * Explain trade-offs made for performance gains.]</p>
+ * <p>
+ * Rather than implementing a complex lock-free queue or another advanced data structure, we use a
+ * simple circular buffer to manage the pool of arrays. This approach is straightforward, minimizes
+ * contention, and is easy to implement, though it requires us to isolate pools by thread. We could
+ * directly implement this 2D array into the {@link CombinationGeneratorTask} class, but that would
+ * lead to a lot of boilerplate code and make the class harder to read and maintain.
+ * </p>
  * 
  * <h2>Usage Patterns</h2>
- * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * <p>
+ * This pool is designed to be isolated by thread, giving each thread its own instance of the pool.
+ * Avoidance of contention is a key design goal, as the pool is used in a highly concurrent
+ * environment where multiple threads may be generating combinations simultaneously. Make sure to
+ * set {@link #numClicks} before initializing any objects of this class by using the
+ * {@link #setNumClicks(int)} method. Avoid passing arrays that have been handled by other threads,
+ * as this can lead to unexpected behavior and bugs.
+ * </p>
  * 
  * <h2>Memory Management</h2>
- * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * <p>
+ * This pool is designed to minimize memory allocations and deallocations on the hot path by
+ * pre-allocating all arrays upfront and reusing them. This approach reduces the pressure on the
+ * garbage collector, at the cost of a larger initial memory footprint. All arrays should be of the
+ * same size, which is determined by the static field {@link #numClicks}, which must be set before
+ * using the pool (else an exception will be thrown).
+ * </p>
  * 
- * <h3>0/13 - 0% of documentation completed</h3>
+ * <h3>3/13 - ~23.1% of documentation completed</h3>
  * 
- * @performance [Specific performance characteristics and measurements]
- * @memory [Memory usage patterns and optimizations]
- * @threading [Thread safety model]
- * @since [When introduced and why]
+ * @since 2025.07.02 - Custom Generator Pools
+ * @performance O(1) operations for both {@link #get()} and {@link #put(short[])} methods.
+ * @memory Preallocated at construction, with a fixed size determined by the {@link #capacity}
+ *         parameter.
+ * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
+ *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
+ *            {@link ThreadLocal thread-local} context, with all arrays being handled by the same
+ *            thread.
+ * @see CombinationGeneratorTask
  */
 public final class ArrayPool 
 {
+    /**
+     * The size of each array in the pool. This field must be set <b>before</b> using the
+     * {@link ArrayPool} class, as pre-allocation depends on this value.
+     * 
+     * <p>
+     * For JVM optimization purposes, it's most beneficial to perform all object allocations at the
+     * start of the program and reuse them throughout the program's lifetime. This avoids the overhead
+     * of frequent allocations and deallocations, which can lead to performance degradation due to
+     * garbage collection. However, we can't allocate arrays of variable size, so we need some field to
+     * determine the size of each array in the pool. This field fills that role.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This field is made static to ensure that it is shared across all instances of the ArrayPool
+     * class. Ideally, we would make this field final, but that would require us to set it in a static
+     * block, either through a system property or a configuration file, which is not ideal for our use
+     * case (though we could pursue this in the future). Instead, we provide {@link #setNumClicks(int) a
+     * setter} method to let users set this value and throw an exception if it is not set before creating
+     * an instance of the ArrayPool.
+     * </p>
+     * 
+     * <p>
+     * Since numClicks is restricted in range to a number between 1 and 109, we could technically use
+     * a byte or short to store this value, but we use an int for simplicity (and because Java does weird
+     * stuff to bytes/shorts during arithmetic operations).
+     * </p>
+     * 
+     * @since 2025.07.24 - ArrayPool Pre-allocation
+     * @performance O(1) access and modification, since it's a static field.
+     * @memory The field itself is a primitive int, so it has a negligible memory footprint.
+     * @see #setNumClicks(int)
+     * @see #ArrayPool(int)
+     */
     private static int numClicks = -1;
+    /**
+     * An array of pre-allocated short arrays, each of size {@link #numClicks}.
+     * 
+     * <p>
+     * We need a structure that can internally manage multiple arrays of the same size, one with quick
+     * accesses and minimal overhead. The 2D array structure is chosen for its simplicity and performance.
+     * </p>
+     * 
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) access time for both getting and putting arrays.
+     * @memory The pool is pre-allocated with a fixed capacity, which is determined by the
+     *         {@link #capacity} parameter, and holds arrays of size {@link #numClicks}.
+     * @optimization Preallocates arrays to avoid frequent allocations and deallocations.
+     * @see numClicks
+     * @see capacity
+     * @see #ArrayPool(int)
+     */
     private final short[][] arrays;
     private final int capacity;
 
@@ -41,6 +124,9 @@ public final class ArrayPool
         if (numClicks <= 0) 
         {
             throw new IllegalArgumentException("numClicks must be set before using ArrayPool.");
+        } else if (capacity <= 0) 
+        {
+            throw new IllegalArgumentException("Capacity must be greater than 0.");
         }
         
         this.capacity = capacity;

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -1,8 +1,8 @@
 package com.github.mrgarbagegamer;
 
 /**
- * ArrayPool - A high performance array pool for pre-allocated combination arrays. Each array is of
- * fixed size {@link #numClicks}
+ * A high performance array pool for pre-allocated combination arrays. Each array is of fixed size
+ * {@link #numClicks}.
  * 
  * <p>
  * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
@@ -39,19 +39,19 @@ package com.github.mrgarbagegamer;
  * This pool is designed to minimize memory allocations and deallocations on the hot path by
  * pre-allocating all arrays upfront and reusing them. This approach reduces the pressure on the
  * garbage collector, at the cost of a larger initial memory footprint. All arrays should be of the
- * same size, which is determined by the static field {@link #numClicks}, which must be set before
- * using the pool (else an exception will be thrown).
+ * same size, which is determined by the {@code static} field {@link #numClicks}, which must be set
+ * before using the pool (else an exception will be thrown).
  * </p>
  * 
  * @see CombinationGeneratorTask
  * @since 2025.07.02 - Custom Generator Pools
- * @performance O(1) operations for both {@link #get()} and {@link #put(short[])} methods.
+ * @performance {@code O(1)} operations for both {@link #get()} and {@link #put(short[])} methods.
  * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
  *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
  *            {@link java.lang.ThreadLocal thread-local} context, with all arrays being handled by
  *            the same thread.
- * @memory Preallocated at construction, with a fixed size determined by the {@link #capacity}
- *         parameter.
+ * @memory Preallocated at construction, with a fixed size determined by the {@link #capacity} and
+ *         {@link #numClicks} fields.
  */
 public final class ArrayPool {
     /**
@@ -68,29 +68,30 @@ public final class ArrayPool {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This field is made static to ensure that it is shared across all instances of the ArrayPool
-     * class. Ideally, we would make this field final, but that would require us to set it in a static
-     * block, either through a system property or a configuration file, which is not ideal for our use
-     * case (though we could pursue this in the future). Instead, we provide {@link #setNumClicks(int) a
-     * setter} method to let users set this value and throw an exception if it is not set before creating
-     * an instance of the ArrayPool.
+     * This field is made static to ensure that it is shared across all instances of the
+     * {@code ArrayPool} class. Ideally, we would make this field {@code final}, but that would require
+     * us to set it in a {@code static} block, either through a system property or a configuration file,
+     * which is not ideal for our use case (though we could pursue this in the future). Instead, we
+     * provide {@link #setNumClicks(int) a setter} method to let users set this value and throw an
+     * exception if it is not set before creating an instance of the {@code ArrayPool}.
      * </p>
      * 
      * <p>
-     * Since numClicks is restricted in range to a number between 1 and 109, we could technically use
-     * a byte or short to store this value, but we use an int for simplicity (and because Java does weird
-     * stuff to bytes/shorts during arithmetic operations).
+     * Since {@code numClicks} is restricted in range to a number between {@code 1} and {@code 109}, we
+     * could technically use a {@code byte} or {@code short} to store this value, but we use an
+     * {@code int} for simplicity (and because Java does weird stuff to {@code byte}s/{@code short}s
+     * during arithmetic operations).
      * </p>
      * 
      * @see #ArrayPool(int)
      * @see #setNumClicks(int)
-     * @since 2025.07.24 - ArrayPool Pre-allocation
-     * @performance O(1) access and modification, since it's a static field.
-     * @memory The field itself is a primitive int, so it has a negligible memory footprint.
+     * @since 2025.07.24 - {@code ArrayPool} Pre-allocation
+     * @performance {@code O(1)} access and modification, since it's a {@code static} field.
+     * @memory The field itself is a primitive {@code int}, so it has a negligible memory footprint.
      */
     private static int numClicks = -1;
     /**
-     * An array of pre-allocated short arrays, each of size {@link #numClicks}.
+     * An array of pre-allocated {@code short} arrays, each of size {@link #numClicks}.
      * 
      * <p>
      * We need a structure that can internally manage multiple arrays of the same size, one with quick
@@ -101,7 +102,7 @@ public final class ArrayPool {
      * @see #numClicks
      * @see #ArrayPool(int)
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) access time for both getting and putting arrays.
+     * @performance {@code O(1)} access time for both getting and putting arrays.
      * @memory The pool is pre-allocated with a fixed capacity, which is determined by the
      *         {@link #capacity} parameter, and holds arrays of size {@link #numClicks}.
      * @optimization Preallocates arrays to avoid frequent allocations and deallocations.
@@ -113,60 +114,62 @@ public final class ArrayPool {
      * <h3>Performance Considerations</h3>
      * <p>
      * The capacity of the pool is a crucial parameter that determines how many arrays can be
-     * {@link #ArrayPool(int) pre-allocated} and managed by the pool. A larger capacity reduces the
-     * likelihood of contention and improves performance, but it also increases the memory footprint of
-     * the pool. A smaller capacity saves memory but may lead to more frequent allocations and
-     * deallocations, which can degrade performance. The optimal capacity depends on the specific use
-     * case and workload. Try to size the pool appropriately based on the expected number of concurrent
-     * threads and frequency of array usage, and lean towards a larger pool to minimize the risk of
-     * contention.
+     * {@link #ArrayPool(int) pre-allocated} and managed by the pool. A larger {@code capacity} reduces
+     * the likelihood of contention and improves performance, but it also increases the memory footprint
+     * of the pool. A smaller {@code capacity} saves memory but may lead to more frequent allocations
+     * and deallocations, which can degrade performance. The optimal {@code capacity} depends on the
+     * specific use case and workload. Try to size the pool appropriately based on the expected number
+     * of concurrent threads and frequency of array usage, and lean towards a larger pool to minimize
+     * the risk of contention.
      * </p>
      * 
      * @see #arrays
      * @see #ArrayPool(int)
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) access time, as it's a final field.
-     * @memory The field itself is a primitive int, so it has a negligible memory footprint.
+     * @performance {@code O(1)} access time, as it's a {@code final} field.
+     * @memory The field itself is a primitive {@code int}, so it has a negligible memory footprint.
      */
     private final int capacity;
 
     /**
-     * The head index for {@link #get()} operations.
+     * The {@code head} index for {@link #get()} operations.
      * 
      * <p>
-     * The head index tracks where the next available array is located in the circular {@link #arrays
-     * buffer}. It is incremented each time an array is obtained from the pool, wrapping around to the
-     * start of the buffer when it reaches the end, implementing a circular buffer mechanism.
+     * The {@code head} index tracks where the next available array is located in the circular
+     * {@link #arrays buffer}. It is incremented each time an array is obtained from the pool, wrapping
+     * around to the start of the buffer when it reaches the end, implementing a circular buffer
+     * mechanism.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast {@link #put(short[]) put} and get operations. The head index
-     * is updated in constant time, ensuring that get operations remain efficient even as the pool
-     * fills up and empties out.
+     * usage while still allowing for fast {@link #put(short[]) put} and {@code get} operations. The
+     * {@code head} index is updated in constant time, ensuring that {@code get} operations remain
+     * efficient even as the pool fills up and empties out.
      * </p>
      * 
      * <p>
-     * We could use a short for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an int avoids potential overflow issues in long-running
-     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
-     * pointer for both head and {@link #tail}, but that would complicate the logic and force an extra
-     * arithmetic operation on each operation, which could impact performance.
+     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could also use a single pointer for both {@code head} and {@link #tail}, but that would
+     * complicate the logic and force an extra arithmetic operation on each operation, which could
+     * impact performance.
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) for get operations.
+     * @performance {@code O(1)} for {@link #get()} operations.
      * @threading The index is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @memory Minimal additional memory overhead (single int).
+     * @memory Minimal additional memory overhead (single {@code int}).
      */
     private int head = 0;
     /**
-     * The tail index for {@link #put(short[])} operations.
+     * The {@code tail} index for {@link #put(short[])} operations.
      * 
      * <p>
-     * The tail index tracks where the next returned array should be placed in the circular
+     * The {@code tail} index tracks where the next returned array should be placed in the circular
      * {@link #arrays buffer}. It is incremented each time an array is returned to the pool, wrapping
      * around to the start of the buffer when it reaches the end, implementing a circular buffer
      * mechanism.
@@ -175,88 +178,91 @@ public final class ArrayPool {
      * <h3>Performance Considerations</h3>
      * <p>
      * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast put and {@link #get() get} operations. The tail index is
-     * updated in constant time, ensuring that put operations remain efficient even as the pool fills
-     * up and empties out.
+     * usage while still allowing for fast {@code put} and {@link #get() get} operations. The
+     * {@code tail} index is updated in constant time, ensuring that {@code put} operations remain
+     * efficient even as the pool fills up and empties out.
      * </p>
      * 
      * <p>
-     * We could use a short for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an int avoids potential overflow issues in long-running
-     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
-     * pointer for both {@link #head} and tail, but that would complicate the logic and force an extra
-     * arithmetic operation on each operation, which could impact performance.
+     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could also use a single pointer for both {@link #head} and {@code tail}, but that would
+     * complicate the logic and force an extra arithmetic operation on each operation, which could
+     * impact performance.
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) for put operations.
+     * @performance {@code O(1)} for {@code put} operations.
      * @threading The index is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @memory Minimal additional memory overhead (single int).
+     * @memory Minimal additional memory overhead (single {@code int}).
      */
     private int tail = 0;
     /**
      * The current number of arrays in the pool.
      * 
      * <p>
-     * The size field tracks how many arrays are currently stored in the pool. It is incremented each
-     * time an array is returned to the pool via {@link #put(short[]) put} and decremented each time an
-     * array is obtained from the pool via {@link #get() get}. This field is crucial for ensuring that
-     * we do not exceed the pool's {@link #capacity} and for determining if the pool is empty.
+     * The {@code size} field tracks how many arrays are currently stored in the pool. It is incremented
+     * each time an array is returned to the pool via {@link #put(short[]) put} and decremented each
+     * time an array is obtained from the pool via {@link #get() get}. This field is crucial for
+     * ensuring that we do not exceed the pool's {@link #capacity} and for determining if the pool is
+     * empty.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The size field is updated in constant time during both put and get operations, ensuring that
-     * these operations remain efficient. It is also used to quickly check if the pool is empty (via
-     * {@link #isEmpty()}).
+     * The {@code size} field is updated in constant time during both {@code put} and {@code get}
+     * operations, ensuring that these operations remain efficient. It is also used to quickly check if
+     * the pool is empty (via {@link #isEmpty()}).
      * </p>
      * 
      * <p>
-     * We could use a short for the size to save a few bytes of memory, but the performance difference
-     * is negligible and using an int avoids potential overflow issues in long-running applications
-     * (plus, Java treats arithmetic with short values weirdly). We could avoid the size field entirely
-     * by using the {@link #head} and {@link #tail} indices to calculate the size on-the-fly (or by
-     * taking a {@link WorkBatch#remainingCapacity} approach and storing the remaining capacity), but
-     * that would complicate the logic and add extra arithmetic operations to the hot path of both put
-     * and get operations, which could impact performance. We also don't anticipate the size coming down
-     * to 0, so the deoptimization risk is minimal.
+     * We could use a {@code short} for the size to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could avoid the {@code size} field entirely by using the {@link #head} and {@link #tail} indices
+     * to calculate the size on-the-fly (or by taking a {@link WorkBatch#remainingCapacity} approach and
+     * storing the remaining capacity), but that would complicate the logic and add extra arithmetic
+     * operations to the hot path of both {@code put} and {@code get} operations, which could impact
+     * performance. We also don't anticipate the {@code size} coming down to {@code 0}, so the
+     * deoptimization risk is minimal.
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) for both put and get operations.
+     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
      * @threading The field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @memory Minimal additional memory overhead (single int).
+     * @memory Minimal additional memory overhead (single {@code int}).
      */
     private int size = 0;
 
     /**
-     * Constructs a new <code>ArrayPool</code> with the specified <code>capacity</code>. Pre-allocates
-     * all arrays to a size of {@link #numClicks}.
+     * Constructs a new {@code ArrayPool} with the specified {@code capacity}. Pre-allocates all arrays
+     * to a size of {@link #numClicks}.
      * 
      * <p>
      * Validation is performed to ensure that {@link #numClicks} has been set and that the
-     * <code>capacity</code> is greater than zero. If these conditions are not met, an
+     * {@code capacity} is greater than zero. If these conditions are not met, an
      * {@link java.lang.IllegalArgumentException IllegalArgumentException} will be thrown.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * The constructor pre-allocates all arrays in the pool to avoid allocations on the hot path. This
-     * ensures that both the {@link #get()} and {@link #put(short[])} methods can operate in O(1) time
-     * without any additional overhead.
+     * ensures that both the {@link #get()} and {@link #put(short[])} methods can operate in
+     * {@code O(1)} time without any additional overhead.
      * </p>
      * 
      * @param capacity the maximum number of arrays the pool can hold. Must be greater than zero.
-     * @throws IllegalArgumentException if {@link #numClicks} is not set or if <code>capacity</code> is
-     *                                  less than or equal to zero.
+     * @throws IllegalArgumentException if {@link #numClicks} is not set or if {@code capacity} is less
+     *                                  than or equal to zero.
      * @see #arrays
      * @see #setNumClicks(int)
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(n) time complexity for the constructor due to pre-allocation of arrays, where n is
-     *              the <code>capacity</code>.
-     * @memory Allocates a fixed amount of memory upfront based on the <code>capacity</code> and
+     * @performance <code>O({@link #capacity})</code> time complexity for the constructor due to
+     *              pre-allocation of arrays.
+     * @memory Allocates a fixed amount of memory upfront based on the {@code capacity} and
      *         {@link #numClicks}.
      * @optimization Pre-allocates all arrays to avoid allocations on the hot path.
      */
@@ -276,15 +282,15 @@ public final class ArrayPool {
      * of the class, as the pool relies on this value for {@link #ArrayPool(int) pre-allocation}.
      * 
      * @param numClicks the size of each array in the pool. Must be greater than zero.
-     * @throws IllegalArgumentException if <code>numClicks</code> is less than or equal to zero.
+     * @throws IllegalArgumentException if {@code numClicks} is less than or equal to zero.
      * @see #numClicks
      * @see #ArrayPool(int)
-     * @since 2025.07.24 - ArrayPool Pre-allocation
-     * @performance O(1) time complexity for setting the value.
+     * @since 2025.07.24 - {@code ArrayPool} Pre-allocation
+     * @performance {@code O(1)} time complexity for setting the value.
      * @threading This method is not thread-safe. It should be called once during application
      *            initialization, before any threads start using the pool.
      * @memory Does not allocate any additional memory, as it only sets a static field. However, future
-     *         allocations of ArrayPool instances will depend on this value.
+     *         allocations of {@code ArrayPool} instances will depend on this value.
      */
     public static void setNumClicks(int numClicks) {
         if (numClicks <= 0) {
@@ -294,29 +300,31 @@ public final class ArrayPool {
     }
 
     /**
-     * Obtains an array from the {@link #head} of the pool, returning <code>null</code> if the pool is empty.
+     * Obtains an array from the {@link #head} of the pool, returning {@code null} if the pool is empty.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * We need to ensure that the get operation is as fast as possible, as it is on the hot path of
-     * combination generation. By using a {@link #arrays circular buffer} and {@link #ArrayPool(int)
-     * pre-allocating} all arrays, we can achieve O(1) performance for this operation. We avoid a null
-     * check on the returned array (as this should never happen if the pool is sized correctly and null
-     * arrays aren't passed to the put method), which further improves performance, keeping only the
-     * {@link #size} check at the start of the method for short-circuiting purposes. If extra
-     * performance is needed, we could remove this check as well, but that would risk causing
-     * <code>size</code> to go negative.
+     * We need to ensure that the {@code get} operation is as fast as possible, as it is on the hot path
+     * of combination generation. By using a {@link #arrays circular buffer} and {@link #ArrayPool(int)
+     * pre-allocating} all arrays, we can achieve {@code O(1)} performance for this operation. We avoid
+     * a {@code null} check on the returned array (as this should never happen if the pool is sized
+     * correctly and {@code null} arrays aren't passed to the {@code put} method), which further
+     * improves performance, keeping only the {@link #size} check at the start of the method for
+     * short-circuiting purposes. If extra performance is needed, we could remove this check as well,
+     * but that would risk causing {@code size} to go negative.
      * </p>
      * 
-     * @return A pre-allocated short array of size {@link #numClicks}, or <code>null</code> if the
-     *        pool is empty.
+     * @return A pre-allocated {@code short} array of size {@link #numClicks}, or {@code null} if the
+     *         pool is empty.
      * @see #size
      * @see #isEmpty()
      * @see #put(short[])
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
-     * @memory No additional memory allocation occurs during this operation, as arrays are pre-allocated.
-     * @optimization Removes null checks by ensuring the pool is pre-allocated and properly managed.
+     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
+     * @memory No additional memory allocation occurs during this operation, as arrays are
+     *         pre-allocated.
+     * @optimization Removes {@code null} checks by ensuring the pool is pre-allocated and properly
+     *               managed.
      */
     public short[] get() {
         if (size == 0)
@@ -336,28 +344,28 @@ public final class ArrayPool {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The put operation is also on the hot path, so it needs to be as fast as possible. By using a
-     * {@link #arrays circular buffer} and {@link #ArrayPool(int) pre-allocating} all arrays, we can
-     * achieve O(1) performance for this operation as well. We avoid a null check on the input array to
-     * improve performance, assuming that the user will not pass null arrays (as this would indicate a
-     * bug in the calling code). We do, however, check if the pool is full to prevent overwriting
-     * existing arrays and incrementing the size beyond the capacity. If extra performance is needed, we
-     * could remove this check as well, but since tasks are stealed between threads, a full pool is a
-     * real possibility.
+     * The {@code put} operation is also on the hot path, so it needs to be as fast as possible. By
+     * using a {@link #arrays circular buffer} and {@link #ArrayPool(int) pre-allocating} all arrays, we
+     * can achieve {@code O(1)} performance for this operation as well. We avoid a {@code null} check on
+     * the input array to improve performance, assuming that the user will not pass {@code null} arrays
+     * (as this would indicate a bug in the calling code). We do, however, check if the pool is full to
+     * prevent overwriting existing arrays and incrementing the {@link #size} beyond the
+     * {@link #capacity}. If extra performance is needed, we could remove this check as well, but since
+     * tasks are stolen between threads, a full pool is a real possibility.
      * </p>
      * 
      * @param array A short array of size {@link #numClicks} to return to the pool. This array should
-     *              not be <code>null</code> and should not be used by other threads.
+     *              not be {@code null} and should not be used by other threads.
      * @see #size
      * @see #ArrayPool(int)
      * @see #get()
      * @see #setNumClicks(int)
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
      * @memory No additional memory allocation occurs during this operation, as the input array is added
      *         to the pool.
-     * @optimization Removes null checks by assuming well-formed input and ensuring the pool is properly
-     *               managed.
+     * @optimization Removes {@code null} checks by assuming well-formed input and ensuring the pool is
+     *               properly managed.
      */
     public void put(short[] array) {
         if (size >= capacity)
@@ -375,11 +383,11 @@ public final class ArrayPool {
     /**
      * Checks if the pool is empty.
      * 
-     * @return <code>true</code> if the pool is empty, <code>false</code> otherwise.
+     * @return {@code true} if the pool is empty, {@code false} otherwise.
      * @see #get()
      * @see #size()
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) time complexity, as it involves a simple comparison.
+     * @performance {@code O(1)} time complexity, as it involves a simple comparison.
      * @threading Not thread-safe. Should be used within a single thread context.
      * @memory No additional memory allocation occurs during this operation.
      */
@@ -395,7 +403,7 @@ public final class ArrayPool {
      * @see #isEmpty()
      * @see #put(short[])
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) time complexity, as it involves a simple field access.
+     * @performance {@code O(1)} time complexity, as it involves a simple field access.
      * @threading Not thread-safe. Should be used within a single thread context.
      * @memory No additional memory allocation occurs during this operation.
      */

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -1,270 +1,160 @@
 package com.github.mrgarbagegamer;
 
 /**
- * A high performance array pool for pre-allocated combination arrays. Each array is of fixed size
- * {@link #numClicks}.
- * 
+ * A high-performance, non-thread-safe object pool for recycling fixed-size {@code short[]} arrays.
+ *
  * <p>
- * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
- * deallocations are expensive operations that can lead to frequent garbage collection pauses and
- * performance degradation. {@link CombinationGeneratorTask} is a particularly worrying case, as the
- * fork/join framework involves creating and destroying many tiny tasks and objects. Prefix arrays
- * are a prime candidate for pooling, as they are frequently allocated and deallocated during the
- * process of generation. By pre-allocating and pooling these arrays, we can reduce the number of
- * allocations on the hot path to zero and amortize the allocation cost over multiple operations,
- * which significantly improves performance.
+ * This pool is a critical component of the memory management strategy for the
+ * {@link CombinationGeneratorTask}. Its primary purpose is to eliminate memory allocation on the
+ * hot path by pre-allocating and reusing {@code prefix} arrays used during generation. The
+ * fundamental rule of high-performance JVM tuning is to <strong>avoid allocations</strong>, and
+ * this class is a key tool for adhering to that principle.
  * </p>
- * 
- * <h2>Optimization Strategy</h2>
+ *
+ * <h2>Design and Implementation</h2>
  * <p>
- * Rather than implementing a complex lock-free queue or another advanced data structure, we use a
- * simple circular buffer to manage the pool of arrays. This approach is straightforward, minimizes
- * contention, and is easy to implement, though it requires us to isolate pools by thread. We could
- * directly implement this 2D array into the {@link CombinationGeneratorTask} class, but that would
- * lead to a lot of boilerplate code and make the class harder to read and maintain.
+ * The pool is implemented as a simple circular buffer using a 2D array, which provides {@code O(1)}
+ * {@link #get()} and {@link #put(short[])} operations with minimal overhead. This design was chosen
+ * for its simplicity and raw performance over more complex, and potentially higher-overhead,
+ * lock-free data structures.
  * </p>
- * 
- * <h2>Usage Patterns</h2>
+ *
+ * <h2>Usage and Thread Safety</h2>
  * <p>
- * This pool is designed to be isolated by thread, giving each thread its own instance of the pool.
- * Avoidance of contention is a key design goal, as the pool is used in a highly concurrent
- * environment where multiple threads may be generating combinations simultaneously. Make sure to
- * set {@link #numClicks} before initializing any objects of this class by using the
- * {@link #setNumClicks(int)} method. Avoid passing arrays that have been handled by other threads,
- * as this can lead to unexpected behavior and bugs.
+ * This class is <strong>not thread-safe</strong> and is designed to be used exclusively within a
+ * {@link ThreadLocal} context. Each generator must own a dedicated instance of {@code ArrayPool} to
+ * prevent race conditions.
  * </p>
- * 
- * <h2>Memory Management</h2>
- * <p>
- * This pool is designed to minimize memory allocations and deallocations on the hot path by
- * pre-allocating all arrays upfront and reusing them. This approach reduces the pressure on the
- * garbage collector, at the cost of a larger initial memory footprint. All arrays should be of the
- * same size, which is determined by the {@code static} field {@link #numClicks}, which must be set
- * before using the pool (else an exception will be thrown).
- * </p>
- * 
+ *
  * @see CombinationGeneratorTask
- * @since 2025.07.02 - Custom Generator Pools
- * @performance {@code O(1)} operations for both {@link #get()} and {@link #put(short[])} methods.
- * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
- *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
- *            {@link java.lang.ThreadLocal thread-local} context, with all arrays being handled by
- *            the same thread.
- * @memory Preallocated at construction, with a fixed size determined by the {@link #capacity} and
- *         {@link #numClicks} fields.
+ * @see TaskPool
+ * @since 2025.07 - Custom Generator Pools
+ * @performance {@code O(1)} for both {@link #get()} and {@link #put(short[])} operations. The
+ *              constructor is {@code O(capacity)} due to pre-allocation.
+ * @threading This class is explicitly not thread-safe. All access must be confined to a single
+ *            thread.
+ * @memory Pre-allocated at construction to avoid runtime allocation, with a memory footprint
+ *         determined by the {@link #capacity} and {@link #numClicks} fields.
  */
 public final class ArrayPool {
     /**
-     * The size of each array in the pool. This field must be set <b>before</b> using the
-     * {@link ArrayPool} class, as pre-allocation depends on this value.
-     * 
+     * The required size for all arrays managed by the pool. This value is shared across all
+     * {@code ArrayPool} instances.
+     *
      * <p>
-     * For JVM optimization purposes, it's most beneficial to perform all object allocations at the
-     * start of the program and reuse them throughout the program's lifetime. This avoids the overhead
-     * of frequent allocations and deallocations, which can lead to performance degradation due to
-     * garbage collection. However, we can't allocate arrays of variable size, so we need some field to
-     * determine the size of each array in the pool. This field fills that role.
+     * This field <strong>must</strong> be set via {@link #setNumClicks(int)} before any
+     * {@code ArrayPool} is {@link #ArrayPool(int) instantiated}. It is {@code static} to ensure that
+     * all generated combination arrays are of a consistent, predictable size, which is essential for
+     * the pre-allocation strategy. Making it non-{@code final} (but settable only once) was a design
+     * trade-off to avoid dependencies on configuration files or system properties for initialization.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This field is made static to ensure that it is shared across all instances of the
-     * {@code ArrayPool} class. Ideally, we would make this field {@code final}, but that would require
-     * us to set it in a {@code static} block, either through a system property or a configuration file,
-     * which is not ideal for our use case (though we could pursue this in the future). Instead, we
-     * provide {@link #setNumClicks(int) a setter} method to let users set this value and throw an
-     * exception if it is not set before creating an instance of the {@code ArrayPool}.
-     * </p>
-     * 
-     * <p>
-     * Since {@code numClicks} is restricted in range to a number between {@code 1} and {@code 109}, we
-     * could technically use a {@code byte} or {@code short} to store this value, but we use an
-     * {@code int} for simplicity (and because Java does weird stuff to {@code byte}s/{@code short}s
-     * during arithmetic operations).
-     * </p>
-     * 
+     *
      * @see #ArrayPool(int)
-     * @see #setNumClicks(int)
-     * @since 2025.07.24 - {@code ArrayPool} Pre-allocation
-     * @performance {@code O(1)} access and modification, since it's a {@code static} field.
-     * @memory The field itself is a primitive {@code int}, so it has a negligible memory footprint.
+     * @since 2025.07 - {@code ArrayPool} Pre-allocation
+     * @performance {@code O(1)} access.
+     * @threading Thread-safe; effectively immutable after being set once.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private static int numClicks = -1;
     /**
-     * An array of pre-allocated {@code short} arrays, each of size {@link #numClicks}.
-     * 
+     * The internal buffer storing the pre-allocated {@code short[]} arrays.
+     *
      * <p>
-     * We need a structure that can internally manage multiple arrays of the same size, one with quick
-     * accesses and minimal overhead. The 2D array structure is chosen for its simplicity and performance.
+     * This 2D array acts as the backing store for the circular buffer. It is allocated once at
+     * construction with a fixed {@link #capacity}, and its arrays are recycled via the {@link #head}
+     * and {@link #tail} pointers.
      * </p>
-     * 
+     *
      * @see #capacity
      * @see #numClicks
      * @see #ArrayPool(int)
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} access time for both getting and putting arrays.
-     * @memory The pool is pre-allocated with a fixed capacity, which is determined by the
-     *         {@link #capacity} parameter, and holds arrays of size {@link #numClicks}.
-     * @optimization Preallocates arrays to avoid frequent allocations and deallocations.
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} access for {@link #get() get}/{@link #put(short[]) put} operations.
+     * @threading Not thread-safe; must be confined to a single thread.
+     * @memory Fixed memory footprint of ~{@code capacity * numClicks * 2} bytes as a {@code short[][]}.
      */
     private final short[][] arrays;
     /**
      * The maximum number of arrays the pool can hold.
-     * 
-     * <h3>Performance Considerations</h3>
+     *
      * <p>
-     * The capacity of the pool is a crucial parameter that determines how many arrays can be
-     * {@link #ArrayPool(int) pre-allocated} and managed by the pool. A larger {@code capacity} reduces
-     * the likelihood of contention and improves performance, but it also increases the memory footprint
-     * of the pool. A smaller {@code capacity} saves memory but may lead to more frequent allocations
-     * and deallocations, which can degrade performance. The optimal {@code capacity} depends on the
-     * specific use case and workload. Try to size the pool appropriately based on the expected number
-     * of concurrent threads and frequency of array usage, and lean towards a larger pool to minimize
-     * the risk of contention.
+     * The {@code capacity} is set at {@link #ArrayPool(int) construction} and determines the
+     * {@link #arrays buffer}'s memory footprint. A larger {@code capacity} reduces the chance of the
+     * pool running out of arrays (which would return {@code null}), but increases initial memory usage.
+     * The optimal size depends on the workload and the expected depth of the recursive tasks.
      * </p>
-     * 
-     * @see #arrays
-     * @see #ArrayPool(int)
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} access time, as it's a {@code final} field.
-     * @memory The field itself is a primitive {@code int}, so it has a negligible memory footprint.
+     *
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} initialization and access.
+     * @threading Thread-safe; immutable after construction.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private final int capacity;
 
     /**
-     * The {@code head} index for {@link #get()} operations.
-     * 
+     * The index of the next available array to be retrieved by {@link #get()}.
+     *
      * <p>
-     * The {@code head} index tracks where the next available array is located in the circular
-     * {@link #arrays buffer}. It is incremented each time an array is obtained from the pool, wrapping
-     * around to the start of the buffer when it reaches the end, implementing a circular buffer
-     * mechanism.
+     * This pointer advances through the circular buffer as arrays are dispensed. Using separate
+     * {@code head} and {@link #tail} pointers was chosen over a single-pointer-with-size design to
+     * remove arithmetic from the hot path of {@code get}/{@link #put(short[]) put} operations.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast {@link #put(short[]) put} and {@code get} operations. The
-     * {@code head} index is updated in constant time, ensuring that {@code get} operations remain
-     * efficient even as the pool fills up and empties out.
-     * </p>
-     * 
-     * <p>
-     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an {@code int} avoids potential overflow issues in
-     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
-     * could also use a single pointer for both {@code head} and {@link #tail}, but that would
-     * complicate the logic and force an extra arithmetic operation on each operation, which could
-     * impact performance.
-     * </p>
-     * 
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} for {@link #get()} operations.
-     * @threading The index is not thread-safe, as it is intended to be used within a single thread
-     *            context.
-     * @memory Minimal additional memory overhead (single {@code int}).
+     *
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} access and update.
+     * @threading Not thread-safe; must be confined to a single thread.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private int head = 0;
     /**
-     * The {@code tail} index for {@link #put(short[])} operations.
-     * 
+     * The index where the next recycled array will be placed by {@link #put(short[])}.
+     *
      * <p>
-     * The {@code tail} index tracks where the next returned array should be placed in the circular
-     * {@link #arrays buffer}. It is incremented each time an array is returned to the pool, wrapping
-     * around to the start of the buffer when it reaches the end, implementing a circular buffer
-     * mechanism.
+     * This pointer advances through the {@link #arrays circular buffer} as arrays are returned. Using
+     * separate {@link #head} and {@code tail} pointers was chosen over a single-pointer-with-size
+     * design to remove arithmetic from the hot path of {@link #get()}/{@code put} operations.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast {@code put} and {@link #get() get} operations. The
-     * {@code tail} index is updated in constant time, ensuring that {@code put} operations remain
-     * efficient even as the pool fills up and empties out.
-     * </p>
-     * 
-     * <p>
-     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an {@code int} avoids potential overflow issues in
-     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
-     * could also use a single pointer for both {@link #head} and {@code tail}, but that would
-     * complicate the logic and force an extra arithmetic operation on each operation, which could
-     * impact performance.
-     * </p>
-     * 
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} for {@code put} operations.
-     * @threading The index is not thread-safe, as it is intended to be used within a single thread
-     *            context.
-     * @memory Minimal additional memory overhead (single {@code int}).
+     *
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} access and update.
+     * @threading Not thread-safe; must be confined to a single thread.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private int tail = 0;
     /**
-     * The current number of arrays in the pool.
-     * 
+     * The current number of arrays available in the pool.
+     *
      * <p>
-     * The {@code size} field tracks how many arrays are currently stored in the pool. It is incremented
-     * each time an array is returned to the pool via {@link #put(short[]) put} and decremented each
-     * time an array is obtained from the pool via {@link #get() get}. This field is crucial for
-     * ensuring that we do not exceed the pool's {@link #capacity} and for determining if the pool is
-     * empty.
+     * This value is decremented by {@link #get()} and incremented by {@link #put(short[])}. It is used
+     * to check if the pool {@link #isEmpty() is empty} or full. While the size could be calculated from
+     * the {@link #head} and {@link #tail} pointers, storing it explicitly makes the checks trivial and
+     * avoids arithmetic in the hot path.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * The {@code size} field is updated in constant time during both {@code put} and {@code get}
-     * operations, ensuring that these operations remain efficient. It is also used to quickly check if
-     * the pool is empty (via {@link #isEmpty()}).
-     * </p>
-     * 
-     * <p>
-     * We could use a {@code short} for the size to save a few bytes of memory, but the performance
-     * difference is negligible and using an {@code int} avoids potential overflow issues in
-     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
-     * could avoid the {@code size} field entirely by using the {@link #head} and {@link #tail} indices
-     * to calculate the size on-the-fly (or by taking a {@link WorkBatch#remainingCapacity} approach and
-     * storing the remaining capacity), but that would complicate the logic and add extra arithmetic
-     * operations to the hot path of both {@code put} and {@code get} operations, which could impact
-     * performance. We also don't anticipate the {@code size} coming down to {@code 0}, so the
-     * deoptimization risk is minimal.
-     * </p>
-     * 
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
-     * @threading The field is not thread-safe, as it is intended to be used within a single thread
-     *            context.
-     * @memory Minimal additional memory overhead (single {@code int}).
+     *
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} access and update.
+     * @threading Not thread-safe; must be confined to a single thread.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private int size = 0;
 
     /**
-     * Constructs a new {@code ArrayPool} with the specified {@code capacity}. Pre-allocates all arrays
-     * to a size of {@link #numClicks}.
-     * 
+     * Constructs a new {@code ArrayPool} and pre-allocates its internal array buffer.
+     *
      * <p>
-     * Validation is performed to ensure that {@link #numClicks} has been set and that the
-     * {@code capacity} is greater than zero. If these conditions are not met, an
-     * {@link java.lang.IllegalArgumentException IllegalArgumentException} will be thrown.
+     * All arrays are allocated upfront to prevent runtime allocation overhead. This constructor will
+     * fail if {@link #numClicks} has not been set, ensuring a fail-fast approach to configuration
+     * errors.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * The constructor pre-allocates all arrays in the pool to avoid allocations on the hot path. This
-     * ensures that both the {@link #get()} and {@link #put(short[])} methods can operate in
-     * {@code O(1)} time without any additional overhead.
-     * </p>
-     * 
-     * @param capacity the maximum number of arrays the pool can hold. Must be greater than zero.
-     * @throws IllegalArgumentException if {@link #numClicks} is not set or if {@code capacity} is less
-     *                                  than or equal to zero.
+     *
+     * @param capacity The maximum number of arrays the pool can hold. Must be positive.
+     * @throws IllegalArgumentException if {@code capacity} is not positive or if {@link #numClicks} has
+     *                                  not been set.
      * @see #arrays
      * @see #setNumClicks(int)
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance <code>O({@link #capacity})</code> time complexity for the constructor due to
-     *              pre-allocation of arrays.
-     * @memory Allocates a fixed amount of memory upfront based on the {@code capacity} and
-     *         {@link #numClicks}.
-     * @optimization Pre-allocates all arrays to avoid allocations on the hot path.
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(capacity)} pre-allocation of arrays.
+     * @memory Allocates a {@code short[capacity][numClicks]} and an {@code ArrayPool} instance.
      */
     public ArrayPool(int capacity) {
         if (numClicks <= 0) {
@@ -280,19 +170,21 @@ public final class ArrayPool {
     }
 
     /**
-     * Sets the size of each array in the pool. This method must be called before creating any instances
-     * of the class, as the pool relies on this value for {@link #ArrayPool(int) pre-allocation}.
-     * 
-     * @param numClicks the size of each array in the pool. Must be greater than zero.
-     * @throws IllegalArgumentException if {@code numClicks} is less than or equal to zero.
+     * Sets the {@code static} size for all arrays that will be managed by {@code ArrayPool} instances.
+     *
+     * <p>
+     * This method is not thread-safe and must be called exactly once during application initialization,
+     * before any threads begin creating or using pools.
+     * </p>
+     *
+     * @param numClicks The size of each array in the pool. Must be positive.
+     * @throws IllegalArgumentException if {@code numClicks} is not positive.
      * @see #numClicks
      * @see #ArrayPool(int)
-     * @since 2025.07.24 - {@code ArrayPool} Pre-allocation
-     * @performance {@code O(1)} time complexity for setting the value.
-     * @threading This method is not thread-safe. It should be called once during application
-     *            initialization, before any threads start using the pool.
-     * @memory Does not allocate any additional memory, as it only sets a static field. However, future
-     *         allocations of {@code ArrayPool} instances will depend on this value.
+     * @since 2025.07 - {@code ArrayPool} Pre-allocation
+     * @performance {@code O(1)} assignment.
+     * @threading Not thread-safe; must be called during single-threaded initialization.
+     * @memory Does not allocate.
      */
     public static void setNumClicks(int numClicks) {
         if (numClicks <= 0) {
@@ -302,31 +194,22 @@ public final class ArrayPool {
     }
 
     /**
-     * Obtains an array from the {@link #head} of the pool, returning {@code null} if the pool is empty.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Retrieves an array from the pool.
+     *
      * <p>
-     * We need to ensure that the {@code get} operation is as fast as possible, as it is on the hot path
-     * of combination generation. By using a {@link #arrays circular buffer} and {@link #ArrayPool(int)
-     * pre-allocating} all arrays, we can achieve {@code O(1)} performance for this operation. We avoid
-     * a {@code null} check on the returned array (as this should never happen if the pool is sized
-     * correctly and {@code null} arrays aren't passed to the {@code put} method), which further
-     * improves performance, keeping only the {@link #size} check at the start of the method for
-     * short-circuiting purposes. If extra performance is needed, we could remove this check as well,
-     * but that would risk causing {@code size} to go negative.
+     * This is an {@code O(1)} operation. To improve performance on the hot path, this method assumes
+     * the caller will handle a {@code null} return gracefully. The slot previously holding the array is
+     * {@code null}ed out to assist the garbage collector, a micro-optimization that can be beneficial
+     * in long-running, high-allocation scenarios.
      * </p>
-     * 
-     * @return A pre-allocated {@code short} array of size {@link #numClicks}, or {@code null} if the
-     *         pool is empty.
-     * @see #size
+     *
+     * @return A pre-allocated {@code short[]} array, or {@code null} if the pool is empty.
      * @see #isEmpty()
      * @see #put(short[])
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
-     * @memory No additional memory allocation occurs during this operation, as arrays are
-     *         pre-allocated.
-     * @optimization Removes {@code null} checks by ensuring the pool is pre-allocated and properly
-     *               managed.
+     * @see #size()
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} retrieval and field updates.
+     * @memory Does not allocate.
      */
     public short[] get() {
         if (size == 0)
@@ -342,32 +225,23 @@ public final class ArrayPool {
     }
 
     /**
-     * Returns an array to the {@link #tail} of the pool. Returns immediately if the pool is full.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Returns an array to the pool, making it available for reuse.
+     *
      * <p>
-     * The {@code put} operation is also on the hot path, so it needs to be as fast as possible. By
-     * using a {@link #arrays circular buffer} and {@link #ArrayPool(int) pre-allocating} all arrays, we
-     * can achieve {@code O(1)} performance for this operation as well. We avoid a {@code null} check on
-     * the input array to improve performance, assuming that the user will not pass {@code null} arrays
-     * (as this would indicate a bug in the calling code). We do, however, check if the pool is full to
-     * prevent overwriting existing arrays and incrementing the {@link #size} beyond the
-     * {@link #capacity}. If extra performance is needed, we could remove this check as well, but since
-     * tasks are stolen between threads, a full pool is a real possibility.
+     * This is an {@code O(1)} operation. If the pool is already at full capacity, this method returns
+     * immediately and the given array is effectively dropped. This can happen if arrays are generated
+     * faster than they are consumed, but a properly sized pool should prevent this.
      * </p>
-     * 
-     * @param array A short array of size {@link #numClicks} to return to the pool. This array should
-     *              not be {@code null} and should not be used by other threads.
-     * @see #size
+     *
+     * @param array The {@code short[]} array to return to the pool. It is assumed to be
+     *              non-{@code null} and of the {@link #numClicks correct size}.
      * @see #ArrayPool(int)
      * @see #get()
      * @see #setNumClicks(int)
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
-     * @memory No additional memory allocation occurs during this operation, as the input array is added
-     *         to the pool.
-     * @optimization Removes {@code null} checks by assuming well-formed input and ensuring the pool is
-     *               properly managed.
+     * @see #size()
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} insertion and field updates.
+     * @memory Does not allocate.
      */
     public void put(short[] array) {
         if (size >= capacity)
@@ -383,31 +257,29 @@ public final class ArrayPool {
     }
 
     /**
-     * Checks if the pool is empty.
-     * 
+     * Checks if the pool contains no available arrays.
+     *
      * @return {@code true} if the pool is empty, {@code false} otherwise.
      * @see #get()
      * @see #size()
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} time complexity, as it involves a simple comparison.
-     * @threading Not thread-safe. Should be used within a single thread context.
-     * @memory No additional memory allocation occurs during this operation.
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} retrieval and comparison.
+     * @memory Does not allocate.
      */
     public boolean isEmpty() {
         return size == 0;
     }
 
     /**
-     * Gets the current number of arrays in the pool.
-     * 
+     * Returns the number of arrays currently available in the pool.
+     *
      * @return The current number of arrays in the pool.
      * @see #get()
      * @see #isEmpty()
      * @see #put(short[])
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} time complexity, as it involves a simple field access.
-     * @threading Not thread-safe. Should be used within a single thread context.
-     * @memory No additional memory allocation occurs during this operation.
+     * @since 2025.07 - Custom Generator Pools
+     * @performance {@code O(1)} retrieval.
+     * @memory Does not allocate.
      */
     public int size() {
         return size;

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -43,15 +43,15 @@ package com.github.mrgarbagegamer;
  * using the pool (else an exception will be thrown).
  * </p>
  * 
+ * @see CombinationGeneratorTask
  * @since 2025.07.02 - Custom Generator Pools
+ * @performance O(1) operations for both {@link #get()} and {@link #put(short[])} methods.
  * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
  *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
  *            {@link java.lang.ThreadLocal thread-local} context, with all arrays being handled by
  *            the same thread.
- * @performance O(1) operations for both {@link #get()} and {@link #put(short[])} methods.
  * @memory Preallocated at construction, with a fixed size determined by the {@link #capacity}
  *         parameter.
- * @see CombinationGeneratorTask
  */
 public final class ArrayPool {
     /**
@@ -82,11 +82,11 @@ public final class ArrayPool {
      * stuff to bytes/shorts during arithmetic operations).
      * </p>
      * 
+     * @see #ArrayPool(int)
+     * @see #setNumClicks(int)
      * @since 2025.07.24 - ArrayPool Pre-allocation
      * @performance O(1) access and modification, since it's a static field.
      * @memory The field itself is a primitive int, so it has a negligible memory footprint.
-     * @see #setNumClicks(int)
-     * @see #ArrayPool(int)
      */
     private static int numClicks = -1;
     /**
@@ -97,14 +97,14 @@ public final class ArrayPool {
      * accesses and minimal overhead. The 2D array structure is chosen for its simplicity and performance.
      * </p>
      * 
+     * @see #capacity
+     * @see #numClicks
+     * @see #ArrayPool(int)
      * @since 2025.07.02 - Custom Generator Pools
      * @performance O(1) access time for both getting and putting arrays.
      * @memory The pool is pre-allocated with a fixed capacity, which is determined by the
      *         {@link #capacity} parameter, and holds arrays of size {@link #numClicks}.
      * @optimization Preallocates arrays to avoid frequent allocations and deallocations.
-     * @see numClicks
-     * @see capacity
-     * @see #ArrayPool(int)
      */
     private final short[][] arrays;
     /**
@@ -122,11 +122,11 @@ public final class ArrayPool {
      * contention.
      * </p>
      * 
+     * @see #arrays
+     * @see #ArrayPool(int)
      * @since 2025.07.02 - Custom Generator Pools
      * @performance O(1) access time, as it's a final field.
      * @memory The field itself is a primitive int, so it has a negligible memory footprint.
-     * @see #arrays
-     * @see #ArrayPool(int)
      */
     private final int capacity;
 
@@ -156,9 +156,9 @@ public final class ArrayPool {
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) for get operations.
      * @threading The index is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @performance O(1) for get operations.
      * @memory Minimal additional memory overhead (single int).
      */
     private int head = 0;
@@ -189,9 +189,9 @@ public final class ArrayPool {
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) for put operations.
      * @threading The index is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @performance O(1) for put operations.
      * @memory Minimal additional memory overhead (single int).
      */
     private int tail = 0;
@@ -224,9 +224,9 @@ public final class ArrayPool {
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) for both put and get operations.
      * @threading The field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @performance O(1) for both put and get operations.
      * @memory Minimal additional memory overhead (single int).
      */
     private int size = 0;
@@ -251,14 +251,14 @@ public final class ArrayPool {
      * @param capacity the maximum number of arrays the pool can hold. Must be greater than zero.
      * @throws IllegalArgumentException if {@link #numClicks} is not set or if <code>capacity</code> is
      *                                  less than or equal to zero.
+     * @see #arrays
+     * @see #setNumClicks(int)
      * @since 2025.07.02 - Custom Generator Pools
      * @performance O(n) time complexity for the constructor due to pre-allocation of arrays, where n is
      *              the <code>capacity</code>.
-     * @optimization Pre-allocates all arrays to avoid allocations on the hot path.
      * @memory Allocates a fixed amount of memory upfront based on the <code>capacity</code> and
      *         {@link #numClicks}.
-     * @see #arrays
-     * @see #setNumClicks(int)
+     * @optimization Pre-allocates all arrays to avoid allocations on the hot path.
      */
     public ArrayPool(int capacity) {
         if (numClicks <= 0) {
@@ -277,14 +277,14 @@ public final class ArrayPool {
      * 
      * @param numClicks the size of each array in the pool. Must be greater than zero.
      * @throws IllegalArgumentException if <code>numClicks</code> is less than or equal to zero.
-     * @since 2025.07.24 - ArrayPool Pre-allocation
-     * @threading This method is not thread-safe. It should be called once during application
-     *            initialization, before any threads start using the pool.
-     * @performance O(1) time complexity for setting the value.
-     * @memory Does not allocate any additional memory, as it only sets a static field. However, future
-     *         allocations of ArrayPool instances will depend on this value.
      * @see #numClicks
      * @see #ArrayPool(int)
+     * @since 2025.07.24 - ArrayPool Pre-allocation
+     * @performance O(1) time complexity for setting the value.
+     * @threading This method is not thread-safe. It should be called once during application
+     *            initialization, before any threads start using the pool.
+     * @memory Does not allocate any additional memory, as it only sets a static field. However, future
+     *         allocations of ArrayPool instances will depend on this value.
      */
     public static void setNumClicks(int numClicks) {
         if (numClicks <= 0) {
@@ -310,13 +310,13 @@ public final class ArrayPool {
      * 
      * @return A pre-allocated short array of size {@link #numClicks}, or <code>null</code> if the
      *        pool is empty.
+     * @see #size
+     * @see #isEmpty()
+     * @see #put(short[])
      * @since 2025.07.02 - Custom Generator Pools
      * @performance O(1) time complexity, as it involves simple arithmetic and array access.
-     * @optimization Removes null checks by ensuring the pool is pre-allocated and properly managed.
      * @memory No additional memory allocation occurs during this operation, as arrays are pre-allocated.
-     * @see #size
-     * @see #put(short[])
-     * @see #isEmpty()
+     * @optimization Removes null checks by ensuring the pool is pre-allocated and properly managed.
      */
     public short[] get() {
         if (size == 0)
@@ -348,16 +348,16 @@ public final class ArrayPool {
      * 
      * @param array A short array of size {@link #numClicks} to return to the pool. This array should
      *              not be <code>null</code> and should not be used by other threads.
+     * @see #size
+     * @see #ArrayPool(int)
+     * @see #get()
+     * @see #setNumClicks(int)
      * @since 2025.07.02 - Custom Generator Pools
      * @performance O(1) time complexity, as it involves simple arithmetic and array access.
-     * @optimization Removes null checks by assuming well-formed input and ensuring the pool is properly
-     *               managed.
      * @memory No additional memory allocation occurs during this operation, as the input array is added
      *         to the pool.
-     * @see #size
-     * @see #setNumClicks(int)
-     * @see #get()
-     * @see #ArrayPool(int)
+     * @optimization Removes null checks by assuming well-formed input and ensuring the pool is properly
+     *               managed.
      */
     public void put(short[] array) {
         if (size >= capacity)
@@ -376,12 +376,12 @@ public final class ArrayPool {
      * Checks if the pool is empty.
      * 
      * @return <code>true</code> if the pool is empty, <code>false</code> otherwise.
-     * @since 2025.07.02 - Custom Generator Pools
-     * @threading Not thread-safe. Should be used within a single thread context.
-     * @performance O(1) time complexity, as it involves a simple comparison.
-     * @memory No additional memory allocation occurs during this operation.
      * @see #get()
      * @see #size()
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) time complexity, as it involves a simple comparison.
+     * @threading Not thread-safe. Should be used within a single thread context.
+     * @memory No additional memory allocation occurs during this operation.
      */
     public boolean isEmpty() {
         return size == 0;
@@ -391,13 +391,13 @@ public final class ArrayPool {
      * Gets the current number of arrays in the pool.
      * 
      * @return The current number of arrays in the pool.
-     * @since 2025.07.02 - Custom Generator Pools
-     * @threading Not thread-safe. Should be used within a single thread context.
-     * @performance O(1) time complexity, as it involves a simple field access.
-     * @memory No additional memory allocation occurs during this operation.
      * @see #get()
-     * @see #put(short[])
      * @see #isEmpty()
+     * @see #put(short[])
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) time complexity, as it involves a simple field access.
+     * @threading Not thread-safe. Should be used within a single thread context.
+     * @memory No additional memory allocation occurs during this operation.
      */
     public int size() {
         return size;

--- a/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/ArrayPool.java
@@ -43,20 +43,19 @@ package com.github.mrgarbagegamer;
  * using the pool (else an exception will be thrown).
  * </p>
  * 
- * <h3>3/13 - ~23.1% of documentation completed</h3>
+ * <h3>7/13 - ~53.8% of documentation completed</h3>
  * 
  * @since 2025.07.02 - Custom Generator Pools
+ * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
+ *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
+ *            {@link java.lang.ThreadLocal thread-local} context, with all arrays being handled by
+ *            the same thread.
  * @performance O(1) operations for both {@link #get()} and {@link #put(short[])} methods.
  * @memory Preallocated at construction, with a fixed size determined by the {@link #capacity}
  *         parameter.
- * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
- *            {@link ArrayPool} to avoid contention. The pool is designed to be used in a
- *            {@link ThreadLocal thread-local} context, with all arrays being handled by the same
- *            thread.
  * @see CombinationGeneratorTask
  */
-public final class ArrayPool 
-{
+public final class ArrayPool {
     /**
      * The size of each array in the pool. This field must be set <b>before</b> using the
      * {@link ArrayPool} class, as pre-allocation depends on this value.
@@ -119,13 +118,39 @@ public final class ArrayPool
     private int tail = 0;
     private int size = 0;
 
-    public ArrayPool(int capacity)
-    {
-        if (numClicks <= 0) 
-        {
+    /**
+     * Constructs a new <code>ArrayPool</code> with the specified <code>capacity</code>. Pre-allocates
+     * all arrays to a size of {@link #numClicks}.
+     * 
+     * <p>
+     * Validation is performed to ensure that {@link #numClicks} has been set and that the
+     * <code>capacity</code> is greater than zero. If these conditions are not met, an
+     * {@link java.lang.IllegalArgumentException IllegalArgumentException} will be thrown.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The constructor pre-allocates all arrays in the pool to avoid allocations on the hot path. This
+     * ensures that both the {@link #get()} and {@link #put(short[])} methods can operate in O(1) time
+     * without any additional overhead.
+     * </p>
+     * 
+     * @param capacity the maximum number of arrays the pool can hold. Must be greater than zero.
+     * @throws IllegalArgumentException if {@link #numClicks} is not set or if <code>capacity</code> is
+     *                                  less than or equal to zero.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(n) time complexity for the constructor due to pre-allocation of arrays, where n is
+     *              the <code>capacity</code>.
+     * @optimization Pre-allocates all arrays to avoid allocations on the hot path.
+     * @memory Allocates a fixed amount of memory upfront based on the <code>capacity</code> and
+     *         {@link #numClicks}.
+     * @see #arrays
+     * @see #setNumClicks(int)
+     */
+    public ArrayPool(int capacity) {
+        if (numClicks <= 0) {
             throw new IllegalArgumentException("numClicks must be set before using ArrayPool.");
-        } else if (capacity <= 0) 
-        {
+        } else if (capacity <= 0) {
             throw new IllegalArgumentException("Capacity must be greater than 0.");
         }
         
@@ -133,18 +158,54 @@ public final class ArrayPool
         this.arrays = new short[capacity][numClicks];
     }
 
-    public static void setNumClicks(int numClicks)
-    {
+    /**
+     * Sets the size of each array in the pool. This method must be called before creating any instances
+     * of the class, as the pool relies on this value for {@link #ArrayPool(int) pre-allocation}.
+     * 
+     * @param numClicks the size of each array in the pool. Must be greater than zero.
+     * @throws IllegalArgumentException if <code>numClicks</code> is less than or equal to zero.
+     * @since 2025.07.24 - ArrayPool Pre-allocation
+     * @threading This method is not thread-safe. It should be called once during application
+     *            initialization, before any threads start using the pool.
+     * @performance O(1) time complexity for setting the value.
+     * @memory Does not allocate any additional memory, as it only sets a static field. However, future
+     *         allocations of ArrayPool instances will depend on this value.
+     * @see #numClicks
+     * @see #ArrayPool(int)
+     */
+    public static void setNumClicks(int numClicks) {
+        if (numClicks <= 0) {
+            throw new IllegalArgumentException("numClicks must be greater than 0.");
+        }
         ArrayPool.numClicks = numClicks;
     }
 
     /**
-     * Get a recycled array from the pool.
-     * This method now returns a guaranteed non-null, correctly-sized array,
-     * or null if the pool is empty. This is simpler and faster.
+     * Obtains an array from the {@link #head} of the pool, returning <code>null</code> if the pool is empty.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * We need to ensure that the get operation is as fast as possible, as it is on the hot path of
+     * combination generation. By using a {@link #arrays circular buffer} and {@link #ArrayPool(int)
+     * pre-allocating} all arrays, we can achieve O(1) performance for this operation. We avoid a null
+     * check on the returned array (as this should never happen if the pool is sized correctly and null
+     * arrays aren't passed to the put method), which further improves performance, keeping only the
+     * {@link #size} check at the start of the method for short-circuiting purposes. If extra
+     * performance is needed, we could remove this check as well, but that would risk causing
+     * <code>size</code> to go negative.
+     * </p>
+     * 
+     * @return A pre-allocated short array of size {@link #numClicks}, or <code>null</code> if the
+     *        pool is empty.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @optimization Removes null checks by ensuring the pool is pre-allocated and properly managed.
+     * @memory No additional memory allocation occurs during this operation, as arrays are pre-allocated.
+     * @see #size
+     * @see #put(short[])
+     * @see #isEmpty()
      */
-    public short[] get()
-    {
+    public short[] get() {
         if (size == 0)
         {
             return null;
@@ -158,11 +219,34 @@ public final class ArrayPool
     }
 
     /**
-     * Return array to the pool.
-     * The null check is removed as we assume valid arrays are returned.
+     * Returns an array to the {@link #tail} of the pool. Returns immediately if the pool is full.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The put operation is also on the hot path, so it needs to be as fast as possible. By using a
+     * {@link #arrays circular buffer} and {@link #ArrayPool(int) pre-allocating} all arrays, we can
+     * achieve O(1) performance for this operation as well. We avoid a null check on the input array to
+     * improve performance, assuming that the user will not pass null arrays (as this would indicate a
+     * bug in the calling code). We do, however, check if the pool is full to prevent overwriting
+     * existing arrays and incrementing the size beyond the capacity. If extra performance is needed, we
+     * could remove this check as well, but since tasks are stealed between threads, a full pool is a
+     * real possibility.
+     * </p>
+     * 
+     * @param array A short array of size {@link #numClicks} to return to the pool. This array should
+     *              not be <code>null</code> and should not be used by other threads.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @optimization Removes null checks by assuming well-formed input and ensuring the pool is properly
+     *               managed.
+     * @memory No additional memory allocation occurs during this operation, as the input array is added
+     *         to the pool.
+     * @see #size
+     * @see #setNumClicks(int)
+     * @see #get()
+     * @see #ArrayPool(int)
      */
-    public void put(short[] array)
-    {
+    public void put(short[] array) {
         if (size >= capacity)
         {
             // This should not happen if the pool is sized correctly, but as a safeguard:

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -5,30 +5,106 @@ import java.util.concurrent.RecursiveAction;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * [Class Name] - [Worker Purpose - e.g., "ForkJoin recursive combination generator"]
+ * CombinationGeneratorTask - Recursive combination generator using the {@link ForkJoinPool}
+ * framework.
  * 
- * <p>[High-level description of what this worker does in the algorithm.
- * Explain its role in the concurrent processing pipeline.]</p>
+ * <p>
+ * Generators produce combinations of clicks, stored as <code>short[]</code> arrays, and add them to
+ * a {@link CombinationQueue queue} for processing by {@link TestClickCombination monkeys}. The
+ * generators use a recursive, divide-and-conquer approach to generate combinations in parallel,
+ * leveraging the {@link ForkJoinPool} framework for efficient task management and work-stealing.
+ * While monkeys handle the more {@link TestClickCombination#satisfiesOddAdjacency(short[]) in-depth
+ * odd adjacency checks}, the generators perform {@link #canPotentiallySatisfyConstraints(int)
+ * constraint checks} at each branch to prune combinations early and increase the time spent on
+ * potentially valid combinations.
+ * </p>
  * 
  * <h2>Execution Model</h2>
- * <p>[How this task executes - recursive subdivision, work-stealing, etc.
- * Include task granularity and splitting criteria.]</p>
+ * <p>
+ * We use a tree structure to represent the combination generation process, where each node in the
+ * tree has a {@link #prefix} representing the clicks made so far. The root task generates subtasks
+ * for each possible first click, and each subtask recursively generates further subtasks for each
+ * subsequent click until the full {@link #numClicks combination length} is reached. Leaf tasks
+ * generate the final combinations and add them to a {@link WorkBatch}, which is then
+ * {@link #flushBatchFast(WorkBatch) flushed} to a randomly chosen {@link CombinationQueue queue}
+ * for processing.
+ * </p>
+ * 
+ * <p>
+ * The task execution is managed by the {@link ForkJoinPool} framework, which handles task
+ * scheduling and work-stealing. Task specific data is stored in instance fields, ensuring thread
+ * safety and isolation between tasks, while shared resources are managed via {@link ThreadLocal}
+ * contexts to avoid contention.
+ * </p>
  * 
  * <h2>Resource Management</h2>
- * <p>[How resources are acquired, used, and cleaned up. Pool usage patterns.]</p>
+ * <p>
+ * The fundamental rule of JVM optimizations is: <b>Don't allocate.</b> Fork-join architectures rely
+ * on the creation of many small tasks that are executed in parallel, but allocating new resources
+ * for every task would lead to excessive garbage collection pressure and performance degradation.
+ * In addition, we can't solely use primitive types to represent the prefixes, as the maximum number
+ * of clicks is 109, larger than the 64 bits available in a long. This means we need to allocate
+ * arrays to store the prefixes, which could lead to trillions of allocations, murdering
+ * performance.
+ * </p>
+ * 
+ * <p>
+ * To mitigate this, we pool resources per thread using the {@link GeneratorContext} class, which
+ * provides access to various resource pools like {@link ArrayPool} and {@link TaskPool}. Each
+ * thread has its own context, and the pools are sized to balance memory usage and contention.
+ * Through this and pre-allocation, we can significantly reduce the number of allocations and
+ * deallocations on the hot path to virtually none.
+ * </p>
  * 
  * <h2>Performance Critical Paths</h2>
- * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
+ * <p>
+ * The interdependent nature of generators and monkeys creates a complex performance profile,
+ * meaning that any bottleneck in one could drag the system down to a halt. We want to avoid
+ * bottlenecks at all costs and minimize the footprint of the hot paths to allow the JIT compiler to
+ * optimize them effectively. To accomplish this, we try to keep the hot paths as simple as
+ * possible, reducing branching and conditionals, and extracting complex logic into separate methods
+ * that can be optimized independently.
+ * </p>
  * 
- * <h3>15/36 - ~41.7% of documentation completed (excluding GeneratorContext)</h3>
+ * <p>
+ * The hottest methods in this class are:
+ * <ul>
+ * <li>{@link #compute()} - the dispatcher for all tasks, directing them to one of three paths</li>
+ * <li>{@link #computeIntermediateSubtasks(GeneratorContext)} - the path for intermediate tasks,
+ * dispatching to one of two paths depending on constraint check status</li>
+ * <li>{@link #canPotentiallySatisfyConstraints(int)} - the constraint check, pruning invalid
+ * branches as early as possible</li>
+ * <li>{@link #computeLeafCombinations(GeneratorContext)} - the path for leaf tasks, generating the
+ * final combinations that are added to a batch</li>
+ * <li>{@link #flushBatchFast(WorkBatch)} - the hand-off method, giving the generators' work to a
+ * monkey</li>
+ * <li>{@link #recycleOwnResources(GeneratorContext)} - the self-cleanup method, recycling the
+ * resources used by a task back to the pools</li>
+ * </ul>
+ * </p>
  * 
- * @algorithm [Detailed algorithm description with complexity analysis]
- * @threading [Concurrency model and synchronization approach]
- * @performance [Performance characteristics and bottleneck analysis]
- * @see [Related worker classes and coordination mechanisms]
+ * <h3>30/36 - ~83.3% of documentation completed (excluding GeneratorContext)</h3>
+ * 
+ * @since 2025.06.08 - Fork Join Refactor
+ * @algorithm Creates a tree of tasks, where each task represents a prefix of clicks. The root task
+ *            generates subtasks for each possible first click, and each subtask recursively
+ *            generates further subtasks for each subsequent click until the full combination length
+ *            is reached. Leaf tasks generate the final combinations and add them to a WorkBatch,
+ *            which is then flushed to a randomly chosen CombinationQueue for processing.
+ * @threading Each task is isolated and thread-safe due to ForkJoinTask design. Pooled and shared
+ *            resources are handled by <code>ThreadLocal</code> contexts and static fields
+ *            respectively.
+ * @performance The overall time complexity is O(n choose k) in the worst case, where n is the
+ *              number of cells and k is the number of clicks, but pruning and parallelism
+ *              significantly reduce the effective workload. Most bottlenecks arise from contention
+ *              on shared resources or the process of enqueuing batches.
+ * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
+ *         in the hot path.
+ * @see CombinationQueue
+ * @see TestClickCombination
+ * @see java.util.concurrent.ForkJoinTask
  */
-public class CombinationGeneratorTask extends RecursiveAction
-{
+public class CombinationGeneratorTask extends RecursiveAction {
     /**
      * The maximum size of a batch before it is flushed to the queue.
      * 
@@ -78,7 +154,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * </p>
      * 
      * <p>
-     * Resource pooling and pre-allocation are key strategies to mitigate tihs issue. We use the custom
+     * Resource pooling and pre-allocation are key strategies to mitigate this issue. We use the custom
      * {@link ArrayPool} and {@link TaskPool} classes to manage pools of arrays and tasks, and share
      * access to these pools via the {@link GeneratorContext} class. To prevent contention and ensure
      * that we have enough resources available for each thread, we need to define a size for these
@@ -165,30 +241,77 @@ public class CombinationGeneratorTask extends RecursiveAction
      * 
      * <h2>Optimization Strategy</h2>
      * <p>
-     * [Specific optimization techniques used - pooling, caching, lock-free, etc. Explain trade-offs
-     * made for performance gains.]
+     * Other than the {@link WorkBatch}, all resources used by a task are pooled, pre-allocated, and
+     * recycled. The context provides access to these pools, allowing tasks to obtain and recycle
+     * resources as needed. Batches are not pooled since they are passed to the queue.
      * </p>
      * 
      * <h2>Usage Patterns</h2>
      * <p>
-     * [How and when to use this utility. Common usage patterns and anti-patterns.]
+     * This context is meant to be stored in a {@link ThreadLocal} variable, ensuring that each thread
+     * has its own instance. It is passed down to all methods that need access to the resource pools,
+     * allowing for efficient resource management without contention. Tasks should obtain resources from
+     * the pools as needed and recycle them when they are no longer needed. After batches are filled and
+     * are flushed to the queue, {@link #resetBatch()} should be called to obtain a new batch. Do not
+     * reference the old batch after flushing, as it may be recycled and used by another thread.
      * </p>
      * 
      * <h2>Memory Management</h2>
      * <p>
-     * [Memory allocation patterns, GC implications, sizing considerations.]
+     * The context itself is stored in a ThreadLocal variable, which means that it will be garbage
+     * collected when the thread is terminated. The resources within the context are pooled and
+     * recycled, which helps to minimize memory usage and reduce garbage collection pressure. However,
+     * care must be taken to ensure that resources are recycled properly to avoid memory leaks.
      * </p>
      * 
-     * <h3>3/7 - ~42.9% of documentation completed</h3>
+     * <p>
+     * As a wrapper class, GeneratorContext has a small memory footprint, but the resources it manages
+     * can be significant. The size of the pools should be tuned to balance memory usage and contention,
+     * with larger pools reducing contention but increasing memory usage.
+     * </p>
      * 
-     * @performance [Specific performance characteristics and measurements]
-     * @memory [Memory usage patterns and optimizations]
-     * @threading [Thread safety model]
-     * @since [When introduced and why]
+     * <h3>6/7 - ~85.7% of documentation completed</h3>
+     * 
+     * @since 2025.07.26 - GeneratorContext Introduction
+     * @performance O(1) access time for pool operations.
+     * @memory Minimal memory footprint as a wrapper class, with pooled resources to minimize
+     *         allocations.
+     * @threading This class is not thread-safe, but is intended to be used in a thread-local manner. A
+     *            thread-local, static variable should be created to use this class.
+     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce
+     *               overhead.
+     * @see ArrayPool
+     * @see CombinationGeneratorTask
+     * @see CombinationGeneratorTask#context
+     * @see TaskPool
+     * @see WorkBatch
      */
-    private static class GeneratorContext
-    {
+    private static class GeneratorContext {
+        /**
+         * An {@link ArrayPool} for storing click prefixes.
+         * 
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @threading Thread-local - Each thread has its own instance of ArrayPool, ensuring thread safety.
+         * @performance O(1) amortized access time for get() and recycle().
+         * @optimization Pooling and reusing arrays to minimize allocations on the hot path.
+         * @memory Memory usage is optimized by reusing arrays and minimizing allocations.
+         * @see ArrayPool
+         * @see CombinationGeneratorTask#context
+         * @see CombinationGeneratorTask#numClicks
+         */
         final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE);
+        /**
+         * The {@link TaskPool} for recycling subtasks.
+         * 
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @threading Thread-local - Each thread has its own instance of TaskPool, ensuring thread safety.
+         * @performance O(1) amortized access time for get() and recycle().
+         * @optimization Pooling and reusing tasks to minimize allocations on the hot path.
+         * @memory Memory usage is optimized by reusing tasks and minimizing allocations.
+         * @see TaskPool#get()
+         * @see TaskPool#put(CombinationGeneratorTask)
+         * @see TaskPool#TaskPool(int)
+         */
         final TaskPool taskPool = new TaskPool(POOL_SIZE / 4);
         /**
          * The current WorkBatch being processed by this thread.
@@ -319,12 +442,146 @@ public class CombinationGeneratorTask extends RecursiveAction
     }
 
     // Static fields
+    /**
+     * The total number of clicks in each combination.
+     * 
+     * <p>
+     * This field is static and shared across all tasks, as the number of clicks is constant for a given
+     * puzzle. It is initialized in the root task and used by all subtasks to determine the length of 
+     * the combinations being generated.
+     * </p>
+     * 
+     * @since 2025.06.08 - Fork Join Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
+     * @performance O(1) access time.
+     * @optimization Static field to avoid redundant storage in each task instance.
+     * @memory Minimal memory usage as a primitive int.
+     * @see #prefix
+     * @see #prefixLength
+     * @see #compute()
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     */
     private static int numClicks;
+    /**
+     * A {@link CombinationQueueArray} from which to randomly select a queue to which to flush.
+     * 
+     * <p>
+     * Generators produce combinations and add them to a {@link CombinationQueue queue} for processing by
+     * {@link TestClickCombination monkeys}. To balance the load between multiple monkeys, we use a
+     * {@link CombinationQueueArray} that holds multiple queues and allows us to randomly select one to
+     * which to flush the generated combinations. This field is static and shared across all tasks, as the
+     * queue array is constant for a given puzzle.
+     * </p>
+     * 
+     * @since 2025.06.08 - Fork Join Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
+     * @performance O(1) access time.
+     * @optimization Static field to avoid redundant storage in each task instance.
+     * @memory Minimal memory usage as a reference.
+     * @see #flushBatchFast(WorkBatch)
+     * @see CombinationQueue
+     * @see java.util.concurrent.ThreadLocalRandom
+     */
     private static CombinationQueueArray queueArray;
+    /**
+     * The maximum index for the first click in a combination.
+     * 
+     * <p>
+     * Since combinations are generated in lexicographical order, we can optimize the generation process
+     * by limiting the range of possible first clicks. The maximum index for the first click is
+     * determined by the final adjacent cell to the first true cell in the grid, as any combinations
+     * starting with a click beyond this point would not be able to toggle the first true cell. This
+     * field is static and shared across all tasks, as the maximum first click index is constant for a
+     * given puzzle.
+     * </p>
+     * 
+     * @since 2025.06.11 - First Click Optimization
+     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any
+     *            subtasks are created.
+     * @performance O(1) access time.
+     * @optimization Static field to avoid redundant storage in each task instance.
+     * @memory Minimal memory usage as a primitive int.
+     * @see #compute()
+     * @see Grid
+     * @see Grid#findFirstTrueAdjacents(com.github.mrgarbagegamer.Grid.ValueFormat)
+     * @see Grid#findFirstTrueCell(com.github.mrgarbagegamer.Grid.ValueFormat)
+     */
     private static int maxFirstClickIndex;
 
     // Cached data between tasks
+    /**
+     * A <code>short[]</code> array representing the current prefix of clicks in
+     * {@link Grid.ValueFormat#Index Index} format.
+     * 
+     * <p>
+     * Each task in the fork-join architecture represents a prefix of clicks, which is built up as we
+     * descend the tree. This prefix is stored in a <code>short[]</code> array, which is passed down to
+     * subtasks as they are created. These arrays are {@link ArrayPool#get() pooled} and
+     * {@link ArrayPool#ArrayPool(int) pre-allocated} to avoid excessive allocations and deallocations
+     * on the hot path, sized to {@link #numClicks} for the sake of ensuring the proper amount of space
+     * is available. The current length of the prefix is tracked via the {@link #prefixLength} field.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using arrays allows for efficient storage and manipulation of the prefix, as we can easily add
+     * new clicks and pass the array down to subtasks. The use of primitive types also helps reduce
+     * memory footprint and improve cache locality. Pooling and pre-allocation help minimize the number
+     * of allocations and deallocations, reducing garbage collection pressure and improving overall
+     * throughput.
+     * </p>
+     * 
+     * <p>
+     * We use <code>short</code> instead of <code>int</code> to reduce memory usage, as the maximum
+     * number of cells is 109, which fits within the range of a <code>short</code>. This helps improve
+     * cache locality and reduce memory footprint, which is important in a high-performance application
+     * like this one. If we found a way to represent the prefix using only primitive types without
+     * arrays, we could potentially improve performance further and remove the need for pooling, but
+     * this is not currently feasible due to the maximum number of clicks exceeding 64.
+     * </p>
+     * 
+     * @since 2025.06.08 - Fork Join Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation. Ensure that prefix arrays are not
+     *            referenced after recycling to avoid concurrency issues.
+     * @performance O(1) for adding clicks, O(n) for copying to subtasks where n is the
+     *              {@link #prefixLength} at that point.
+     * @optimization Pooled and pre-allocated to minimize allocations on the hot path. Sized to
+     *               {@link #numClicks} to avoid resizing.
+     * @memory Uses <code>short</code> arrays to reduce memory usage while maintaining sufficient range.
+     * @see #recycleOwnResources(GeneratorContext)
+     * @see ArrayPool
+     * @see ArrayPool#get()
+     * @see ArrayPool#put(short[])
+     * @see GeneratorContext
+     * @see GeneratorContext#prefixArrayPool
+     */
     private short[] prefix;
+    /**
+     * The current length of the {@link #prefix} array, representing the number of clicks made so far.
+     * 
+     * <p>
+     * Since we use pre-allocated, {@link ArrayPool pooled} arrays to store the prefix of clicks, we need a way to track the
+     * current length of the <code>prefix</code> array, as it may not be fully filled. This field serves that purpose, allowing us to
+     * keep track of how many clicks have been made so far and where to add the next click.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a separate field to track the length of the prefix allows for efficient addition of new clicks, as we can simply
+     * add the new click at the current length index and increment the length. This avoids the need to resize or copy the array,
+     * which would be expensive and could lead to excessive allocations and deallocations. It also simplifies the logic for determining
+     * whether a task is a leaf, root, or intermediate task, as we can simply compare the length to the {@link #numClicks} field.
+     * </p>
+     * 
+     * @since 2025.06.08 - Fork Join Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(1) for updates and checks.
+     * @optimization Simple integer field to minimize overhead.
+     * @memory Minimal memory usage as a primitive int.
+     * @see #numClicks
+     * @see #prefix
+     * @see #compute()
+     */
     private int prefixLength;
     /**
      * A bitmask representing the adjacency state of the current prefix. Each bit corresponds to an
@@ -367,6 +624,36 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @see Grid#findTrueCells()
      */
     private long cachedAdjacencyState = -1; // -1 means root task, -2 means constraints are skipped
+    /**
+     * A flag indicating whether to skip constraint checks for this task and its children.
+     * 
+     * <p>
+     * Since {@link #prefix prefixes} are built up incrementally and our
+     * {@link #canPotentiallySatisfyConstraints(int) constraint checks} are monotonic, if a
+     * <code>prefix</code> is known to satisfy the constraints, we know that all of its children will
+     * also satisfy the constraints. To optimize performance and reduce redundant checks, we can skip
+     * constraint checks for a task and its children if its parent has been verified to satisfy the
+     * constraints. This flag serves that purpose, facilitating the separation of paths in intermediate
+     * task generation.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Skipping constraint checks for tasks that are guaranteed to satisfy them reduces the number of
+     * checks performed, allowing more time to be spent on potentially valid combinations. This
+     * optimization is particularly effective in deep branches of the generation tree, where many tasks
+     * can be skipped. It also simplifies the logic for intermediate task generation, as we can separate
+     * the paths based on this flag and perform a single check prior to dispatching to a subtask path.
+     * </p>
+     * 
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(1) for checks and updates.
+     * @optimization Reduces redundant constraint checks in deep branches of the generation tree.
+     * @memory Minimal memory usage as a primitive boolean.
+     * @see #cachedAdjacencyState
+     * @see #computeIntermediateSubtasks(GeneratorContext)
+     */
     private boolean skipConstraintsCheck = false; // If a prefix is known to satisfy constraints, we can skip checks for its children
 
     /**
@@ -409,6 +696,32 @@ public class CombinationGeneratorTask extends RecursiveAction
      */
     private static long targetMask;
     
+    /**
+     * The {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
+     * 
+     * <p>
+     * Since our code already leverages the fork-join framework for parallelism, we can skip
+     * explicit cancellation checks in the hot path by placing the responsibility of task
+     * cancellation on the pool itself, signaled by a {@link TestClickCombination monkey} when it
+     * finds a solution. For monkeys to be able to signal cancellation, however, they need
+     * access to the pool, which we provide via this static field.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a static field for the pool allows for quick and easy access from any task or
+     * monkey, without the need to pass references around or use ThreadLocals. This reduces
+     * overhead and simplifies the code, making it easier to maintain and understand. The volatile
+     * keyword ensures that changes to the pool reference are visible across threads, though the pool
+     * is best set once at the start of generation and left constant thereafter.
+     * </p>
+     * 
+     * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
+     * @threading Volatile static field - Ensures visibility of changes across threads.
+     * @performance O(1) access time.
+     * @optimization Static field for quick access without passing references.
+     * @memory Minimal memory usage as a single reference.
+     */
     private static volatile ForkJoinPool generatorPool;
 
     public static void setForkJoinPool(ForkJoinPool pool)
@@ -481,9 +794,9 @@ public class CombinationGeneratorTask extends RecursiveAction
      * the generators perform constraint checks at each branch, we still want some kind of fast check to
      * be performed at the "leaf" of the generation tree (when a full-length combination has been
      * built). We therefore create a slimmed-down version of the
-     * {@link TestClickCombination#satisfiesOddAdjacency(short[], short[])} check that operates only on
-     * the first true cell. To do this, we need to be able to quickly determine which cells are adjacent
-     * to the first true cell, which we can do by pre-computing a bitmask for it.
+     * {@link TestClickCombination#satisfiesOddAdjacency(short[])} check that operates only on the first
+     * true cell. To do this, we need to be able to quickly determine which cells are adjacent to the
+     * first true cell, which we can do by pre-computing a bitmask for it.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -511,8 +824,42 @@ public class CombinationGeneratorTask extends RecursiveAction
      */
     private static long[] FIRST_TRUE_ADJACENTS;
     
-    private static void computeAdjacencyMaskFast(short firstTrueCell) 
-    {
+    /**
+     * Computes and caches the adjacency mask for the first true cell.
+     * 
+     * <p>
+     * For the odd adjacency check done during {@link #computeLeafCombinations(GeneratorContext) leaf
+     * combination generation}, we need a fast way to determine which cells are adjacent to the first
+     * initially true cell. Bitmasks are a compact and efficient way to represent sets of toggled cells
+     * and worked well in the initial version of that check, but recomputing the mask for every
+     * combination would be too costly. Since we're looking at the initial state of the {@link Grid
+     * grid}, which never changes, we can pre-compute {@link #FIRST_TRUE_ADJACENTS this mask} during
+     * root task initialization and reuse it for all combinations.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is called only once per puzzle during root task initialization, so the overhead of
+     * computing the mask is negligible. The use of bitwise operations helps keep the computation fast
+     * and efficient. We use a temporary
+     * <code>short[]M/code> array to hold the adjacent cells, and create a new
+     * <code>long[2]</code> for our mask. Synchronization isn't necessary since this method is called
+     * once during the initialization of the root task, which is single-threaded, guaranteeing that no
+     * other threads will access the static field during this time.
+     * </p>
+     * 
+     * @param firstTrueCell The index of the first true cell in the grid, in
+     *                      {@link Grid.ValueFormat#Index Index} format.
+     * @since 2025.06.11 - Bitmasked Leaf Pruning Introduction
+     * @threading Single-threaded during root task initialization, no synchronization needed.
+     * @performance O(n) where n is the number of adjacent cells to the first true cell.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @memory Uses an array of two <code>long</code>s to represent the adjacency of the first true
+     *         cell. Creates a temporary <code>short[]</code> array for adjacent cells.
+     * @see #FIRST_TRUE_ADJACENTS
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     */
+    private static void computeAdjacencyMaskFast(short firstTrueCell) {
         short[] adjacents = Grid.findAdjacents(firstTrueCell);
         long[] mask = new long[2];
         
@@ -606,10 +953,58 @@ public class CombinationGeneratorTask extends RecursiveAction
         }
     }
 
-    // ROOT TASK PATH:
-    // Compute and fork the subtasks for the root task, then await quiescence
-    private void computeRootSubtasks(GeneratorContext ctx)
-    {
+    /**
+     * Computes and forks subtasks for each possible first click, then awaits their completion.
+     * 
+     * <p>
+     * The root task is responsible for generating the initial set of subtasks that will explore all
+     * possible combinations of clicks. It does this by iterating over all valid first clicks and
+     * forking a new subtask for each one. Each subtask is initialized with a prefix containing the
+     * first click and the appropriate cached adjacency state.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Forking subtasks for each first click allows us to leverage the parallelism of the ForkJoinPool
+     * framework, distributing the workload across multiple threads. We limit the range of first clicks
+     * to the specified {@link #maxFirstClickIndex} to reduce the number of subtasks, which can help
+     * with memory usage and contention.
+     * </p>
+     * 
+     * <p>
+     * After forking all subtasks, we call {@link #helpQuiesce()} to wait for their completion. This is
+     * because {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)
+     * ForkJoinPool.awaitQuiescence()} is stupid. For some dumb reason, it doesn't consider forked tasks
+     * as part of its global quiescence check, allowing it to return early if the root task completes
+     * before its children, even if those children are still running. The recycling infrastructure
+     * relies on each task cleaning up after itself, and if the root task finishes before its children
+     * and exits early, the main thread will be unparked and will think that generation is complete (or
+     * that the solution is found), which is obviously wrong. To block the main thread until all
+     * subtasks are complete, we need a way to wait for quiescence that considers forked tasks, which is
+     * what {@link #helpQuiesce()} does. In particular, since the root task is
+     * {@link ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask) invoked} by the main thread, it
+     * will keep the main thread parked until either generation is complete or the solution is found.
+     * </p>
+     * 
+     * <p>
+     * The idea that a <code>ForkJoinTask</code>'s <code>awaitQuiescence()</code> method doesn't account
+     * for forked tasks is...stupid. The fact that helpQuiesce() works properly makes me believe that
+     * this is an oversight or bug in the JDK, since it proves that the ForkJoinPool can track forked
+     * tasks. Oh well.
+     * </p>
+     * 
+     * @param ctx the thread-local {@link GeneratorContext} containing resource pools.
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(n) where n is the number of valid first clicks.
+     * @optimization Limits the range of first clicks to reduce the number of subtasks. Piggybacks on
+     *               the thread-local nature of the context to avoid multiple ThreadLocal accesses.
+     * @memory Memory usage is minimized by recycling resources and using pools. No allocations should
+     *         occur in this method unless the pools are somehow empty.
+     * @see #helpQuiesce()
+     * @see #recycleOwnResources(GeneratorContext)
+     */
+    private void computeRootSubtasks(GeneratorContext ctx) {
         final short start = 0;
         final short max = (short) (Math.min(Grid.NUM_CELLS - numClicks, maxFirstClickIndex) + 1);
 
@@ -635,9 +1030,48 @@ public class CombinationGeneratorTask extends RecursiveAction
         helpQuiesce(); // Wait for all subtasks to complete before returning
         // This will ensure that the root task does not exit prematurely, keeping the main thread parked
     }
-    // MONOMORPHIC: Single init method to avoid polymorphic call sites
-    public void init(short[] prefix, int prefixLength, long parentAdjacencyState, boolean skipConstraints)
-    {
+    
+    /**
+     * Initializes the task with the given parameters, preparing it for execution.
+     * 
+     * <p>
+     * To avoid excessive allocations and deallocations, we recycle task objects via a {@link TaskPool},
+     * avoiding the need to allocate a new task for every step of the combination generation process.
+     * However, recycling tasks means that we need a way to reinitialize them with new parameters before
+     * execution. This method serves that purpose, taking in the necessary parameters and setting the
+     * task's fields accordingly.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be fast and efficient, as it is called frequently during the
+     * combination generation process. The method simply assigns the provided parameters to the task's
+     * fields and calls the underlying {@link #reinitialize()} method to reset any derived state,
+     * allowing the task to be resubmitted without causing issues with the {@link ForkJoinPool}
+     * framework.
+     * </p>
+     * 
+     * <p>
+     * Previously, we had separate init methods for tasks that would and wouldn't
+     * {@link #skipConstraintsCheck skip constraint checks}, but this created a polymorphic call site that
+     * hindered JVM optimizations. By consolidating the init methods into a single monomorphic method, we
+     * can improve performance and allow the JIT compiler to perform more aggressive optimizations, with
+     * the trade-off being an unnecessary assignment in some cases.
+     * </p>
+     * 
+     * @param prefix a <code>short[]</code> representing the current combination state.
+     * @param prefixLength the length of the prefix array.
+     * @param parentAdjacencyState the cached adjacency state from the parent task.
+     * @param skipConstraints whether to skip constraint checks for this task and its children.
+     * @since 2025.07.11 - Task Pool Introduction
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(1) for assignments and reinitialization.
+     * @optimization Monomorphic method to avoid polymorphic call sites and improve JIT optimizations.
+     * @memory Memory usage is minimized by recycling task objects via a TaskPool. No allocations occur in this method.
+     * @see #reinitialize()
+     * @see TaskPool
+     */
+    public void init(short[] prefix, int prefixLength, long parentAdjacencyState, boolean skipConstraints) {
         this.prefix = prefix;
         this.prefixLength = prefixLength;
         this.cachedAdjacencyState = parentAdjacencyState;
@@ -705,7 +1139,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * method, which we want to avoid in the hot path.
      * </p>
      * 
-     * @param ctx - the {@link GeneratorContext} containing the current batch and resource pools.
+     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
      * @since 2025.07.03 - Splitting the Compute Method Into Paths
      * @threading Thread-safe due to ForkJoinTask isolation.
      * @performance O({@link #prefixLength}) for prefix parity computation,
@@ -775,8 +1209,54 @@ public class CombinationGeneratorTask extends RecursiveAction
     }
     
     // PURE HOT PATH SEPARATION: Dispatch once per task, not per loop iteration
-    private void computeIntermediateSubtasks(GeneratorContext ctx)
-    {
+    /**
+     * Dispatches to the appropriate subtask computation method based on the
+     * {@link #skipConstraintsCheck constraint check flag}. This method is called by {@link #compute()}
+     * for intermediate tasks and directs the flow accordingly.
+     * 
+     * <p>
+     * Intermediate tasks are those that are neither the root task nor leaf tasks. They have a
+     * {@link #prefixLength} less than <code>{@link #numClicks} - 1</code> and are responsible for
+     * computing and forking subtasks for the next clicks. {@link #canPotentiallySatisfyConstraints(int)
+     * Pruning logic} is applied in our code to eliminate invalid paths for generators early, but the
+     * nature of our tasks means that if a prefix is known to satisfy the constraints, all of its
+     * descendants must also satisfy the constraints. Therefore, tracking whether a prefix satisfies the
+     * constraints allows us to avoid redundant checks for all descendants, which can significantly
+     * improve the performance of subtask computation. However, this introduces branching and
+     * conditionals into the hot path, which we want to avoid.
+     * </p>
+     * 
+     * <p>
+     * To resolve this, we separate the subtask computation into two distinct methods:
+     * {@link #computeIntermediateSubtasksSkipPath(GeneratorContext) one for prefixes that satisfy the
+     * constraints} and {@link #computeIntermediateSubtasksConstraintPath(GeneratorContext) one for
+     * prefixes that require constraint checks}. This allows us to maintain a monomorphic call site for
+     * each path, reducing branching and conditionals in the hot path and allowing the JIT compiler to
+     * perform more aggressive optimizations.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is intentionally kept simple to minimize overhead. While a previous version of the
+     * code implemented the constraint check logic directly into <code>compute()</code>, this created a
+     * bifurcation of the call site that hindered optimizations. Implementing it into any of the
+     * computation methods would introduce branching into the hot path, forcing a conditional check and
+     * redundant pieces of code into the hot path. By separating the paths into distinct methods and
+     * using a simple dispatcher, we can maintain monomorphic call sites for each path, increasing the
+     * likelihood of JIT optimizations and improving overall performance.
+     * </p>
+     * 
+     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(1) for dispatching.
+     * @optimization Monomorphic call sites for each path to reduce branching and conditionals in the hot path.
+     * @see #skipConstraintsCheck
+     * @see #compute()
+     * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
+     * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
+     */
+    private void computeIntermediateSubtasks(GeneratorContext ctx) {
         if (skipConstraintsCheck) {
             computeIntermediateSubtasksSkipPath(ctx);
         } else {
@@ -821,7 +1301,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * and make it smaller for better JIT optimization.
      * </p>
      * 
-     * @param ctx - the {@link GeneratorContext} containing the current batch and resource pools.
+     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
      * @since 2025.08.04 - Specialized Subtask Paths
      * @threading Thread-safe due to ForkJoinTask isolation.
      * @performance O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} - 
@@ -832,8 +1312,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @see #skipConstraintsCheck
      * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
      */
-    private void computeIntermediateSubtasksSkipPath(GeneratorContext ctx)
-    {
+    private void computeIntermediateSubtasksSkipPath(GeneratorContext ctx) {
         final short start = (short) (prefix[prefixLength - 1] + 1);
         final short max = (short) (Grid.NUM_CELLS - (numClicks - prefixLength) + 1);
         final ArrayPool prefixPool = ctx.prefixArrayPool;
@@ -898,7 +1377,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * simplify the code and make it smaller for better JIT optimization.
      * </p>
      * 
-     * @param ctx - the {@link GeneratorContext} containing the current batch and resource pools.
+     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
      * @since 2025.08.04 - Specialized Subtask Paths
      * @threading Thread-safe due to ForkJoinTask isolation.
      * @performance O(1) for the early constraint check,
@@ -911,8 +1390,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
      * @see #ensureTrueCellMasks(short[])
      */
-    private void computeIntermediateSubtasksConstraintPath(GeneratorContext ctx)
-    {
+    private void computeIntermediateSubtasksConstraintPath(GeneratorContext ctx) {
         final short start = (short) (prefix[prefixLength - 1] + 1);
         final short max = (short) (Grid.NUM_CELLS - (numClicks - prefixLength) + 1);
         
@@ -1003,7 +1481,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * optimized path for valid prefixes.
      * </p>
      * 
-     * @param startIdx - the index of the first possible next click (used for suffix OR checks)
+     * @param startIdx the index of the first possible next click (used for suffix OR checks)
      * @return <code>true</code> if the current prefix or any descendant can satisfy the constraints,
      *         <code>false</code> otherwise.
      * @since 2025.07.03 - Splitting the Compute Method Into Paths
@@ -1022,8 +1500,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @see Grid#findTrueCells(Grid.ValueFormat)
      * @see Grid#findAdjacents(short)
      */
-    private boolean canPotentiallySatisfyConstraints(int startIdx)
-    {   
+    private boolean canPotentiallySatisfyConstraints(int startIdx) {   
         // OPTIMIZATION: Call ensureTrueCellMasks once in the root task to avoid a call here.
 
         // cachedAdjacencyState can only be -1 for the root task (which skips this check)
@@ -1129,16 +1606,47 @@ public class CombinationGeneratorTask extends RecursiveAction
     private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix(); // Stored in index format
 
     // This method is used to initialize the click adjacency matrix, and is static
-    private static boolean[][] initClickAdjacencyMatrix() 
-    {
+    /**
+     * Initializes the {@link #CLICK_ADJACENCY_MATRIX} representing adjacency relationships between
+     * cells.
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The method creates a <code>boolean[][]</code> where each row corresponds to a cell in the grid
+     * and each column corresponds to whether that cell is adjacent to another cell. It iterates over
+     * all cells in the grid, using {@link Grid#findAdjacents(short, Grid.ValueFormat)} to find the
+     * adjacent cells for each cell. The adjacency relationships are then stored in the matrix.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is called once at class initialization, so its performance is not as critical as
+     * other parts of the program. This matrix is technically only used for the initialization of
+     * {@link #TRUE_CELL_ADJACENCY_MASKS}, meaning that it could be replaced by direct calls to
+     * {@link Grid#findAdjacents(short, Grid.ValueFormat)} (or the creation of a method to expose the
+     * cache behind {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}), though we've kept it
+     * since this method pre-dates the creation of the bitmasked adjacency checks.
+     * </p>
+     * 
+     * @return a <code>boolean[][]</code> where <code>matrix[i][j]</code> is true if cell i is adjacent
+     *         to cell j.
+     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @threading Statically initialized once at class load time.
+     * @performance O(n^2) where n is the number of cells in the grid, due to nested iteration over
+     *              cells and their adjacents.
+     * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
+     *               for efficient adjacency representation.
+     * @memory Allocates a fixed-size boolean matrix of size n x n, where n is the number of cells in
+     *         the grid.
+     * @see #CLICK_ADJACENCY_MATRIX
+     * @see Grid#findAdjacents(short, Grid.ValueFormat)
+     */
+    private static boolean[][] initClickAdjacencyMatrix() {
         boolean[][] matrix = new boolean[Grid.NUM_CELLS][Grid.NUM_CELLS];
-        for (short i = 0; i < Grid.NUM_CELLS; i++) 
-        {
+        for (short i = 0; i < Grid.NUM_CELLS; i++) {
             short[] adjacents = Grid.findAdjacents(i, Grid.ValueFormat.Index);
-            if (adjacents != null) 
-            {
-                for (short adj : adjacents) 
-                {
+            if (adjacents != null) {
+                for (short adj : adjacents) {
                     if (adj < Grid.NUM_CELLS) matrix[i][adj] = true;
                 }
             }
@@ -1189,7 +1697,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * overhead.
      * </p>
      * 
-     * @param trueCells - the array of indices of initially true cells in the grid.
+     * @param trueCells the array of indices of initially true cells in the grid.
      * @since 2025.07.06 - Bitmasked Adjacency Checks
      * @threading Thread-safe due to synchronized block and double-checked locking.
      * @performance O({@link #numClicks} * m) where m is the number of initially true cells.
@@ -1202,8 +1710,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @see #CLICK_ADJACENCY_MATRIX
      * @see #initClickAdjacencyMatrix()
      */
-    private static void ensureTrueCellMasks(short[] trueCells) 
-    {
+    private static void ensureTrueCellMasks(short[] trueCells) {
         if (TRUE_CELL_ADJACENCY_MASKS == null | SUFFIX_OR_MASKS == null)
         {
             synchronized (CombinationGeneratorTask.class) 
@@ -1298,7 +1805,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * improvement.
      * </p>
      * 
-     * @param batch - the {@link WorkBatch} to flush.
+     * @param batch the {@link WorkBatch} to flush.
      * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
      *         was interrupted.
      * @since 2025.06.08 - Fork Join Refactor
@@ -1310,8 +1817,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @see CombinationQueueArray#getAllQueues()
      * @see CombinationQueue#add(WorkBatch)
      */
-    private final boolean flushBatchFast(WorkBatch batch) 
-    {   
+    private final boolean flushBatchFast(WorkBatch batch) {   
         CombinationQueue[] queues = queueArray.getAllQueues();
         int startIdx = ThreadLocalRandom.current().nextInt(queues.length);
         
@@ -1335,8 +1841,40 @@ public class CombinationGeneratorTask extends RecursiveAction
         }
     }
 
-    private void recycleOwnResources(GeneratorContext ctx)
-    {
+    /**
+     * Recycles the resources owned by this task back to the pools in the given
+     * {@link GeneratorContext}.
+     * 
+     * <p>
+     * Fork-join tasks are designed to be small and fast, but frequent allocations can lead to GC
+     * pressure and degrade performance. We implement resource pooling to mitigate this, allowing tasks
+     * to reuse arrays and task objects rather than constantly allocating and deallocating them, but we
+     * need a way to return these resources to the pools when a task is done. This method does that.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is called once per task completion, making it less performance-critical than other
+     * parts of the code, but we still want to ensure that it runs efficiently so generators can quickly
+     * move to the next task. We avoid accessing the {@link ThreadLocal} context here, instead relying
+     * on the passed-in context and its fields. This reduces the overhead of accessing thread-local
+     * storage to once per task and allows the pools to piggyback on the same context used for
+     * {@link WorkBatch batch} management.
+     * </p>
+     * 
+     * @param ctx the {@link GeneratorContext} containing the resource pools.
+     * @since 2025.07.22 - Task Self-Recycling
+     * @threading Thread-safe due to ForkJoinTask isolation and local context access.
+     * @performance O(1) for returning resources to the pools.
+     * @optimization Avoids ThreadLocal access by using passed-in context, reuses existing pools.
+     * @see #context
+     * @see ArrayPool
+     * @see ArrayPool#put(short[])
+     * @see GeneratorContext
+     * @see TaskPool
+     * @see TaskPool#put(CombinationGeneratorTask)
+     */
+    private void recycleOwnResources(GeneratorContext ctx) {
         // No ThreadLocal access needed - use passed context
         
         // Recycle prefix array to context pool
@@ -1348,12 +1886,51 @@ public class CombinationGeneratorTask extends RecursiveAction
     }
 
     // TODO: Rework this method so it actually flushes all pending batches, since we currently just handle the batch for one context
-    public static void flushAllPendingBatches(CombinationQueueArray queueArray, ForkJoinPool pool) 
-    {
+    /**
+     * Flushes all pending {@link WorkBatch batches} from all threads to any available queues in the
+     * {@link CombinationQueueArray}. This method currently only flushes the batch for a single thread's
+     * {@link GeneratorContext context}, though we could fix that simply by registering all contexts in
+     * a static list when they are created.
+     * 
+     * <p>
+     * To amortize the cost of flushing batches, we allow tasks to accumulate work in their
+     * <code>WorkBatch</code>es until they reach {@link #BATCH_SIZE}, flushing only after they reach
+     * this threshold. However, it is possible (and likely) that all tasks will complete with partially
+     * full batches remaining (leaving a maximum of <code>(BATCH_SIZE - 1) * (numThreads)) combinations
+     * left). To ensure that all generated combinations are tested, we need a way for the main thread to
+     * flush these remaining batches after all tasks are done, which is what this method does.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is called once after all tasks are complete, so its performance is not as critical as
+     * other parts of the program. However, we still want to ensure that it runs efficiently and does
+     * not introduce unnecessary overhead. We use {@link ForkJoinPool#submit(ForkJoinTask)} to create
+     * and offload a custom flushing task to the pool, allowing us to leverage the pool's worker threads
+     * to perform the operation. We also make sure to check if a solution has already been found or if
+     * the pool is shut down before proceeding to avoid a race condition or unnecessary work.
+     * </p>
+     * 
+     * @param queueArray the {@link CombinationQueueArray} containing the {@link CombinationQueue
+     *                   queues} to flush to.
+     * @param pool       the {@link ForkJoinPool} to submit the flushing task to.
+     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
+     * @threading Thread-safe due to local context access and atomic operations in
+     *            {@link CombinationQueue#add(WorkBatch)}.
+     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues
+     *              are full.
+     * @optimization Uses ForkJoinPool to leverage worker threads, checks for solution found or pool
+     *               shutdown to avoid unnecessary work.
+     * @see #context
+     * @see #flushBatchHelper(WorkBatch, CombinationQueueArray, boolean, boolean)
+     * @see GeneratorContext#resetBatch()
+     * @see CombinationQueueArray
+     * @see WorkBatch
+     */
+    public static void flushAllPendingBatches(CombinationQueueArray queueArray, ForkJoinPool pool) {
         if (queueArray.solutionFound || pool.isShutdown()) return;
         
-        try 
-        {
+        try {
             pool.submit(() -> {
                 // Single ThreadLocal access per flush operation
                 final GeneratorContext ctx = context.get();
@@ -1364,8 +1941,7 @@ public class CombinationGeneratorTask extends RecursiveAction
                     ctx.resetBatch(); // Reset rather than remove ThreadLocal
                 }
             }).join();
-        } catch (Exception e) 
-        {
+        } catch (Exception e) {
             // Do nothing, just return.
         }
     }

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * <h2>Performance Critical Paths</h2>
  * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
  * 
- * <h3>0/37 - 0% of documentation completed (excluding GeneratorContext)</h3>
+ * <h3>2/37 - ~5% of documentation completed (excluding GeneratorContext)</h3>
  * 
  * @algorithm [Detailed algorithm description with complexity analysis]
  * @threading [Concurrency model and synchronization approach]
@@ -33,24 +33,75 @@ public class CombinationGeneratorTask extends RecursiveAction
     // private static final int FLUSH_THRESHOLD = (int) (BATCH_SIZE * 0.5); // The threshold at which we flush the batch to the queue. Rather than setting this to a fixed value, we set it to a proportion of the batch size to allow for more efficient flushing without excessive overhead. // TODO: Consider re-adding the FLUSH_THRESHOLD if needed
     private static final int POOL_SIZE = 2048; // Reduced since we're using more efficient pools
 
-    // REPLACE: Multiple ThreadLocals with single context
     /**
-     * GeneratorContext - [Performance Purpose - e.g., "High-performance memory pool"]
+     * A ThreadLocal context containing references to resource pools.
+     * 
+     * <p>
+     * Recycling resources is crucial for performance in the JVM, but maintaining multiple ThreadLocals
+     * is expensive, especially with the frequent access patterns in this class. To optimize this, we
+     * consolidate all ThreadLocal data into a single context object that can be passed down to all
+     * methods.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The context is stored in a ThreadLocal variable to ensure that each thread has its own instance,
+     * allowing for efficient resource management without contention. This context holds references to
+     * various resource pools, such as the prefix array pool and task pool, which are used to recycle
+     * arrays and tasks respectively.
+     * </p>
+     * 
+     * @since 2025.07.26 - GeneratorContext Introduction
+     * @threading ThreadLocal - Each thread has its own instance of GeneratorContext, ensuring thread
+     *            safety and isolation of resources
+     * @performance O(1) access time for ThreadLocal.get()
+     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce overhead
+     * @memory ThreadLocal memory usage is minimized by pooling resources and recycling them
+     * @see GeneratorContext
+     * @see ArrayPool
+     * @see TaskPool
+     * @see WorkBatch
+     */
+    private static final ThreadLocal<GeneratorContext> context =
+        ThreadLocal.withInitial(GeneratorContext::new);
+
+    /**
+     * GeneratorContext - A thread-local context for managing resource pools and state.
      * 
      * <h1>P0 - Core Architecture</h1>
      * 
-     * <p>[Detailed description of the performance problem this class solves.
-     * Include before/after metrics where applicable.]</p>
+     * <p>
+     * A core part of the fork-join architecture is work-stealing, where each worker has a double-ended
+     * queue of tasks to process, allowing them to steal work from others when their deque is empty. We
+     * create a task for every step of the combination generation process, which is great for
+     * work-stealing, but violates the golden rule of JVM optimizations: <b>Don't allocate.</b>
+     * </p>
+     * 
+     * <p>
+     * Recycling is necessary to avoid excessive allocations and deallocations, and we give each thread
+     * its own pool of resources to work with. However, we can't pass down these references directly
+     * since the task may be executed by a different thread than the one that created it. This problem
+     * is solvable via ThreadLocals, which allow us to store thread-specific data, but the
+     * {@link ThreadLocal#get()} method is expensive to call. We need to minimize the number of calls to
+     * this method by consolidating all ThreadLocal data into a single context object that can be passed
+     * down to all methods. GeneratorContext provides us with a way to do that.
+     * </p>
      * 
      * <h2>Optimization Strategy</h2>
-     * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
-     * Explain trade-offs made for performance gains.]</p>
+     * <p>
+     * [Specific optimization techniques used - pooling, caching, lock-free, etc. Explain trade-offs
+     * made for performance gains.]
+     * </p>
      * 
      * <h2>Usage Patterns</h2>
-     * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+     * <p>
+     * [How and when to use this utility. Common usage patterns and anti-patterns.]
+     * </p>
      * 
      * <h2>Memory Management</h2>
-     * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+     * <p>
+     * [Memory allocation patterns, GC implications, sizing considerations.]
+     * </p>
      * 
      * <h3>0/6 - 0% of documentation completed</h3>
      * 
@@ -59,10 +110,6 @@ public class CombinationGeneratorTask extends RecursiveAction
      * @threading [Thread safety model]
      * @since [When introduced and why]
      */
-    private static final ThreadLocal<GeneratorContext> context =
-        ThreadLocal.withInitial(GeneratorContext::new);
-
-    // Generator context consolidates all per-thread resources
     private static class GeneratorContext
     {
         final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE / 4);
@@ -106,6 +153,46 @@ public class CombinationGeneratorTask extends RecursiveAction
     // Cached data between tasks
     private short[] prefix;
     private int prefixLength;
+    /**
+     * A bitmask representing the adjacency state of the current prefix. Each bit corresponds to an
+     * initially true cell in the grid, and a bit is set if the cell is toggled by the current prefix.
+     * The use of a long limits us to 64 initially true cells, but all puzzles in this game have initial
+     * true counts that are below this limit.
+     * 
+     * <p>
+     * A click on a cell only toggles the cells adjacent to it. This provides us with an important
+     * property of the puzzle's solution: The solution must toggle all initially true cells. This
+     * property allows us to prune combinations early by seeing what true cells are toggled by the
+     * current prefix and checking if the remaining clicks could toggle the remaining true cells.
+     * </p>
+     * 
+     * <p>
+     * We want to prune combinations as early as possible to increase the time spent on potentially
+     * valid combinations, but recomputing the adjacency state for every prefix would be too expensive.
+     * Therefore, we cache the adjacency state of the current prefix and incrementally update it as we
+     * add new clicks to the prefix.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Incremental updates amortize the cost of recomputation, allowing us to maintain a low overhead.
+     * Bitwise operations are fast and efficient, making this approach suitable for high-performance
+     * combinatorial tasks.
+     * </p>
+     * 
+     * @since 2025.07.15 - Cached adjacency state introduction
+     * @threading Thread-safe due to ForkJoinTask isolation
+     * @performance O(1) for updates, O(n) for initial computation where n is the prefixLength at that
+     *              point.
+     * @optimization Caches the state between tasks to avoid recomputing for every prefix.
+     * @memory Uses a long to represent the adjacency state, which is efficient for up to 64 initially
+     *         true cells.
+     * @see #skipConstraintsCheck
+     * @see #canPotentiallySatisfyConstraints(int)
+     * @see #ensureTrueCellMasks(short[])
+     * @see Grid#areAdjacent(short cellA, short cellB)
+     * @see Grid#findTrueCells()
+     */
     private long cachedAdjacencyState = -1; // -1 means root task, -2 means constraints are skipped
     private boolean skipConstraintsCheck = false; // If a prefix is known to satisfy constraints, we can skip checks for its children
 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -179,7 +179,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * [Memory allocation patterns, GC implications, sizing considerations.]
      * </p>
      * 
-     * <h3>0/7 - 0% of documentation completed</h3>
+     * <h3>1/7 - ~15% of documentation completed</h3>
      * 
      * @performance [Specific performance characteristics and measurements]
      * @memory [Memory usage patterns and optimizations]
@@ -190,6 +190,36 @@ public class CombinationGeneratorTask extends RecursiveAction
     {
         final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE);
         final TaskPool taskPool = new TaskPool(POOL_SIZE / 4);
+        /**
+         * The current WorkBatch being processed by this thread.
+         * 
+         * <p>
+         * Generators produce combinations in batches to amortize the cost of queue operations, making the
+         * generation process more efficient. Since work batches are sized greater than the maximum number
+         * of combinations that can be generated in a single task, we need a way to preserve the current
+         * batch between tasks. We could make work batches thread-safe, but that would come at the cost of
+         * performance. Instead, we bundle the current batch into the {@link ThreadLocal thread-local}
+         * context, giving each thread its own batch to work with.
+         * </p>
+         * 
+         * <h3>Performance Considerations</h3>
+         * <p>
+         * By keeping the current batch in the thread-local context, we avoid contention and locking
+         * overhead, allowing each thread to work independently. This design also simplifies the logic for
+         * managing batches, as each thread can handle its own batch without needing to coordinate with
+         * others. Bundling the batch into the context gives us the benefit of <code>ThreadLocal</code>
+         * storage without the cost of multiple ThreadLocal accesses.
+         * </p>
+         * 
+         * @since 2025.07.01 - WorkBatch Introduction
+         * @threading Thread-local - Each thread has its own instance of WorkBatch, ensuring thread safety.
+         * @performance O(1) access time.
+         * @optimization Bundled into GeneratorContext to reduce ThreadLocal access overhead.
+         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @see WorkBatch
+         * @see CombinationGeneratorTask#context
+         * @see CombinationGeneratorTask#BATCH_SIZE
+         */
         WorkBatch currentBatch = null;
 
         WorkBatch getOrCreateBatch()

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * <h2>Performance Critical Paths</h2>
  * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
  * 
- * <h3>2/37 - ~5% of documentation completed (excluding GeneratorContext)</h3>
+ * <h3>8/36 - ~22% of documentation completed (excluding GeneratorContext)</h3>
  * 
  * @algorithm [Detailed algorithm description with complexity analysis]
  * @threading [Concurrency model and synchronization approach]
@@ -29,9 +29,85 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class CombinationGeneratorTask extends RecursiveAction
 {
-    public static final int BATCH_SIZE = 8000; // The maximum size of a batch before it is flushed to the queue. Batches will try to be flushed when they reach the FLUSH_THRESHOLD, but will always be flushed when they reach this size.
-    // private static final int FLUSH_THRESHOLD = (int) (BATCH_SIZE * 0.5); // The threshold at which we flush the batch to the queue. Rather than setting this to a fixed value, we set it to a proportion of the batch size to allow for more efficient flushing without excessive overhead. // TODO: Consider re-adding the FLUSH_THRESHOLD if needed
-    private static final int POOL_SIZE = 2048; // Reduced since we're using more efficient pools
+    /**
+     * The maximum size of a batch before it is flushed to the queue.
+     * 
+     * <p>
+     * To amortize the cost of queue operations, we bundle combinations into {@link WorkBatch} objects
+     * and flush them to the queue as one. Naturally, this means that we have to define a maximum size
+     * for each batch.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The batch size is a compromise between multiple factors. Larger batches reduce the overhead of
+     * queue operations and allow for generators and {@link TestClickCombination monkeys} to work for
+     * longer periods of time without interruption, but they increase the memory footprint and can cause
+     * longer monkey pauses as they wait for new batches to process. Smaller batches are more responsive
+     * and can give monkeys more frequent tasks, but they increase the overhead and time spent on queue
+     * operations, which can cause contention and reduce overall throughput.
+     * </p>
+     * 
+     * <p>
+     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a batch size of 8000 seems to
+     * be a good compromise between these factors. I originally included a flush threshold to encourage
+     * more frequent flushing of batches to the queue, but the overhead of size checks made it less
+     * helpful. Batch size is not a silver bullet, but increasing the size can sometimes help with monkey
+     * bottlenecks, while decreasing it can help with generator bottlenecks.
+     * </p>
+     * 
+     * @since 2025.06.08 - Work-stealing introduction
+     * @see #flushBatchFast(WorkBatch)
+     * @see GeneratorContext
+     * @see GeneratorContext#getOrCreateBatch()
+     * @see CombinationQueue
+     * @see CombinationQueue#add(WorkBatch)
+     */
+    public static final int BATCH_SIZE = 8000;
+    /**
+     * The size of resource pools used in the generator context per thread.
+     * 
+     * <p>
+     * The golden rule of JVM optimizations: <b>Don't allocate.</b> This is especially true for
+     * high-performance applications like this one, where we need to minimize the number of allocations
+     * and deallocations to avoid garbage collection pauses and improve throughput. The fork-join
+     * architecture, which is used in this application, relies heavily on the creation of several tasks
+     * that are executed in parallel, but creating a new task with new resources for every step of the
+     * combination generation process would lead to trillions of allocations and deallocations, which
+     * would be catastrophic for performance.
+     * </p>
+     * 
+     * <p>
+     * Resource pooling and pre-allocation are key strategies to mitigate tihs issue. We use the custom
+     * {@link ArrayPool} and {@link TaskPool} classes to manage pools of arrays and tasks, and share
+     * access to these pools via the {@link GeneratorContext} class. To prevent contention and ensure
+     * that we have enough resources available for each thread, we need to define a size for these
+     * pools.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since pools pre-allocate resources, the size of the pool directly affects the memory footprint of
+     * the application. A smaller pool size reduces memory usage, but increases the likelihood of
+     * contention and accidental allocations, which can lead to performance degradation. A larger pool
+     * size is the opposite: it reduces contention and makes accidental allocations less likely, but at
+     * the cost of increased memory usage.
+     * </p>
+     * 
+     * <p>
+     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a pool size of 512 seems to
+     * be a good compromise between these factors. It allows for enough resources to be available for
+     * each thread without causing excessive memory usage or contention. Tuning the sizes of the pools
+     * can help with memory usage and cache locality, but must be done carefully to avoid accidental
+     * allocations.
+     * </p>
+     * 
+     * @since 2025.06.10 - Array Pooling Introduction
+     * @see ArrayPool
+     * @see TaskPool
+     * @see GeneratorContext
+     */
+    private static final int POOL_SIZE = 512;
 
     /**
      * A ThreadLocal context containing references to resource pools.
@@ -103,7 +179,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * [Memory allocation patterns, GC implications, sizing considerations.]
      * </p>
      * 
-     * <h3>0/6 - 0% of documentation completed</h3>
+     * <h3>0/7 - 0% of documentation completed</h3>
      * 
      * @performance [Specific performance characteristics and measurements]
      * @memory [Memory usage patterns and optimizations]
@@ -112,8 +188,8 @@ public class CombinationGeneratorTask extends RecursiveAction
      */
     private static class GeneratorContext
     {
-        final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE / 4);
-        final TaskPool taskPool = new TaskPool(128);
+        final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE);
+        final TaskPool taskPool = new TaskPool(POOL_SIZE / 4);
         WorkBatch currentBatch = null;
 
         WorkBatch getOrCreateBatch()
@@ -196,7 +272,45 @@ public class CombinationGeneratorTask extends RecursiveAction
     private long cachedAdjacencyState = -1; // -1 means root task, -2 means constraints are skipped
     private boolean skipConstraintsCheck = false; // If a prefix is known to satisfy constraints, we can skip checks for its children
 
-    private static long targetMask; // We can cache the target mask for the current task to avoid recomputing it in constraint checks
+    /**
+     * A bitmask representing the target true adjacency state for the current task. Initialized in the
+     * root task to avoid recomputation in constraint checks.
+     * 
+     * <p>
+     * Constraint checks are performed to ensure that the current prefix or one of its descendants can
+     * satisfy the constraint of touching each initially true cell at least once. For compact
+     * representation in {@link #canPotentiallySatisfyConstraints(int)}, we make a long bitmask to
+     * represent the prefix's current adjacency state, with the bitmask being sized to the number of
+     * initially true cells, and each 1 corresponding to a true cell.
+     * </p>
+     * 
+     * <p>
+     * The target mask for the constraint check contains all bits set to 1, but we can't define this as
+     * a static final constant since the number of initially true cells can vary between puzzles. To
+     * resolve this, we initialize this mask in the root task constructor, where we have access to the
+     * initially true cells. This lets us avoid recomputing the mask in every single constraint check,
+     * giving a minor performance boost.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Recomputing the mask each time isn't too complicated, but it adds undesirable overhead to our
+     * constraint checks, increasing the size of the checks and reducing the likelihood of JIT
+     * optimizations. It would also require us to pass an array of the true cells to every constraint
+     * check call. Optimizations like this appear small, but add up quickly when performed billions or
+     * trillions of times.
+     * </p>
+     * 
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @threading Computed once in the root task and reused across all subtasks.
+     * @performance O(1) for checks, O(1) for initial computation in the root task.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @memory Uses a long to represent the target state, which is efficient for up to 64 initially true cells.
+     * @see #cachedAdjacencyState
+     * @see #SUFFIX_OR_MASKS
+     * @see #ensureTrueCellMasks(short[])
+     */
+    private static long targetMask;
     
     private static volatile ForkJoinPool generatorPool;
 
@@ -258,14 +372,49 @@ public class CombinationGeneratorTask extends RecursiveAction
         ensureTrueCellMasks(trueCells);
 
         // OPTIMIZATION: Pre-compute and cache the first true cell mask once per puzzle
-        firstTrueCell = trueCells[0];
-        computeAdjacencyMaskFast();
+        short firstTrueCell = trueCells[0];
+        computeAdjacencyMaskFast(firstTrueCell);
     }
 
+    /**
+     * A mask representing the adjacency of the first true cell to other cells.
+     * 
+     * <p>
+     * While the {@link TestClickCombination monkeys} handle the more in-depth odd adjacency checks and
+     * the generators perform constraint checks at each branch, we still want some kind of fast check to
+     * be performed at the "leaf" of the generation tree (when a full-length combination has been
+     * built). We therefore create a slimmed-down version of the
+     * {@link TestClickCombination#satisfiesOddAdjacency(short[], short[])} check that operates only on
+     * the first true cell. To do this, we need to be able to quickly determine which cells are adjacent
+     * to the first true cell, which we can do by pre-computing a bitmask for it.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * We use bitmasks for their efficiency in representing sets of toggled cells; other formats like
+     * arrays or lists would be too slow and memory-intensive, and {@link java.util.BitSet}s incur
+     * abstraction penalties. Since longs are 64-bit and our {@link Grid} is {@link Grid#NUM_CELLS 109
+     * cells}, we need two longs to represent first true adjacency for the whole grid. This isn't
+     * particularly awful, but it's a limitation that forces us to perform two checks per final cell
+     * instead of one.
+     * </p>
+     * 
+     * @since 2025.06.11 - Revamped Odd Adjacency Check
+     * @threading Statically initialized once in {@link #computeAdjacencyMaskFast(short)} by the root
+     *            task.
+     * @performance O(1) for checks, O(n) for initial computation where n is the number of adjacent
+     *              cells.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation. A
+     *               bitmask is used for compact representation.
+     * @memory Uses an array of two longs to represent the adjacency of the first true cell.
+     * @see #computeAdjacencyMaskFast(short)
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @see Grid#findAdjacents(short)
+     * @see Grid#findFirstTrueCell(Grid.ValueFormat)
+     */
     private static long[] FIRST_TRUE_ADJACENTS;
-    private static short firstTrueCell;
     
-    private static void computeAdjacencyMaskFast() 
+    private static void computeAdjacencyMaskFast(short firstTrueCell) 
     {
         short[] adjacents = Grid.findAdjacents(firstTrueCell);
         long[] mask = new long[2];
@@ -511,8 +660,82 @@ public class CombinationGeneratorTask extends RecursiveAction
         return (availableAdjacencies & needed) == needed;
     }
 
-    // Keep existing constraint checking logic unchanged
+    /**
+     * Bitmasks representing the adjacency of each cell to initially true cells.
+     * 
+     * <p>
+     * Efficiently generating combinations requires the ability to prune invalid paths early, preventing
+     * wasted computation. A key property of the puzzle is that a solution must toggle all initially
+     * true cells. This gives us a way to prune combinations early, but we still need a way to quickly
+     * determine which true cells are toggled by a given prefix of clicks. This field gives us that
+     * ability.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Bitmasks are used for their efficiency in representing sets of toggled cells; other formats like
+     * arrays or lists would be too slow and memory-intensive. The use of longs does limit us to
+     * pre-computing up to 64 initially true cells, but all puzzles in this game have initial true
+     * counts that are below this limit.
+     * </p>
+     * 
+     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
+     * @performance O(1) for adjacency checks, O(n) for initial computation where n is the number of
+     *              initially true cells
+     * @memory One long per cell, guaranteeing a fixed memory footprint regardless of the number of true
+     *         cells and avoiding object overhead.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @see #SUFFIX_OR_MASKS
+     * @see #ensureTrueCellMasks(short[])
+     * @see Grid#findAdjacents(short cell)
+     * @see Grid#findTrueCells(Grid.ValueFormat format)
+     */
     private static long[] TRUE_CELL_ADJACENCY_MASKS = null;
+    /**
+     * Pre-computed suffix OR masks for fast constraint checks.
+     * 
+     * <p>
+     * There are three cases that can occur when performing a constraint check:
+     * </p>
+     * <ol>
+     * <li>The current prefix already satisfies the constraints, meaning the test is passed.</li>
+     * <li>The current prefix doesn't fully satisfy the constraints, but one or more of its descendants
+     * may be able to.</li>
+     * <li>The current prefix and all of its descendants cannot satisfy the constraints.</li>
+     * </ol>
+     * 
+     * <p>
+     * The first case is trivial, but the second and third are more complex. Since combinations have
+     * clicks in an increasing order (and no duplicates), we know that the range of additional clicks
+     * holding this prefix is constrained to the range of cells that are greater than the last click in
+     * the prefix. By summing together the true adjacency masks of all clicks after the last click in
+     * the prefix, we can quickly determine if any of the child combinations can toggle the remaining
+     * true cells.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The mask at index i contains the OR of all masks from i to the end of the array. This allows
+     * us to avoid an O(109 - i) check for each prefix, reducing the complexity to O(1). Bitmasks
+     * are used for their efficiency in representing sets of toggled cells; other formats like arrays
+     * or lists would be too slow and memory-intensive. The use of longs does limit us to
+     * pre-computing up to 64 initially true cells, but all puzzles in this game have initial
+     * true counts that are below this limit.
+     * </p>
+     * 
+     * @since 2025.07.14 - Suffix OR Masks Introduction
+     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
+     * @performance O(1) for suffix OR checks, O(n) for initial computation where n is the number of cells
+     *              in the grid.
+     * @memory One long per cell, guaranteeing a fixed memory footprint regardless of the number of true
+     *         cells and avoiding object overhead.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @see TRUE_CELL_ADJACENCY_MASKS
+     * @see #ensureTrueCellMasks(short[])
+     * @see #canPotentiallySatisfyConstraints(int)
+     * @see Grid#findAdjacents(short cell)
+     */
     private static long[] SUFFIX_OR_MASKS = null;
     private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix(); // Stored in index format
 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -5,12 +5,11 @@ import java.util.concurrent.RecursiveAction;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * CombinationGeneratorTask - Recursive combination generator using the {@link ForkJoinPool}
- * framework.
+ * A recursive combination generator using the {@link ForkJoinPool} framework.
  * 
  * <p>
- * Generators produce combinations of clicks, stored as <code>short[]</code> arrays, and add them to
- * a {@link CombinationQueue queue} for processing by {@link TestClickCombination monkeys}. The
+ * Generators produce combinations of clicks, stored as {@code short[]} arrays, and add them to a
+ * {@link CombinationQueue queue} for processing by {@link TestClickCombination monkeys}. The
  * generators use a recursive, divide-and-conquer approach to generate combinations in parallel,
  * leveraging the {@link ForkJoinPool} framework for efficient task management and work-stealing.
  * While monkeys handle the more {@link TestClickCombination#satisfiesOddAdjacency(short[]) in-depth
@@ -42,10 +41,10 @@ import java.util.concurrent.ThreadLocalRandom;
  * The fundamental rule of JVM optimizations is: <b>Don't allocate.</b> Fork-join architectures rely
  * on the creation of many small tasks that are executed in parallel, but allocating new resources
  * for every task would lead to excessive garbage collection pressure and performance degradation.
- * In addition, we can't solely use primitive types to represent the prefixes, as the maximum number
- * of clicks is 109, larger than the 64 bits available in a long. This means we need to allocate
- * arrays to store the prefixes, which could lead to trillions of allocations, murdering
- * performance.
+ * In addition, we can't solely use primitive types to represent the {@code prefix}es, as the
+ * maximum number of clicks is {@value Grid#NUM_CELLS}, larger than the 64 bits available in a
+ * {@code long}. This means we need to allocate arrays to store the prefixes, which could lead to
+ * trillions of allocations, murdering performance.
  * </p>
  * 
  * <p>
@@ -87,29 +86,31 @@ import java.util.concurrent.ThreadLocalRandom;
  * @see TestClickCombination
  * @see java.util.concurrent.ForkJoinTask
  * @since 2025.06.08 - Fork Join Refactor
- * @performance The overall time complexity is O(n choose k) in the worst case, where n is the
- *              number of cells and k is the number of clicks, but pruning and parallelism
- *              significantly reduce the effective workload. Most bottlenecks arise from contention
- *              on shared resources or the process of enqueuing batches.
- * @threading Each task is isolated and thread-safe due to ForkJoinTask design. Pooled and shared
- *            resources are handled by <code>ThreadLocal</code> contexts and static fields
- *            respectively.
- * @algorithm Creates a tree of tasks, where each task represents a prefix of clicks. The root task
- *            generates subtasks for each possible first click, and each subtask recursively
- *            generates further subtasks for each subsequent click until the full combination length
- *            is reached. Leaf tasks generate the final combinations and add them to a WorkBatch,
- *            which is then flushed to a randomly chosen CombinationQueue for processing.
+ * @performance The overall time complexity is
+ *              <code>O({@link Grid#NUM_CELLS NUM_CELLS} choose {@link #numClicks})</code> in the
+ *              worst case, but pruning and parallelism significantly reduce the effective workload.
+ *              Most bottlenecks arise from contention on shared resources or the process of
+ *              enqueuing batches.
+ * @threading Each task is isolated and thread-safe due to {@link java.util.concurrent.ForkJoinTask
+ *            ForkJoinTask} design. Pooled and shared resources are handled by {@code ThreadLocal}
+ *            contexts and static fields respectively.
+ * @algorithm Creates a tree of tasks, where each task represents a {@code prefix} of clicks. The
+ *            root task generates subtasks for each possible first click, and each subtask
+ *            recursively generates further subtasks for each subsequent click until the full
+ *            combination length is reached. Leaf tasks generate the final combinations and add them
+ *            to a {@link WorkBatch}, which is then flushed to a randomly chosen
+ *            {@link CombinationQueue} for processing.
  * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
  *         in the hot path.
  */
 public class CombinationGeneratorTask extends RecursiveAction {
     /**
-     * The maximum size of a batch before it is flushed to the queue.
+     * The maximum size of a batch before it is flushed to {@link CombinationQueue a queue}.
      * 
      * <p>
      * To amortize the cost of queue operations, we bundle combinations into {@link WorkBatch} objects
-     * and flush them to the queue as one. Naturally, this means that we have to define a maximum size
-     * for each batch.
+     * and {@link #flushBatchFast(WorkBatch) flush} them to the queue as one. Naturally, this means that
+     * we have to define a maximum size for each batch.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -123,11 +124,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * <p>
-     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a batch size of 8000 seems to
-     * be a good compromise between these factors. I originally included a flush threshold to encourage
-     * more frequent flushing of batches to the queue, but the overhead of size checks made it less
-     * helpful. Batch size is not a silver bullet, but increasing the size can sometimes help with monkey
-     * bottlenecks, while decreasing it can help with generator bottlenecks.
+     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a batch size of
+     * {@value #BATCH_SIZE} seems to be a good compromise between these factors. I originally included a
+     * flush threshold to encourage more frequent flushing of batches to the queue, but the overhead of
+     * {@code size} checks made it less helpful. Batch size is not a silver bullet, but increasing the
+     * size can sometimes help with monkey bottlenecks, while decreasing it can help with generator
+     * bottlenecks.
      * </p>
      * 
      * @see #flushBatchFast(WorkBatch)
@@ -139,7 +141,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
      */
     public static final int BATCH_SIZE = 8000;
     /**
-     * The size of resource pools used in the generator context per thread.
+     * The size of resource pools used in each thread's {@link #context}.
      * 
      * <p>
      * The golden rule of JVM optimizations: <b>Don't allocate.</b> This is especially true for
@@ -169,11 +171,11 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * <p>
-     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a pool size of 512 seems to
-     * be a good compromise between these factors. It allows for enough resources to be available for
-     * each thread without causing excessive memory usage or contention. Tuning the sizes of the pools
-     * can help with memory usage and cache locality, but must be done carefully to avoid accidental
-     * allocations.
+     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a pool size of
+     * {@value #POOL_SIZE} seems to be a good compromise between these factors. It allows for enough
+     * resources to be available for each thread without causing excessive memory usage or contention.
+     * Tuning the sizes of the pools can help with memory usage and cache locality, but must be done
+     * carefully to avoid accidental allocations.
      * </p>
      * 
      * @see ArrayPool
@@ -184,41 +186,41 @@ public class CombinationGeneratorTask extends RecursiveAction {
     private static final int POOL_SIZE = 512;
 
     /**
-     * A ThreadLocal context containing references to resource pools.
+     * A {@link java.lang.ThreadLocal ThreadLocal} context containing references to resource pools.
      * 
      * <p>
-     * Recycling resources is crucial for performance in the JVM, but maintaining multiple ThreadLocals
-     * is expensive, especially with the frequent access patterns in this class. To optimize this, we
-     * consolidate all ThreadLocal data into a single context object that can be passed down to all
-     * methods.
+     * Recycling resources is crucial for performance in the JVM, but maintaining multiple
+     * {@code ThreadLocal}s is expensive, especially with the frequent access patterns in this class. To
+     * optimize this, we consolidate all {@code ThreadLocal} data into a single context object that can
+     * be passed down to all methods.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The context is stored in a ThreadLocal variable to ensure that each thread has its own instance,
-     * allowing for efficient resource management without contention. This context holds references to
-     * various resource pools, such as the prefix array pool and task pool, which are used to recycle
-     * arrays and tasks respectively.
+     * The context is stored in a {@code ThreadLocal} variable to ensure that each thread has its own
+     * instance, allowing for efficient resource management without contention. This context holds
+     * references to various resource pools, such as the {@link GeneratorContext#prefixArrayPool prefix
+     * array pool} and {@link GeneratorContext#taskPool task pool}, which are used to recycle arrays and
+     * tasks respectively.
      * </p>
      * 
      * @see ArrayPool
      * @see GeneratorContext
      * @see TaskPool
      * @see WorkBatch
-     * @since 2025.07.26 - GeneratorContext Introduction
-     * @performance O(1) access time for ThreadLocal.get()
-     * @threading ThreadLocal - Each thread has its own instance of GeneratorContext, ensuring thread
-     *            safety and isolation of resources
-     * @memory ThreadLocal memory usage is minimized by pooling resources and recycling them
-     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce overhead
+     * @since 2025.07.26 - {@code GeneratorContext} Introduction
+     * @performance {@code O(1)} access time for {@link java.lang.ThreadLocal#get() ThreadLocal.get()}
+     * @threading {@code ThreadLocal} - Each thread has its own instance of {@code GeneratorContext},
+     *            ensuring thread safety and isolation of resources
+     * @memory {@code ThreadLocal} memory usage is minimized by pooling resources and recycling them
+     * @optimization Consolidation of multiple {@code ThreadLocal}s into a single context object to
+     *               reduce overhead
      */
     private static final ThreadLocal<GeneratorContext> context =
         ThreadLocal.withInitial(GeneratorContext::new);
 
     /**
-     * GeneratorContext - A thread-local context for managing resource pools and state.
-     * 
-     * <h1>P0 - Core Architecture</h1>
+     * A thread-local context for managing resource pools and state.
      * 
      * <p>
      * A core part of the fork-join architecture is work-stealing, where each worker has a double-ended
@@ -233,8 +235,9 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * since the task may be executed by a different thread than the one that created it. This problem
      * is solvable via ThreadLocals, which allow us to store thread-specific data, but the
      * {@link ThreadLocal#get()} method is expensive to call. We need to minimize the number of calls to
-     * this method by consolidating all ThreadLocal data into a single context object that can be passed
-     * down to all methods. GeneratorContext provides us with a way to do that.
+     * this method by consolidating all {@link java.lang.ThreadLocal ThreadLocal} data into a single
+     * context object that can be passed down to all methods. {@code GeneratorContext} provides us with
+     * a way to do that.
      * </p>
      * 
      * <h2>Optimization Strategy</h2>
@@ -256,16 +259,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * <h2>Memory Management</h2>
      * <p>
-     * The context itself is stored in a ThreadLocal variable, which means that it will be garbage
-     * collected when the thread is terminated. The resources within the context are pooled and
+     * The context itself is stored in a {@code ThreadLocal} variable, which means that it will be
+     * garbage collected when the thread is terminated. The resources within the context are pooled and
      * recycled, which helps to minimize memory usage and reduce garbage collection pressure. However,
      * care must be taken to ensure that resources are recycled properly to avoid memory leaks.
      * </p>
      * 
      * <p>
-     * As a wrapper class, GeneratorContext has a small memory footprint, but the resources it manages
-     * can be significant. The size of the pools should be tuned to balance memory usage and contention,
-     * with larger pools reducing contention but increasing memory usage.
+     * As a wrapper class, {@code GeneratorContext} has a small memory footprint, but the resources it
+     * manages can be significant. The {@link CombinationGeneratorTask#POOL_SIZE size of the pools}
+     * should be tuned to balance memory usage and contention, with larger pools reducing contention but
+     * increasing memory usage.
      * </p>
      * 
      * @see #context
@@ -273,25 +277,27 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see CombinationGeneratorTask
      * @see TaskPool
      * @see WorkBatch
-     * @since 2025.07.26 - GeneratorContext Introduction
-     * @performance O(1) access time for pool operations.
+     * @since 2025.07.26 - {@code GeneratorContext} Introduction
+     * @performance {@code O(1)} access time for pool operations.
      * @threading This class is not thread-safe, but is intended to be used in a thread-local manner. A
      *            thread-local, static variable should be created to use this class.
      * @memory Minimal memory footprint as a wrapper class, with pooled resources to minimize
      *         allocations.
-     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce
-     *               overhead.
+     * @optimization Consolidation of multiple {@code ThreadLocal}s into a single context object to
+     *               reduce overhead.
      */
     private static class GeneratorContext {
         /**
-         * An {@link ArrayPool} for storing click prefixes.
+         * An {@link ArrayPool} for storing click {@code prefix}es.
          * 
          * @see #context
          * @see #numClicks
          * @see ArrayPool
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @performance O(1) amortized access time for get() and recycle().
-         * @threading Thread-local - Each thread has its own instance of ArrayPool, ensuring thread safety.
+         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} amortized access time for {@link ArrayPool#get()} and
+         *              {@link ArrayPool#put(short[])}.
+         * @threading Thread-local - Each thread has its own instance of {@code ArrayPool}, ensuring thread
+         *            safety.
          * @memory Memory usage is optimized by reusing arrays and minimizing allocations.
          * @optimization Pooling and reusing arrays to minimize allocations on the hot path.
          */
@@ -302,15 +308,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * @see TaskPool#TaskPool(int)
          * @see TaskPool#get()
          * @see TaskPool#put(CombinationGeneratorTask)
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @performance O(1) amortized access time for get() and recycle().
-         * @threading Thread-local - Each thread has its own instance of TaskPool, ensuring thread safety.
+         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} amortized access time for {@link TaskPool#get()} and
+         *              {@link TaskPool#put(CombinationGeneratorTask)}.
+         * @threading Thread-local - Each thread has its own instance of {@code TaskPool}, ensuring thread
+         *            safety.
          * @memory Memory usage is optimized by reusing tasks and minimizing allocations.
          * @optimization Pooling and reusing tasks to minimize allocations on the hot path.
          */
         final TaskPool taskPool = new TaskPool(POOL_SIZE / 4);
         /**
-         * The current WorkBatch being processed by this thread.
+         * The current {@link WorkBatch} being processed by this thread.
          * 
          * <p>
          * Generators produce combinations in batches to amortize the cost of queue operations, making the
@@ -326,27 +334,29 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * By keeping the current batch in the thread-local context, we avoid contention and locking
          * overhead, allowing each thread to work independently. This design also simplifies the logic for
          * managing batches, as each thread can handle its own batch without needing to coordinate with
-         * others. Bundling the batch into the context gives us the benefit of <code>ThreadLocal</code>
-         * storage without the cost of multiple ThreadLocal accesses.
+         * others. Bundling the batch into the context gives us the benefit of {@code ThreadLocal} storage
+         * without the cost of multiple {@code ThreadLocal} accesses.
          * </p>
          * 
          * @see #BATCH_SIZE
          * @see #context
          * @see WorkBatch
-         * @since 2025.07.01 - WorkBatch Introduction
-         * @performance O(1) access time.
-         * @threading Thread-local - Each thread has its own instance of WorkBatch, ensuring thread safety.
+         * @since 2025.07.01 - {@code WorkBatch} Introduction
+         * @performance {@code O(1)} access time.
+         * @threading Thread-local - Each thread has its own instance of {@code WorkBatch}, ensuring thread
+         *            safety.
          * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
-         * @optimization Bundled into GeneratorContext to reduce ThreadLocal access overhead.
+         * @optimization Bundled into {@code GeneratorContext} to reduce {@code ThreadLocal} access
+         *               overhead.
          */
         WorkBatch currentBatch = null;
 
         /**
-         * Gets the {@link #currentBatch current <code>WorkBatch</code>}, obtaining a new one if necessary.
+         * Gets the {@link #currentBatch current WorkBatch}}, obtaining a new one if necessary.
          * 
          * <p>
-         * We need to ensure that we always have a valid <code>{@link WorkBatch}</code> to add combinations
-         * to. If the current batch is null (either because it hasn't been created yet or because it was
+         * We need to ensure that we always have a valid {@link WorkBatch} to add combinations to. If the
+         * current batch is {@code null} (either because it hasn't been created yet or because it was
          * flushed), we need some mechanism to "create" a new one. This method serves that purpose,
          * performing a simple null check and creating a new batch if necessary.
          * </p>
@@ -354,16 +364,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * <h3>Performance Considerations</h3>
          * <p>
          * This method is designed to be fast and efficient, as it is called frequently during the
-         * combination generation process. The null check is a simple and quick operation, and creating a
-         * new batch is also efficient due to the use of a pool.
+         * combination generation process. The {@code null} check is a simple and quick operation, and
+         * creating a new batch is also efficient due to the use of a pool.
          * </p>
          * 
-         * @return The current <code>{@link WorkBatch}</code>, guaranteed to be non-null.
+         * @return The current {@link WorkBatch}, guaranteed to be non-{@code null}.
          * @see #context
          * @see #getNewBatchBlocking()
          * @see WorkBatch
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @performance O(1) null check and access time.
+         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} null check and access time.
          * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
          *            safety.
          * @optimization Caches current batch to avoid redundant allocations or pool calls.
@@ -376,27 +386,27 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
 
         /**
-         * Obtains a new <code>{@link WorkBatch}</code> from {@link CombinationQueueArray#getWorkBatchPool()
-         * the pool}, blocking if necessary until one is available.
+         * Obtains a new {@link WorkBatch} from {@link CombinationQueueArray#getWorkBatchPool() the pool},
+         * "blocking" (spinning) if necessary until one is available.
          * 
          * <p>
-         * After all the combinations in a batch have been processed, the batch is recycled into a separate
-         * queue for reuse. This method retrieves a batch from that queue, blocking if necessary until one
-         * is available. Since batches have pre-allocated buffers for combinations, we need to ensure that
-         * the batches themselves are recycled to avoid excessive allocations and deallocations on the hot
-         * path. This method serves that purpose, providing a way to obtain a new batch in a blocking manner
-         * from the queue.
+         * After all the combinations in a batch have been processed, the batch is recycled into a
+         * {@link CombinationQueueArray#workBatchPool separate queue} for reuse. This method retrieves a
+         * batch from that queue, spinning if necessary until one is available. Since batches have
+         * pre-allocated buffers for combinations, we need to ensure that the batches themselves are
+         * recycled to avoid excessive allocations and deallocations on the hot path. This method serves
+         * that purpose, providing a way to obtain a new batch in a "blocking" manner from the queue.
          * </p>
          * 
          * <h3>Performance Considerations</h3>
          * <p>
          * This method is internally used often during the generation process, so it needs to be fast and
          * efficient while maintaining thread safety and allowing for signaling. Crucially, we need to
-         * ensure that the method can be exited if the task is cancelled, which is why we use a while loop
-         * with a {@link org.jctools.queues.MpmcArrayQueue#relaxedPoll() relaxed poll} instead of a blocking
-         * poll method to avoid deadlocks at the cost of busy-waiting. Crucially, we avoid calling
-         * {@link Thread#onSpinWait()} in the loop since it does not respond to cancellation (for some
-         * reason, at least in my testing).
+         * ensure that the method can be exited if the task is cancelled, which is why we use a
+         * {@code while} loop with a {@link org.jctools.queues.MpmcArrayQueue#relaxedPoll() relaxed poll}
+         * instead of a blocking {@code poll} method to avoid deadlocks at the cost of busy-waiting.
+         * Crucially, we avoid calling {@link Thread#onSpinWait()} in the loop since it does not respond to
+         * cancellation (for some reason, at least in my testing).
          * </p>
          * 
          * <p>
@@ -406,16 +416,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * additional threads. For now, we leave this as a simple busy-wait loop.
          * </p>
          * 
-         * @return A new <code>WorkBatch</code>, guaranteed to be non-null.
+         * @return A new {@code WorkBatch}, guaranteed to be non-{@code null}.
          * @see CombinationQueueArray
          * @see CombinationQueueArray#getWorkBatchPool()
          * @see WorkBatch
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @performance O(1) amortized access time, blocking if necessary.
+         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} amortized access time, blocking if necessary.
          * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
-         *           safety.
+         *            safety.
          * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
-         * @optimization Uses a busy-wait loop with relaxed polling to avoid deadlocks and allow for cancellation.
+         * @optimization Uses a busy-wait loop with relaxed polling to avoid deadlocks and allow for
+         *               cancellation.
          */
         private WorkBatch getNewBatchBlocking() {
             WorkBatch batch;
@@ -427,7 +438,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
 
         /**
-         * Resets the {@link #currentBatch current <code>WorkBatch</code>} by obtaining a new one from the pool.
+         * Resets the {@link #currentBatch current WorkBatch} by obtaining a new one from the pool.
          * 
          * <p>
          * After a batch has been filled and flushed to the queue, we need to obtain a new batch to continue
@@ -436,12 +447,13 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * it may be recycled and used by another thread.
          * </p>
          * 
-         * @return The new current <code>WorkBatch</code>, guaranteed to be non-null.
+         * @return The new current {@code WorkBatch}, guaranteed to be non-{@code null}.
          * @see #getNewBatchBlocking()
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @performance O(1) amortized access time, blocking if necessary.
-         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread safety.
-         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} amortized access time, blocking if necessary.
+         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
+         *            safety.
+         * @memory Memory usage is minimized by reusing {@link WorkBatch} instances from the pool.
          * @optimization Combines batch reset and retrieval into a single operation to reduce overhead.
          */
         WorkBatch resetBatch() {
@@ -454,9 +466,9 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * The total number of clicks in each combination.
      * 
      * <p>
-     * This field is static and shared across all tasks, as the number of clicks is constant for a given
-     * puzzle. It is initialized in the root task and used by all subtasks to determine the length of 
-     * the combinations being generated.
+     * This field is {@code static} and shared across all tasks, as the number of clicks is constant for
+     * a given puzzle. It is initialized in the root task and used by all subtasks to determine the
+     * length of the combinations being generated.
      * </p>
      * 
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
@@ -464,31 +476,33 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #prefix
      * @see #prefixLength
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance O(1) access time.
-     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
-     * @memory Minimal memory usage as a primitive int.
-     * @optimization Static field to avoid redundant storage in each task instance.
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     *            Initialized in the root task before any subtasks are created.
+     * @memory Minimal memory usage as a primitive {@code int}.
+     * @optimization {@code Static} field to avoid redundant storage in each task instance.
      */
     private static int numClicks;
     /**
      * A {@link CombinationQueueArray} from which to randomly select a queue to which to flush.
      * 
      * <p>
-     * Generators produce combinations and add them to a {@link CombinationQueue queue} for processing by
-     * {@link TestClickCombination monkeys}. To balance the load between multiple monkeys, we use a
+     * Generators produce combinations and add them to a {@link CombinationQueue queue} for processing
+     * by {@link TestClickCombination monkeys}. To balance the load between multiple monkeys, we use a
      * {@link CombinationQueueArray} that holds multiple queues and allows us to randomly select one to
-     * which to flush the generated combinations. This field is static and shared across all tasks, as the
-     * queue array is constant for a given puzzle.
+     * which to flush the generated combinations. This field is {@code static} and shared across all
+     * tasks, as the queue array is constant for a given puzzle.
      * </p>
      * 
      * @see #flushBatchFast(WorkBatch)
      * @see CombinationQueue
      * @see java.util.concurrent.ThreadLocalRandom
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance O(1) access time.
-     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     *            Initialized in the root task before any subtasks are created.
      * @memory Minimal memory usage as a reference.
-     * @optimization Static field to avoid redundant storage in each task instance.
+     * @optimization {@code Static} field to avoid redundant storage in each task instance.
      */
     private static CombinationQueueArray queueArray;
     /**
@@ -497,10 +511,10 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <p>
      * Since combinations are generated in lexicographical order, we can optimize the generation process
      * by limiting the range of possible first clicks. The maximum index for the first click is
-     * determined by the final adjacent cell to the first true cell in the grid, as any combinations
-     * starting with a click beyond this point would not be able to toggle the first true cell. This
-     * field is static and shared across all tasks, as the maximum first click index is constant for a
-     * given puzzle.
+     * determined by the final adjacent cell to the {@link Grid#findFirstTrueCell(Grid.ValueFormat)
+     * first true cell} in the grid, as any combinations starting with a click beyond this point would
+     * not be able to toggle the first {@code true} cell. This field is {@code static} and shared across
+     * all tasks, as the maximum first click index is constant for a given puzzle.
      * </p>
      * 
      * @see #compute()
@@ -508,44 +522,45 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see Grid#findFirstTrueAdjacents(com.github.mrgarbagegamer.Grid.ValueFormat)
      * @see Grid#findFirstTrueCell(com.github.mrgarbagegamer.Grid.ValueFormat)
      * @since 2025.06.11 - First Click Optimization
-     * @performance O(1) access time.
-     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any
-     *            subtasks are created.
-     * @memory Minimal memory usage as a primitive int.
-     * @optimization Static field to avoid redundant storage in each task instance.
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     *            Initialized in the root task before any subtasks are created.
+     * @memory Minimal memory usage as a primitive {@code int}.
+     * @optimization {@code Static} field to avoid redundant storage in each task instance.
      */
     private static int maxFirstClickIndex;
 
     // Cached data between tasks
     /**
-     * A <code>short[]</code> array representing the current prefix of clicks in
-     * {@link Grid.ValueFormat#Index Index} format.
+     * A {@code short[]} representing the current prefix of clicks in {@link Grid.ValueFormat#Index
+     * Index} format.
      * 
      * <p>
      * Each task in the fork-join architecture represents a prefix of clicks, which is built up as we
-     * descend the tree. This prefix is stored in a <code>short[]</code> array, which is passed down to
+     * descend the tree. This prefix is stored in a {@code short[]} array, which is passed down to
      * subtasks as they are created. These arrays are {@link ArrayPool#get() pooled} and
      * {@link ArrayPool#ArrayPool(int) pre-allocated} to avoid excessive allocations and deallocations
      * on the hot path, sized to {@link #numClicks} for the sake of ensuring the proper amount of space
-     * is available. The current length of the prefix is tracked via the {@link #prefixLength} field.
+     * is available. The current length of {@code prefix} is tracked via the {@link #prefixLength}
+     * field.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Using arrays allows for efficient storage and manipulation of the prefix, as we can easily add
-     * new clicks and pass the array down to subtasks. The use of primitive types also helps reduce
+     * Using arrays allows for efficient storage and manipulation of {@code prefix}, as we can easily
+     * add new clicks and pass the array down to subtasks. The use of primitive types also helps reduce
      * memory footprint and improve cache locality. Pooling and pre-allocation help minimize the number
      * of allocations and deallocations, reducing garbage collection pressure and improving overall
      * throughput.
      * </p>
      * 
      * <p>
-     * We use <code>short</code> instead of <code>int</code> to reduce memory usage, as the maximum
-     * number of cells is 109, which fits within the range of a <code>short</code>. This helps improve
-     * cache locality and reduce memory footprint, which is important in a high-performance application
-     * like this one. If we found a way to represent the prefix using only primitive types without
-     * arrays, we could potentially improve performance further and remove the need for pooling, but
-     * this is not currently feasible due to the maximum number of clicks exceeding 64.
+     * We use {@code short} instead of {@code int} to reduce memory usage, as the maximum number of
+     * cells is {@value Grid#NUM_CELLS}, which fits within the range of a {@code short}. This helps
+     * improve cache locality and reduce memory footprint, which is important in a high-performance
+     * application like this one. If we found a way to represent the prefix using only primitive types
+     * without arrays, we could potentially improve performance further and remove the need for pooling,
+     * but this is not currently feasible due to the maximum number of clicks exceeding 64.
      * </p>
      * 
      * @see #recycleOwnResources(GeneratorContext)
@@ -555,11 +570,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see GeneratorContext
      * @see GeneratorContext#prefixArrayPool
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance O(1) for adding clicks, O(n) for copying to subtasks where n is the
-     *              {@link #prefixLength} at that point.
-     * @threading Thread-safe due to ForkJoinTask isolation. Ensure that prefix arrays are not
-     *            referenced after recycling to avoid concurrency issues.
-     * @memory Uses <code>short</code> arrays to reduce memory usage while maintaining sufficient range.
+     * @performance {@code O(1)} for adding clicks, <code>O({@link #prefixLength})</code> for copying to
+     *              subtasks.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     *            Ensure that prefix arrays are not referenced after recycling to avoid concurrency
+     *            issues.
+     * @memory Uses {@code short} arrays to reduce memory usage while maintaining sufficient range.
      * @optimization Pooled and pre-allocated to minimize allocations on the hot path. Sized to
      *               {@link #numClicks} to avoid resizing.
      */
@@ -569,18 +585,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * <p>
      * Since we use pre-allocated, {@link ArrayPool pooled} arrays to store the prefix of clicks, we
-     * need a way to track the current length of the <code>prefix</code> array, as it may not be fully
+     * need a way to track the current length of the {@code prefix} array, as it may not be fully
      * filled. This field serves that purpose, allowing us to keep track of how many clicks have been
      * made so far and where to add the next click.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Using a separate field to track the length of the prefix allows for efficient addition of new
-     * clicks, as we can simply add the new click at the current length index and increment the length.
-     * This avoids the need to resize or copy the array, which would be expensive and could lead to
-     * excessive allocations and deallocations. It also simplifies the logic for determining whether a
-     * task is a leaf, root, or intermediate task, as we can simply compare the length to the
+     * Using a separate field to track the length of the {@code prefix} allows for efficient addition of
+     * new clicks, as we can simply add the new click at the current length index and increment the
+     * length. This avoids the need to resize or copy the array, which would be expensive and could lead
+     * to excessive allocations and deallocations. It also simplifies the logic for determining whether
+     * a task is a leaf, root, or intermediate task, as we can simply compare the length to the
      * {@link #numClicks} field.
      * </p>
      * 
@@ -588,30 +604,31 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #numClicks
      * @see #prefix
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance O(1) for updates and checks.
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @memory Minimal memory usage as a primitive int.
-     * @optimization Simple integer field to minimize overhead.
+     * @performance {@code O(1)} for updates and checks.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @memory Minimal memory usage as a primitive {@code int}.
+     * @optimization Simple {@code int} field to minimize overhead.
      */
     private int prefixLength;
     /**
-     * A bitmask representing the adjacency state of the current prefix. Each bit corresponds to an
-     * initially true cell in the grid, and a bit is set if the cell is toggled by the current prefix.
-     * The use of a long limits us to 64 initially true cells, but all puzzles in this game have initial
-     * true counts that are below this limit.
+     * A bitmask representing the adjacency state of the current {@link #prefix}. Each bit corresponds
+     * to an initially true cell in the grid, and a bit is set if the cell is toggled by the current
+     * {@code prefix}. The use of a {@code long} limits us to 64 initially true cells, but all puzzles
+     * in this game have initial true counts that are below this limit.
      * 
      * <p>
      * A click on a cell only toggles the cells adjacent to it. This provides us with an important
      * property of the puzzle's solution: The solution must toggle all initially true cells. This
      * property allows us to prune combinations early by seeing what true cells are toggled by the
-     * current prefix and checking if the remaining clicks could toggle the remaining true cells.
+     * current {@code prefix} and checking if the remaining clicks could toggle the remaining true
+     * cells.
      * </p>
      * 
      * <p>
      * We want to prune combinations as early as possible to increase the time spent on potentially
-     * valid combinations, but recomputing the adjacency state for every prefix would be too expensive.
-     * Therefore, we cache the adjacency state of the current prefix and incrementally update it as we
-     * add new clicks to the prefix.
+     * valid combinations, but recomputing the adjacency state for every {@code prefix} would be too
+     * expensive. Therefore, we cache the adjacency state of the current {@code prefix} and
+     * incrementally update it as we add new clicks to the {@code prefix}.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -621,28 +638,28 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * combinatorial tasks.
      * </p>
      * 
+     * @see #skipConstraintsCheck
      * @see #canPotentiallySatisfyConstraints(int)
      * @see #ensureTrueCellMasks(short[])
-     * @see #skipConstraintsCheck
      * @see Grid#areAdjacent(short, short)
      * @see Grid#findTrueCells()
      * @since 2025.07.15 - Cached adjacency state introduction
-     * @performance O(1) for updates, O(n) for initial computation where n is the prefixLength at that
-     *              point.
-     * @threading Thread-safe due to ForkJoinTask isolation
-     * @memory Uses a long to represent the adjacency state, which is efficient for up to 64 initially
-     *         true cells.
-     * @optimization Caches the state between tasks to avoid recomputing for every prefix.
+     * @performance {@code O(1)} for updates, <code>O({@link #prefixLength})</code> for initial
+     *              computation.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation
+     * @memory Uses a {@code long} to represent the adjacency state, which is efficient for up to 64
+     *         initially {@code true} cells.
+     * @optimization Caches the state between tasks to avoid recomputing for every {@link #prefix}.
      */
-    private long cachedAdjacencyState = -1; // -1 means root task, -2 means constraints are skipped
+    private long cachedAdjacencyState = -1;
     /**
      * A flag indicating whether to skip constraint checks for this task and its children.
      * 
      * <p>
      * Since {@link #prefix prefixes} are built up incrementally and our
      * {@link #canPotentiallySatisfyConstraints(int) constraint checks} are monotonic, if a
-     * <code>prefix</code> is known to satisfy the constraints, we know that all of its children will
-     * also satisfy the constraints. To optimize performance and reduce redundant checks, we can skip
+     * {@code prefix} is known to satisfy the constraints, we know that all of its children will also
+     * satisfy the constraints. To optimize performance and reduce redundant checks, we can skip
      * constraint checks for a task and its children if its parent has been verified to satisfy the
      * constraints. This flag serves that purpose, facilitating the separation of paths in intermediate
      * task generation.
@@ -660,50 +677,51 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #cachedAdjacencyState
      * @see #computeIntermediateSubtasks(GeneratorContext)
      * @since 2025.08.04 - Reduced Branching Refactor
-     * @performance O(1) for checks and updates.
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @memory Minimal memory usage as a primitive boolean.
+     * @performance {@code O(1)} for checks and updates.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @memory Minimal memory usage as a primitive {@code boolean}.
      * @optimization Reduces redundant constraint checks in deep branches of the generation tree.
      */
-    private boolean skipConstraintsCheck = false; // If a prefix is known to satisfy constraints, we can skip checks for its children
+    private boolean skipConstraintsCheck = false;
 
     /**
-     * A bitmask representing the target true adjacency state for the current task. Initialized in the
-     * root task to avoid recomputation in constraint checks.
+     * A bitmask representing the target {@code true} adjacency state for the current task. Initialized
+     * in the root task to avoid recomputation in constraint checks.
      * 
      * <p>
-     * Constraint checks are performed to ensure that the current prefix or one of its descendants can
-     * satisfy the constraint of touching each initially true cell at least once. For compact
-     * representation in {@link #canPotentiallySatisfyConstraints(int)}, we make a long bitmask to
-     * represent the prefix's current adjacency state, with the bitmask being sized to the number of
-     * initially true cells, and each 1 corresponding to a true cell.
+     * Constraint checks are performed to ensure that the current {@code prefix} or one of its
+     * descendants can satisfy the constraint of touching each initially true cell at least once. For
+     * compact representation in {@link #canPotentiallySatisfyConstraints(int)}, we make a long bitmask
+     * to represent the prefix's {@link #cachedAdjacencyState current adjacency state}, with the bitmask
+     * being sized to the number of initially true cells, and each {@code 1} corresponding to a true
+     * cell.
      * </p>
      * 
      * <p>
      * The target mask for the constraint check contains all bits set to 1, but we can't define this as
-     * a static final constant since the number of initially true cells can vary between puzzles. To
-     * resolve this, we initialize this mask in the root task constructor, where we have access to the
-     * initially true cells. This lets us avoid recomputing the mask in every single constraint check,
-     * giving a minor performance boost.
+     * a {@code static final} constant since the number of initially {@code true} cells can vary between
+     * puzzles. To resolve this, we initialize this mask in the root task constructor, where we have
+     * access to the initially {@code true} cells. This lets us avoid recomputing the mask in every
+     * single constraint check, giving a minor performance boost.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Recomputing the mask each time isn't too complicated, but it adds undesirable overhead to our
      * constraint checks, increasing the size of the checks and reducing the likelihood of JIT
-     * optimizations. It would also require us to pass an array of the true cells to every constraint
-     * check call. Optimizations like this appear small, but add up quickly when performed billions or
-     * trillions of times.
+     * optimizations. It would also require us to pass an array of the {@code true} cells to every
+     * constraint check call. Optimizations like this appear small, but add up quickly when performed
+     * billions or trillions of times.
      * </p>
      * 
      * @see #cachedAdjacencyState
      * @see #SUFFIX_OR_MASKS
      * @see #ensureTrueCellMasks(short[])
      * @since 2025.08.04 - Reduced Branching Refactor
-     * @performance O(1) for checks, O(1) for initial computation in the root task.
+     * @performance {@code O(1)} for checks, {@code O(1)} for initial computation in the root task.
      * @threading Computed once in the root task and reused across all subtasks.
-     * @memory Uses a long to represent the target state, which is efficient for up to 64 initially true
-     *         cells.
+     * @memory Uses a {@code long} to represent the target state, which is efficient for up to 64
+     *         initially {@code true} cells.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
      */
     private static long targetMask;
@@ -716,21 +734,21 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * cancellation checks in the hot path by placing the responsibility of task cancellation on the
      * pool itself, signaled by a {@link TestClickCombination monkey} when it finds a solution. For
      * monkeys to be able to signal cancellation, however, they need access to the pool, which we
-     * provide via this static field.
+     * provide via this {@code static} field.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Using a static field for the pool allows for quick and easy access from any task or monkey,
-     * without the need to pass references around or use ThreadLocals. This reduces overhead and
-     * simplifies the code, making it easier to maintain and understand. The volatile keyword ensures
-     * that changes to the pool reference are visible across threads, though the pool is best set once
-     * at the start of generation and left constant thereafter.
+     * Using a {@code static} field for the pool allows for quick and easy access from any task or
+     * monkey, without the need to pass references around or use {@code ThreadLocal}s. This reduces
+     * overhead and simplifies the code, making it easier to maintain and understand. The
+     * {@code volatile} keyword ensures that changes to the pool reference are visible across threads,
+     * though the pool is best set once at the start of generation and left constant thereafter.
      * </p>
      * 
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
-     * @performance O(1) access time.
-     * @threading Volatile static field - Ensures visibility of changes across threads.
+     * @performance {@code O(1)} access time.
+     * @threading {@code static volatile} field - Ensures visibility of changes across threads.
      * @memory Minimal memory usage as a single reference.
      * @optimization Static field for quick access without passing references.
      */
@@ -750,9 +768,9 @@ public class CombinationGeneratorTask extends RecursiveAction {
      *             generator tasks.
      * @see TestClickCombination#triggerGeneratorShutdown()
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
-     * @performance O(1) assignment.
-     * @threading Thread-safe due to the use of a volatile static field, though this method should be
-     *            called by one thread only.
+     * @performance {@code O(1)} assignment.
+     * @threading Thread-safe due to the use of a {@code static volatile} field, though this method
+     *            should be called by one thread only.
      * @memory Minimal memory usage as a single reference.
      * @optimization Static field for quick access without passing references.
      */
@@ -768,12 +786,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * {@link TestClickCombination monkeys} to signal cancellation when they find a solution.
      * </p>
      * 
-     * @return the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used for executing
-     *         generator tasks.
+     * @return the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used for executing generator
+     *         tasks.
      * @see TestClickCombination#triggerGeneratorShutdown()
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
-     * @performance O(1) access time.
-     * @threading Thread-safe due to the use of a volatile static field.
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe due to the use of a {@code static volatile} field.
      * @memory Only gets a reference, so minimal memory usage.
      * @optimization Static field for quick access without passing references.
      */
@@ -784,16 +802,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
     // Root task constructor
     /**
      * Constructs a new root task with the specified parameters. The root task is expected to be a
-     * singleton, as it initializes static fields used by all subtasks, but we do not enforce this
-     * restriction in code.
+     * singleton, as it initializes {@code static} fields used by all subtasks, but we do not enforce
+     * this restriction in code.
      * 
      * <p>
-     * The root task initializes static fields that are shared across all tasks, such as the
+     * The root task initializes {@code static} fields that are shared across all tasks, such as the
      * {@link #numClicks number of clicks}, the {@link #queueArray queue array}, and the
      * {@link #maxFirstClickIndex maximum first click index}. It also initializes instance fields like
      * the {@link #prefix prefix array} and {@link #prefixLength prefix length} for the root task (with
-     * the prefix length taking a value of 0). The root task also pre-computes the {@link #targetMask
-     * target mask} for {@link #canPotentiallySatisfyConstraints(int) constraint checks} and the
+     * {@code prefixLength = 0}). The root task also pre-computes the {@link #targetMask target mask}
+     * for {@link #canPotentiallySatisfyConstraints(int) constraint checks} and the
      * {@link #FIRST_TRUE_ADJACENTS first true adjacency mask} for the
      * {@link #computeLeafCombinations(GeneratorContext) odd adjacency check}.
      * </p>
@@ -802,28 +820,28 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <p>
      * Since the root task is only created once per puzzle, we can afford to perform some expensive
      * initialization operations here without impacting overall performance. Pre-computing masks and
-     * initializing static fields helps reduce overhead during the generation process, allowing subtasks
-     * to focus on generating combinations efficiently. The use of pooled arrays for the prefix helps
-     * minimize allocations and deallocations, reducing garbage collection pressure and improving
-     * throughput.
+     * initializing {@code static} fields helps reduce overhead during the generation process, allowing
+     * subtasks to focus on generating combinations efficiently. The use of pooled arrays for
+     * {@code prefix} helps minimize allocations and deallocations, reducing garbage collection pressure
+     * and improving throughput.
      * </p>
      * 
      * @param numClicks          the number of clicks in each combination.
      * @param queueArray         the {@link CombinationQueueArray} to which generated combinations will
      *                           be flushed.
-     * @param trueCells          an array of initially true cells in {@link Grid.ValueFormat#Index
-     *                           Index} format.
+     * @param trueCells          a {@code short[]} of initially true cells in
+     *                           {@link Grid.ValueFormat#Index Index} format.
      * @param maxFirstClickIndex the maximum index for the first click in a combination.
-     * @throws IllegalArgumentException if any of the parameters are invalid (<code>null</code> or out
-     *                                  of range).
+     * @throws IllegalArgumentException if any of the parameters are invalid ({@code null} or out of
+     *                                  range).
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance O(n) for initialization where n is the number of initially true cells, amortized
-     *              over the entire generation process.
-     * @threading Thread-safe due to ForkJoinTask isolation. Static fields are initialized in the root
-     *            task before any subtasks are created.
-     * @memory Uses pooled arrays for the prefix to reduce memory usage. Static fields are minimal in
+     * @performance {@code O(trueCells.length)} for initialization, amortized over the entire generation
+     *              process.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     *            Static fields are initialized in the root task before any subtasks are created.
+     * @memory Uses pooled arrays for {@code prefix} to reduce memory usage. Static fields are minimal in
      *         size.
-     * @optimization Pre-computes masks and initializes static fields to reduce overhead during
+     * @optimization Pre-computes masks and initializes {@code static} fields to reduce overhead during
      *               generation. Uses pooled arrays for the prefix to minimize allocations.
      */
     public CombinationGeneratorTask(int numClicks, CombinationQueueArray queueArray, short[] trueCells,
@@ -872,26 +890,27 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * A mask representing the adjacency of the first true cell to other cells.
+     * A mask representing the adjacency of the first {@code true} cell to other cells.
      * 
      * <p>
      * While the {@link TestClickCombination monkeys} handle the more in-depth odd adjacency checks and
      * the generators perform constraint checks at each branch, we still want some kind of fast check to
      * be performed at the "leaf" of the generation tree (when a full-length combination has been
      * built). We therefore create a slimmed-down version of the
-     * {@link TestClickCombination#satisfiesOddAdjacency(short[])} check that operates only on the first
-     * true cell. To do this, we need to be able to quickly determine which cells are adjacent to the
-     * first true cell, which we can do by pre-computing a bitmask for it.
+     * {@link TestClickCombination#satisfiesOddAdjacency(short[]) odd adjacency} check that operates
+     * only on the first {@code true} cell. To do this, we need to be able to quickly determine which
+     * cells are adjacent to the first {@code true} cell, which we can do by pre-computing a bitmask for
+     * it.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * We use bitmasks for their efficiency in representing sets of toggled cells; other formats like
-     * arrays or lists would be too slow and memory-intensive, and {@link java.util.BitSet}s incur
-     * abstraction penalties. Since longs are 64-bit and our {@link Grid} is {@link Grid#NUM_CELLS 109
-     * cells}, we need two longs to represent first true adjacency for the whole grid. This isn't
-     * particularly awful, but it's a limitation that forces us to perform two checks per final cell
-     * instead of one.
+     * arrays or lists would be too slow and memory-intensive, and {@link java.util.BitSet BitSet}s
+     * incur abstraction penalties. Since {@code long}s are 64-bit and our {@link Grid} is
+     * {@value Grid#NUM_CELLS} cells, we need two {@code long}s to represent first {@code true}
+     * adjacency for the whole grid. This isn't particularly awful, but it's a limitation that forces us
+     * to perform two checks per final cell instead of one.
      * </p>
      * 
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
@@ -899,11 +918,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see Grid#findAdjacents(short)
      * @see Grid#findFirstTrueCell(Grid.ValueFormat)
      * @since 2025.06.11 - Revamped Odd Adjacency Check
-     * @performance O(1) for checks, O(n) for initial computation where n is the number of adjacent
-     *              cells.
+     * @performance {@code O(1)} for checks, <code>O({@link Grid#findFirstTrueAdjacents()
+     *              Grid.findFirstTrueAdjacents().length}</code> for initial computation.
      * @threading Statically initialized once in {@link #computeAdjacencyMaskFast(short)} by the root
      *            task.
-     * @memory Uses an array of two longs to represent the adjacency of the first true cell.
+     * @memory Uses an array of two {@code long}s to represent the adjacency of the first {@code true}
+     *         cell.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation. A
      *               bitmask is used for compact representation.
      */
@@ -915,22 +935,21 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <p>
      * For the odd adjacency check done during {@link #computeLeafCombinations(GeneratorContext) leaf
      * combination generation}, we need a fast way to determine which cells are adjacent to the first
-     * initially true cell. Bitmasks are a compact and efficient way to represent sets of toggled cells
-     * and worked well in the initial version of that check, but recomputing the mask for every
-     * combination would be too costly. Since we're looking at the initial state of the {@link Grid
-     * grid}, which never changes, we can pre-compute {@link #FIRST_TRUE_ADJACENTS this mask} during
-     * root task initialization and reuse it for all combinations.
+     * initially {@code true} cell. Bitmasks are a compact and efficient way to represent sets of
+     * toggled cells and worked well in the initial version of that check, but recomputing the mask for
+     * every combination would be too costly. Since we're looking at the initial state of the
+     * {@link Grid grid}, which never changes, we can pre-compute {@link #FIRST_TRUE_ADJACENTS this
+     * mask} during root task initialization and reuse it for all combinations.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * This method is called only once per puzzle during root task initialization, so the overhead of
      * computing the mask is negligible. The use of bitwise operations helps keep the computation fast
-     * and efficient. We use a temporary
-     * <code>short[]M/code> array to hold the adjacent cells, and create a new
-     * <code>long[2]</code> for our mask. Synchronization isn't necessary since this method is called
+     * and efficient. We use a temporary {@code short[]} array to hold the adjacent cells, and create a
+     * new {@code long[2]} for our mask. Synchronization isn't necessary since this method is called
      * once during the initialization of the root task, which is single-threaded, guaranteeing that no
-     * other threads will access the static field during this time.
+     * other threads will access the {@code static} field during this time.
      * </p>
      * 
      * @param firstTrueCell The index of the first true cell in the grid, in
@@ -938,10 +957,11 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #FIRST_TRUE_ADJACENTS
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
      * @since 2025.06.11 - Bitmasked Leaf Pruning Introduction
-     * @performance O(n) where n is the number of adjacent cells to the first true cell.
+     * @performance <code>O({@link Grid#findAdjacents(short) Grid.findAdjacents(firstTrueCell)}.length)</code> for
+     *              initial computation.
      * @threading Single-threaded during root task initialization, no synchronization needed.
-     * @memory Uses an array of two <code>long</code>s to represent the adjacency of the first true
-     *         cell. Creates a temporary <code>short[]</code> array for adjacent cells.
+     * @memory Uses an array of two {@code long}s to represent the adjacency of the first true cell.
+     *         Creates a temporary {@code short[]} array for adjacent cells.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
      */
     private static void computeAdjacencyMaskFast(short firstTrueCell) {
@@ -961,7 +981,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * <p>
      * The golden rule of JVM optimizations is <b>don't allocate.</b> Since tasks are pre-allocated by
-     * {@link TaskPool} and reused, we designate this constructor as <code>protected</code> to prevent
+     * {@link TaskPool} and reused, we designate this constructor as {@code protected} to prevent
      * external code from calling it and potentially causing allocations. Instead, external code must
      * obtain tasks from the pool via {@link TaskPool#get()} and assign their instance fields through
      * the {@link #init(short[], int, long, boolean) init()} method.
@@ -969,8 +989,9 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
      * @since 2025.07.11 - Task Pool Introduction
-     * @performance O(1) access time, since no allocations or operations are performed.
-     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
+     * @performance {@code O(1)} access time, since no allocations or operations are performed.
+     * @threading Isolated by the {@link java.util.concurrent.ForkJoinTask ForkJoinTask} framework, each
+     *            task runs in its own thread.
      * @memory No memory usage, as no allocations are performed.
      * @optimization Protected to prevent external allocations, enforcing the use of the task pool.
      */
@@ -981,18 +1002,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * framework.
      * 
      * <p>
-     * The ForkJoinPool framework requires that we implement the {@link RecursiveAction#compute()}
-     * method to define the task's execution logic. Per the framework's design, we want to break
-     * combinations into subtasks and recursively process them in parallel. Depending on the
-     * {@link #prefixLength}, we need to determine which path to take:
+     * The {@code ForkJoinTask} interface requires that we implement the
+     * {@link RecursiveAction#compute()} method to define the task's execution logic. Per the
+     * framework's design, we want to break combinations into subtasks and recursively process them in
+     * parallel. Depending on the {@link #prefixLength}, we need to determine which path to take:
      * <ul>
-     * <li><code>prefixLength == 0</code>: This is the root task, which will
+     * <li>{@code prefixLength == 0}: This is the root task, which will
      * {@link #computeRootSubtasks(GeneratorContext) compute and fork subtasks for the first clicks} and
      * await their completion.</li>
-     * <li><code>prefixLength == {@link #numClicks} - 1</code>: This is a leaf task, which will
-     * {@link #computeLeafCombinations(GeneratorContext) compute the combinations for the last click} and
-     * add them to a {@link WorkBatch} for processing.</li>
-     * <li><code>0 &lt; prefixLength &lt; numClicks - 1</code>: This is an intermediate task, which will
+     * <li>{@code prefixLength == {@link #numClicks} - 1}: This is a leaf task, which will
+     * {@link #computeLeafCombinations(GeneratorContext) compute the combinations for the last click}
+     * and add them to a {@link WorkBatch} for processing.</li>
+     * <li>{@code 0 < prefixLength < numClicks - 1}: This is an intermediate task, which will
      * {@link #computeIntermediateSubtasks(GeneratorContext) compute and fork subtasks} for the next
      * clicks.</li>
      * </ul>
@@ -1013,17 +1034,19 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * <p>
      * We also minimize the number of {@link ThreadLocal} accesses by passing down the context directly
-     * to methods, which reduces the overhead of accessing <code>ThreadLocal</code> variables. The
-     * bundled context object allows us to access all necessary resources with only one expensive call
-     * per task, something that can be amortized over the entire task's execution.
+     * to methods, which reduces the overhead of accessing {@code ThreadLocal} variables. The bundled
+     * context object allows us to access all necessary resources with only one expensive call per task,
+     * something that can be amortized over the entire task's execution.
      * </p>
      * 
      * @see #recycleOwnResources(GeneratorContext)
      * @see GeneratorContext
      * @see java.lang.ThreadLocal#get()
      * @since 2025.06.08 - Work-stealing introduction
-     * @performance O(1) access time for ThreadLocal context, O(1) for dispatching.
-     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
+     * @performance {@code O(1)} access time for {@code ThreadLocal} context, {@code O(1)} for
+     *              dispatching.
+     * @threading Isolated by the {@link java.util.concurrent.ForkJoinTask ForkJoinTask} framework, each
+     *            task runs in its own thread.
      * @memory Memory usage is minimized by recycling resources and using pools.
      * @optimization Multiple paths for different task types to reduce branches and conditionals.
      */
@@ -1062,16 +1085,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <p>
      * The root task is responsible for generating the initial set of subtasks that will explore all
      * possible combinations of clicks. It does this by iterating over all valid first clicks and
-     * forking a new subtask for each one. Each subtask is initialized with a prefix containing the
-     * first click and the appropriate cached adjacency state.
+     * forking a new subtask for each one. Each subtask is initialized with a {@link #prefix} containing
+     * the first click and the appropriate {@link #cachedAdjacencyState cached adjacency state}.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Forking subtasks for each first click allows us to leverage the parallelism of the ForkJoinPool
-     * framework, distributing the workload across multiple threads. We limit the range of first clicks
-     * to the specified {@link #maxFirstClickIndex} to reduce the number of subtasks, which can help
-     * with memory usage and contention.
+     * Forking subtasks for each first click allows us to leverage the parallelism of the
+     * {@link java.util.concurrent.ForkJoinPool ForkJoinPool} framework, distributing the workload
+     * across multiple threads. We limit the range of first clicks to the specified
+     * {@link #maxFirstClickIndex} to reduce the number of subtasks, which can help with memory usage
+     * and contention.
      * </p>
      * 
      * <p>
@@ -1090,22 +1114,23 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * <p>
-     * The idea that a <code>ForkJoinTask</code>'s <code>awaitQuiescence()</code> method doesn't account
-     * for forked tasks is...stupid. The fact that helpQuiesce() works properly makes me believe that
-     * this is an oversight or bug in the JDK, since it proves that the ForkJoinPool can track forked
-     * tasks. Oh well.
+     * The idea that a {@code ForkJoinTask}'s {@code awaitQuiescence()} method doesn't account for
+     * forked tasks is silly. The fact that {@code helpQuiesce()} works properly makes me believe
+     * that this is an oversight or bug in the JDK, since it proves that the {@code ForkJoinPool} can
+     * track forked tasks. Oh well.
      * </p>
      * 
      * @param ctx the thread-local {@link GeneratorContext} containing resource pools.
      * @see #helpQuiesce()
      * @see #recycleOwnResources(GeneratorContext)
      * @since 2025.08.04 - Reduced Branching Refactor
-     * @performance O(n) where n is the number of valid first clicks.
-     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance {@code O(N)} where {@code N} is the number of valid first clicks.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
      * @memory Memory usage is minimized by recycling resources and using pools. No allocations should
      *         occur in this method unless the pools are somehow empty.
      * @optimization Limits the range of first clicks to reduce the number of subtasks. Piggybacks on
-     *               the thread-local nature of the context to avoid multiple ThreadLocal accesses.
+     *               the thread-local nature of the context to avoid multiple
+     *               {@link java.lang.ThreadLocal ThreadLocal} accesses.
      */
     private void computeRootSubtasks(GeneratorContext ctx) {
         final short start = 0;
@@ -1155,23 +1180,24 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * <p>
-     * Previously, we had separate init methods for tasks that would and wouldn't
-     * {@link #skipConstraintsCheck skip constraint checks}, but this created a polymorphic call site that
-     * hindered JVM optimizations. By consolidating the init methods into a single monomorphic method, we
-     * can improve performance and allow the JIT compiler to perform more aggressive optimizations, with
-     * the trade-off being an unnecessary assignment in some cases.
+     * Previously, we had separate {@code init()} methods for tasks that would and wouldn't
+     * {@link #skipConstraintsCheck skip constraint checks}, but this created a polymorphic call site
+     * that hindered JVM optimizations. By consolidating the {@code init} methods into a single
+     * monomorphic method, we can improve performance and allow the JIT compiler to perform more
+     * aggressive optimizations, with the trade-off being an unnecessary assignment in some cases.
      * </p>
      * 
-     * @param prefix a <code>short[]</code> representing the current combination state.
-     * @param prefixLength the length of the prefix array.
-     * @param parentAdjacencyState the cached adjacency state from the parent task.
-     * @param skipConstraints whether to skip constraint checks for this task and its children.
+     * @param prefix               a {@code short[]} representing the current combination state.
+     * @param prefixLength         the length of {@code prefix}.
+     * @param parentAdjacencyState the {@link #cachedAdjacencyState} from the parent task.
+     * @param skipConstraints      whether to skip constraint checks for this task and its children.
      * @see #reinitialize()
      * @see TaskPool
      * @since 2025.07.11 - Task Pool Introduction
-     * @performance O(1) for assignments and reinitialization.
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @memory Memory usage is minimized by recycling task objects via a TaskPool. No allocations occur in this method.
+     * @performance {@code O(1)} for assignments and reinitialization.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @memory Memory usage is minimized by recycling task objects via a {@code TaskPool}. No
+     *         allocations occur in this method.
      * @optimization Monomorphic method to avoid polymorphic call sites and improve JIT optimizations.
      */
     public void init(short[] prefix, int prefixLength, long parentAdjacencyState, boolean skipConstraints) {
@@ -1189,34 +1215,34 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * {@link #flushBatchFast(WorkBatch) flushed} and replaced.
      * 
      * <p>
-     * In a leaf task, the prefix is at its maximum length, and we need to compute all valid
-     * combinations stemming from it. At this point, our tasks are at the optimal size for direct
-     * computation, and we can start checking them for validity. We do this by iterating over all
-     * possible next clicks, observing to see if they satisfy the parity condition for the first true
-     * cell (ensuring that there are an odd number of toggles of the first true cell) and adding them to
-     * the current batch.
+     * In a leaf task, the {@link #prefix} is at its maximum length ({@code numClicks - 1}), and we need
+     * to compute all valid combinations stemming from it. At this point, our tasks are at the optimal
+     * size for direct computation, and we can start checking them for validity. We do this by iterating
+     * over all possible next clicks, observing to see if they satisfy the parity condition for the
+     * first {@code true} cell (ensuring an odd number of toggles of the first {@code true} cell) and
+     * adding them to the current batch.
      * </p>
      * 
      * <h3>Algorithm Details</h3>
      * <p>
      * Before iterating over the possible next clicks, we have to compute the parity of the prefix. We
      * do this by iterating over the prefix and checking if the current cell is adjacent to the first
-     * true cell. If it is, we toggle the boolean parity variable. After we finish iterating, the parity
-     * variable will be in one of two states:
+     * {@code true} cell. If it is, we toggle the {@code boolean parity} variable. After we finish
+     * iterating, {@code parity} will be in one of two states:
      * </p>
      * 
      * <ul>
-     * <li><code><b>true</b></code>: The prefix has an odd number of toggles of the first true cell (we
-     * need to ensure that the final click doesn't toggle the first true cell)</li>
-     * <li><code><b>false</b></code>: The prefix has an even number of toggles of the first true cell
-     * (we need to ensure that the final click toggles the first true cell)</li>
+     * <li><b>{@code true}</b>: The prefix has an odd number of toggles of the first {@code true} cell
+     * (we need to ensure that the final click doesn't toggle the first {@code true} cell)</li>
+     * <li><b>{@code false}</b>: The prefix has an even number of toggles of the first {@code true} cell
+     * (we need to ensure that the final click toggles the first {@code true} cell)</li>
      * </ul>
      * 
      * <p>
      * The parity of the final click must be the opposite of the prefix parity to ensure that the first
-     * true cell is toggled correctly. Therefore, we iterate over all possible next clicks and check if
-     * the click's adjacency to the first true cell matches the prefix parity. If it doesn't, then we
-     * add it to the current batch, flushing the batch if full.
+     * {@code true} cell is toggled correctly. Therefore, we iterate over all possible next clicks and
+     * check if the click's adjacency to the first {@code true} cell matches the prefix parity. If it
+     * doesn't, then we add it to the current batch, flushing the batch if full.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -1234,12 +1260,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * multiple descendants. If a task makes it to this level, all of its descendant combinations will
      * be tested, incurring a conditional check for every single one of them. However, the removal of
      * this check would cause a performance regression from an increased number of queue operations (and
-     * an increase in non-viable combinations that each monkey would have to test). For now, we've kept
-     * this check in place, but it may be removed or lessened in the future. A potential idea is to take
-     * the approach of {@link #cachedAdjacencyState} and perform the parity checks on each task to
-     * divide the cost of the check across tasks. Another route would be to skip the parity check
-     * altogether if the prefix is known to satisfy the constraints, but that would add branching to the
-     * method, which we want to avoid in the hot path.
+     * an increase in non-viable combinations that each {@link TestClickCombination monkey} would have
+     * to test). For now, we've kept this check in place, but it may be removed or lessened in the
+     * future. A potential idea is to take the approach of {@link #cachedAdjacencyState} and perform
+     * parity checks on each task to divide the cost of the check across tasks. Another route would be
+     * to skip the parity check altogether if the prefix is known to satisfy the constraints, but that
+     * would add branching to the method, which we want to avoid in the hot path.
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
@@ -1247,10 +1273,10 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #flushBatchFast(WorkBatch)
      * @see GeneratorContext#getOrCreateBatch()
      * @since 2025.07.03 - Splitting the Compute Method Into Paths
-     * @performance O({@link #prefixLength}) for prefix parity computation,
-     *              O(<code>{@link Grid#NUM_CELLS} - {@link #prefix}[prefixLength - 1]</code>) for
-     *              iterating over possible next clicks.
-     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance <code>O({@link #prefixLength})</code> for prefix parity computation,
+     *              <code>O({@link Grid#NUM_CELLS NUM_CELLS} - {@link #prefix}[{@link #prefixLength} - 1])
+     *              </code> for iterating over possible next clicks.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
      * @algorithm Iterates over the prefix to compute parity, then iterates over possible next clicks to
      *            find valid combinations based on the computed parity.
      * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
@@ -1320,11 +1346,11 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * {@link #prefixLength} less than <code>{@link #numClicks} - 1</code> and are responsible for
      * computing and forking subtasks for the next clicks. {@link #canPotentiallySatisfyConstraints(int)
      * Pruning logic} is applied in our code to eliminate invalid paths for generators early, but the
-     * nature of our tasks means that if a prefix is known to satisfy the constraints, all of its
-     * descendants must also satisfy the constraints. Therefore, tracking whether a prefix satisfies the
-     * constraints allows us to avoid redundant checks for all descendants, which can significantly
-     * improve the performance of subtask computation. However, this introduces branching and
-     * conditionals into the hot path, which we want to avoid.
+     * nature of our tasks means that if a {@code prefix} is known to satisfy the constraints, all of
+     * its descendants must also satisfy the constraints. Therefore, tracking whether a {@code prefix}
+     * satisfies the constraints allows us to avoid redundant checks for all descendants, which can
+     * significantly improve the performance of subtask computation. However, this introduces branching
+     * and conditionals into the hot path, which we want to avoid.
      * </p>
      * 
      * <p>
@@ -1339,7 +1365,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <h3>Performance Considerations</h3>
      * <p>
      * This method is intentionally kept simple to minimize overhead. While a previous version of the
-     * code implemented the constraint check logic directly into <code>compute()</code>, this created a
+     * code implemented the constraint check logic directly into {@code compute()}, this created a
      * bifurcation of the call site that hindered optimizations. Implementing it into any of the
      * computation methods would introduce branching into the hot path, forcing a conditional check and
      * redundant pieces of code into the hot path. By separating the paths into distinct methods and
@@ -1353,9 +1379,10 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
      * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
      * @since 2025.08.04 - Reduced Branching Refactor
-     * @performance O(1) for dispatching.
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @optimization Monomorphic call sites for each path to reduce branching and conditionals in the hot path.
+     * @performance {@code O(1)} for dispatching.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @optimization Monomorphic call sites for each path to reduce branching and conditionals in the
+     *               hot path.
      */
     private void computeIntermediateSubtasks(GeneratorContext ctx) {
         if (skipConstraintsCheck) {
@@ -1373,15 +1400,15 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * In the fork-join architecture, tasks that are too large to be directly computed are split into
      * smaller subtasks that can be processed in parallel. In our program, these are non-leaf tasks
      * (tasks where the {@link #prefixLength} is less than <code>{@link #numClicks} - 1</code>). This
-     * method computes the next clicks for the current prefix and forks subtasks for each valid next
-     * click.
+     * method computes the next clicks for the current {@code prefix} and forks subtasks for each valid
+     * next click.
      * </p>
      * 
      * <p>
-     * This form of the method is specifically for tasks where the prefix is already known to satisfy
-     * the constraints, allowing us to skip constraint checks for all descendants. This simplifies the
-     * loop significantly, increasing the likelihood of JIT optimizations and reducing the overall
-     * footprint of the method.
+     * This form of the method is specifically for tasks where the {@code prefix} is already known to
+     * satisfy the constraints, allowing us to skip constraint checks for all descendants. This
+     * simplifies the loop significantly, increasing the likelihood of JIT optimizations and reducing
+     * the overall footprint of the method.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -1395,21 +1422,21 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * <p>
-     * We could consider removing the array allocation safeguard and assume that the array pool will
-     * always return a non-null array. This would allow us to remove the null check and the array
-     * allocation in the loop at the cost of having to ensure that the array pool is properly sized at
-     * initialization. Since we already do this anyways, it may be worth exploring to simplify the code
-     * and make it smaller for better JIT optimization.
+     * We could consider removing the array allocation safeguard and assume that the {@link ArrayPool}
+     * will always return a non-{@code null} array. This would allow us to remove the {@code null} check
+     * and the conditional allocation in the loop at the cost of having to ensure that the pool is
+     * properly sized at initialization. Since we already do this anyways, it may be worth exploring to
+     * simplify the code and make it smaller for better JIT optimization.
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
      * @see #skipConstraintsCheck
      * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
      * @since 2025.08.04 - Specialized Subtask Paths
-     * @performance O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
-     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
+     * @performance <code>O({@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
+     *              {@link #prefix}[prefixLength - 1] + 1)</code> for iterating over possible next
      *              clicks.
-     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
      * @optimization Removes constraint check branching, caches loop-invariant values, and uses a tight
      *               loop with minimal branching to allow for aggressive JIT optimizations.
      */
@@ -1445,8 +1472,8 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * In the fork-join architecture, tasks that are too large to be directly computed are split into
      * smaller subtasks that can be processed in parallel. In our program, these are non-leaf tasks
      * (tasks where the {@link #prefixLength} is less than <code>{@link #numClicks} - 1</code>). This
-     * method computes the next clicks for the current prefix and forks subtasks for each valid next
-     * click.
+     * method computes the next clicks for the current {@code prefix} and forks subtasks for each valid
+     * next click.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -1455,16 +1482,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * minimize branching and conditionals, allowing the JIT compiler to perform aggressive
      * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
      * calculations and array dereferences. In this method, we also perform an early constraint check
-     * before loop entry to ensure the validity of the current prefix. We make sure to propagate the
-     * parent's {@link #skipConstraintsCheck} flag to the children to allow them to skip checks if the
-     * prefix is already known to satisfy constraints.
+     * before loop entry to ensure the validity of the current {@code prefix}. We make sure to propagate
+     * the parent's {@link #skipConstraintsCheck} flag to the children to allow them to skip checks if
+     * the {@code prefix} is known to satisfy constraints.
      * </p>
      * 
      * <p>
      * As part of the optimization to minimize conditionals, we calculate the child adjacency state
-     * every time in this method, even if the constraint check finds that the prefix directly satisfies
-     * the constraints. While this does avoid branching in the loop, it adds an unnecessary XOR
-     * operation. It may be worth considering an optimization where we check the
+     * every time in this method, even if the constraint check finds that {@code prefix} directly
+     * satisfies the constraints. While this does avoid branching in the loop, it adds an unnecessary
+     * XOR operation. It may be worth considering an optimization where we check the
      * {@link #skipConstraintsCheck} flag after performing the early check and execute
      * {@link #computeIntermediateSubtasksSkipPath(GeneratorContext)} if the flag is set, but this may
      * add additional method complexity.
@@ -1472,10 +1499,10 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * <p>
      * In a different vein, we could consider removing the array allocation safeguard and assume that
-     * the array pool will always return a non-null array. This would allow us to remove the null check
-     * and the array allocation in the loop at the cost of having to ensure that the array pool is
-     * properly sized at initialization. Since we already do this anyways, it may be worth exploring to
-     * simplify the code and make it smaller for better JIT optimization.
+     * the {@link ArrayPool} will always return a non-{@code null} array. This would allow us to remove
+     * the {@code null} check and the array allocation in the loop at the cost of having to ensure that
+     * the pool is properly sized at initialization. Since we already do this anyways, it may be worth
+     * exploring to simplify the code and make it smaller for better JIT optimization.
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
@@ -1483,11 +1510,11 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
      * @see #ensureTrueCellMasks(short[])
      * @since 2025.08.04 - Specialized Subtask Paths
-     * @performance O(1) for the early constraint check,
-     *              O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
-     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
+     * @performance {@code O(1)} for the early constraint check,
+     *              <code>O({@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
+     *              {@link #prefix}[prefixLength - 1] + 1)</code> for iterating over possible next
      *              clicks.
-     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
      * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
      *               tight loop with minimal branching to allow for aggressive JIT optimizations.
      */
@@ -1531,7 +1558,8 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
     
     /**
-     * Checks if the current prefix (or the prefix of a descendant task) can satisfy the constraints.
+     * Checks if the current {@link #prefix} (or the {@code prefix} of a descendant task) could satisfy
+     * the constraints.
      * 
      * <p>
      * Though fork-join tasks are designed to be small and fast, too many of them can lead to
@@ -1544,26 +1572,27 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <h3>Algorithm Details</h3>
      * <p>
      * To start, we need to understand the constraints of the puzzle. We know that a solution must
-     * toggle all initially true cells in order to be valid. While it is also a requirement that those
-     * cells are toggled an odd number of times, we can simplify our checks at the moment by focusing on
-     * whether the cells are toggled at all.
+     * toggle all initially {@code true} cells in order to be valid. While it is also a requirement that
+     * those cells are toggled an odd number of times, we can simplify our checks at the moment by
+     * focusing on whether the cells are toggled at all.
      * </p>
      * 
      * <p>
-     * Since this check concerns itself with only the initially true cells, we can simplify the grid to
-     * a target bitmask representing the toggled state of those cells. We can then XOR this target mask
-     * with the current adjacency state to find which bits need to be flipped to satisfy the
-     * constraints. If all of the initially true cells are toggled, the XOR result will be zero and we
-     * can skip further checks, returning true and setting the {@link #skipConstraintsCheck} flag.
+     * Since this check concerns itself with only the initially {@code true} cells, we can simplify the
+     * grid to a {@link #targetMask target bitmask} representing the toggled state of those cells. We
+     * can then XOR {@code targetMask} with {@link #cachedAdjacencyState} to find which bits need to be
+     * flipped to satisfy the constraints. If all of the initially {@code true} cells are toggled, the
+     * XOR result will be zero and we can skip further checks, returning {@code true} and setting the
+     * {@link #skipConstraintsCheck} flag.
      * </p>
      * 
      * <p>
-     * As we're performing these checks very early on, it's possible that the current prefix may not be
-     * long enough to satisfy the constraints but a descendant task may be able to. To handle this, we
-     * use {@link #SUFFIX_OR_MASKS pre-computed OR masks} to quickly check if any of the remaining
-     * clicks could satisfy the constraints. If this mask ANDed with the needed bits is equal to the
-     * needed bits (the mask contains all bits that need to be flipped), we can assume that at least one
-     * descendant can satisfy the constraints and return true.
+     * As we're performing these checks very early on, it's possible that the current {@code prefix} may
+     * not be long enough to satisfy the constraints but a descendant task may be able to. To handle
+     * this, we use {@link #SUFFIX_OR_MASKS pre-computed OR masks} to quickly check if any of the
+     * remaining clicks could satisfy the constraints. If this mask ANDed with the needed bits is equal
+     * to the needed bits (the mask contains all bits that need to be flipped), we can assume that at
+     * least one descendant can satisfy the constraints and return true.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -1572,32 +1601,32 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * strict. We cache all loop-invariant values at the start of the method to minimize repeated
      * calculations and array dereferences. The use of bitmasks allows us to perform set operations
      * quickly and efficiently, reducing the complexity of the checks. The pre-computed suffix OR masks
-     * allow us to avoid O(n) checks for each prefix, reducing the complexity to O(1).
+     * allow us to avoid {@code O(N)} checks for each {@code prefix}, reducing the complexity to
+     * {@code O(1)}.
      * </p>
      * 
      * <p>
      * If a prefix is found to directly satisfy the constraints, we set the
      * {@link #skipConstraintsCheck} flag to true to skip future checks for all descendants. This
      * optimization is crucial for performance, as it allows us to avoid redundant checks and create an
-     * optimized path for valid prefixes.
+     * optimized path for valid {@code prefixes}.
      * </p>
      * 
      * @param startIdx the index of the first possible next click (used for suffix OR checks)
-     * @return <code>true</code> if the current prefix or any descendant can satisfy the constraints,
-     *         <code>false</code> otherwise.
-     * @see #cachedAdjacencyState
-     * @see #SUFFIX_OR_MASKS
-     * @see #targetMask
+     * 
+     * @return {@code true} if the current {@link #prefix} or any descendant can satisfy the
+     *         constraints, {@code false} otherwise.
      * @see #TRUE_CELL_ADJACENCY_MASKS
      * @see #ensureTrueCellMasks(short[])
      * @see Grid#findAdjacents(short)
      * @see Grid#findTrueCells(Grid.ValueFormat)
      * @since 2025.07.03 - Splitting the Compute Method Into Paths
-     * @performance O(1) for the check due to bitmask operations and pre-computed suffix OR masks.
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @algorithm Uses bitmask operations to determine if the current prefix or any descendant can
-     *            satisfy the constraints and compares against a pre-computed target mask and
-     *            pre-computed suffix OR masks.
+     * @performance {@code O(1)} for the check due to bitmask operations and pre-computed suffix OR
+     *              masks.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @algorithm Uses bitmask operations to determine if the current {@code prefix} or any descendant
+     *            can satisfy the constraints and compares against a pre-computed {@link #targetMask
+     *            target mask} and pre-computed {@link #SUFFIX_OR_MASKS suffix OR masks}.
      * @optimization Caches loop-invariant values, uses bitmask operations, and employs pre-computed
      *               suffix OR masks to reduce complexity.
      */
@@ -1628,22 +1657,22 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Bitmasks representing the adjacency of each cell to initially true cells.
+     * Bitmasks representing the adjacency of each cell to initially {@code true} cells.
      * 
      * <p>
      * Efficiently generating combinations requires the ability to prune invalid paths early, preventing
      * wasted computation. A key property of the puzzle is that a solution must toggle all initially
-     * true cells. This gives us a way to prune combinations early, but we still need a way to quickly
-     * determine which true cells are toggled by a given prefix of clicks. This field gives us that
-     * ability.
+     * {@code true} cells. This gives us a way to prune combinations early, but we still need a way to
+     * quickly determine which {@code true} cells are toggled by a given {@code prefix} of clicks. This
+     * field gives us that ability.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Bitmasks are used for their efficiency in representing sets of toggled cells; other formats like
-     * arrays or lists would be too slow and memory-intensive. The use of longs does limit us to
-     * pre-computing up to 64 initially true cells, but all puzzles in this game have initial true
-     * counts that are below this limit.
+     * arrays or lists would be too slow and memory-intensive. The use of {@code long}s does limit us to
+     * pre-computing up to 64 initially true cells, but all puzzles in this game have initial
+     * {@code true} counts that are below this limit.
      * </p>
      * 
      * @see #ensureTrueCellMasks(short[])
@@ -1651,11 +1680,11 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see Grid#findAdjacents(short)
      * @see Grid#findTrueCells(Grid.ValueFormat)
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @performance O(1) for adjacency checks, O(n) for initial computation where n is the number of
-     *              initially true cells
+     * @performance {@code O(1)} for adjacency checks, {@code O(trueCells.length)} for initial
+     *              computation.
      * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
-     * @memory One long per cell, guaranteeing a fixed memory footprint regardless of the number of true
-     *         cells and avoiding object overhead.
+     * @memory One {@code long} per cell, guaranteeing a fixed memory footprint regardless of the number
+     *         of {@code true} cells and avoiding object overhead.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
      */
     private static long[] TRUE_CELL_ADJACENCY_MASKS = null;
@@ -1666,41 +1695,43 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * There are three cases that can occur when performing a constraint check:
      * </p>
      * <ol>
-     * <li>The current prefix already satisfies the constraints, meaning the test is passed.</li>
-     * <li>The current prefix doesn't fully satisfy the constraints, but one or more of its descendants
-     * may be able to.</li>
-     * <li>The current prefix and all of its descendants cannot satisfy the constraints.</li>
+     * <li>The current {@link #prefix} already satisfies the constraints, meaning the test is
+     * passed.</li>
+     * <li>The current {@code prefix} doesn't fully satisfy the constraints, but one or more of its
+     * descendants may be able to.</li>
+     * <li>The current {@code prefix} and all of its descendants cannot satisfy the constraints.</li>
      * </ol>
      * 
      * <p>
      * The first case is trivial, but the second and third are more complex. Since combinations have
      * clicks in an increasing order (and no duplicates), we know that the range of additional clicks
-     * holding this prefix is constrained to the range of cells that are greater than the last click in
-     * the prefix. By summing together the true adjacency masks of all clicks after the last click in
-     * the prefix, we can quickly determine if any of the child combinations can toggle the remaining
-     * true cells.
+     * holding this {@code prefix} is constrained to the range of cells that are greater than the last
+     * click in the {@code prefix}. By summing together the {@link #TRUE_CELL_ADJACENCY_MASKS true
+     * adjacency masks} of all clicks after the last click in the {@code prefix}, we can quickly
+     * determine if any of the child combinations can toggle the remaining {@code true} cells.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The mask at index i contains the OR of all masks from i to the end of the array. This allows
-     * us to avoid an O(109 - i) check for each prefix, reducing the complexity to O(1). Bitmasks
-     * are used for their efficiency in representing sets of toggled cells; other formats like arrays
-     * or lists would be too slow and memory-intensive. The use of longs does limit us to
-     * pre-computing up to 64 initially true cells, but all puzzles in this game have initial
-     * true counts that are below this limit.
+     * The mask at index {@code i} contains the OR of all masks from {@code i} to the end of the array.
+     * This allows us to avoid an <code>O({@value Grid#NUM_CELLS} - i)</code> check for each
+     * {@code prefix}, reducing the complexity to {@code O(1)}. Bitmasks are used for their efficiency
+     * in representing sets of toggled cells; other formats like arrays or lists would be too slow and
+     * memory-intensive. The use of {@code long}s does limit us to pre-computing up to 64 initially
+     * {@code true} cells, but all puzzles in this game have initial true counts that are below this
+     * limit.
      * </p>
      * 
+     * @see #TRUE_CELL_ADJACENCY_MASKS
      * @see #canPotentiallySatisfyConstraints(int)
      * @see #ensureTrueCellMasks(short[])
-     * @see #TRUE_CELL_ADJACENCY_MASKS
      * @see Grid#findAdjacents(short)
      * @since 2025.07.14 - Suffix OR Masks Introduction
-     * @performance O(1) for suffix OR checks, O(n) for initial computation where n is the number of cells
-     *              in the grid.
+     * @performance {@code O(1)} for suffix OR checks, <code>O({@value Grid#NUM_CELLS})</code> for
+     *              initial computation.
      * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
-     * @memory One long per cell, guaranteeing a fixed memory footprint regardless of the number of true
-     *         cells and avoiding object overhead.
+     * @memory One {@code long} per cell, guaranteeing a fixed memory footprint regardless of the number
+     *         of {@code true} cells and avoiding object overhead.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
      */
     private static long[] SUFFIX_OR_MASKS = null;
@@ -1720,27 +1751,26 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see #initClickAdjacencyMatrix()
      * @see Grid#findAdjacents(short, Grid.ValueFormat)
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @performance O(1) for adjacency checks, O(n^2) for initial computation where n is the number of
-     *              cells in the grid.
+     * @performance {@code O(1)} for adjacency checks, <code>O({@value Grid#NUM_CELLS}²)</code> for
+     *              initial computation.
      * @threading Statically initialized once at class load time.
-     * @memory Fixed-size boolean matrix of size n x n, where n is the number of cells in the grid. This
+     * @memory Fixed-size boolean matrix of size {@value Grid#NUM_CELLS} × {@value Grid#NUM_CELLS}. This
      *         guarantees a fixed memory footprint and avoids object overhead.
-     * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
-     *               for efficient adjacency representation.
+     * @optimization Pre-computed once at class load time to avoid recomputation, uses {@code boolean}
+     *               matrix for efficient adjacency representation.
      */
     private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix();
 
-    // This method is used to initialize the click adjacency matrix, and is static
     /**
      * Initializes the {@link #CLICK_ADJACENCY_MATRIX} representing adjacency relationships between
      * cells.
      * 
      * <h3>Algorithm Details</h3>
      * <p>
-     * The method creates a <code>boolean[][]</code> where each row corresponds to a cell in the grid
-     * and each column corresponds to whether that cell is adjacent to another cell. It iterates over
-     * all cells in the grid, using {@link Grid#findAdjacents(short, Grid.ValueFormat)} to find the
-     * adjacent cells for each cell. The adjacency relationships are then stored in the matrix.
+     * The method creates a {@code boolean[][]} where each row corresponds to a cell in the grid and
+     * each column corresponds to whether that cell is adjacent to another cell. It iterates over all
+     * cells in the grid, using {@link Grid#findAdjacents(short, Grid.ValueFormat)} to find the adjacent
+     * cells for each cell. The adjacency relationships are then stored in the matrix.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -1753,18 +1783,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * since this method pre-dates the creation of the bitmasked adjacency checks.
      * </p>
      * 
-     * @return a <code>boolean[][]</code> where <code>matrix[i][j]</code> is true if cell i is adjacent
-     *         to cell j.
+     * @return a {@code boolean[][]} where {@code matrix[i][j]} is true if cell {@code i} is adjacent to
+     *         cell {@code j}.
      * @see #CLICK_ADJACENCY_MATRIX
      * @see Grid#findAdjacents(short, Grid.ValueFormat)
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @performance O(n^2) where n is the number of cells in the grid, due to nested iteration over
-     *              cells and their adjacents.
+     * @performance <code>O({@value Grid#NUM_CELLS}²)</code>, due to nested iteration over cells and
+     *              their adjacents.
      * @threading Statically initialized once at class load time.
-     * @memory Allocates a fixed-size boolean matrix of size n x n, where n is the number of cells in
-     *         the grid.
-     * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
-     *               for efficient adjacency representation.
+     * @memory Allocates a fixed-size boolean matrix of size {@value Grid#NUM_CELLS} ×
+     *         {@value Grid#NUM_CELLS}.
+     * @optimization Pre-computed once at class load time to avoid recomputation, uses {@code boolean}
+     *               matrix for efficient adjacency representation.
      */
     private static boolean[][] initClickAdjacencyMatrix() {
         boolean[][] matrix = new boolean[Grid.NUM_CELLS][Grid.NUM_CELLS];
@@ -1784,26 +1814,26 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * already initialized.
      * 
      * <p>
-     * Our pruning strategy relies on quickly determining which true cells are toggled by a given prefix
-     * of clicks. In order to make these checks efficient (and constant time), we use pre-computed masks
-     * where possible to avoid repeated calculations. Naturally, though, that means that we need to
-     * compute these masks at some point. This method does that, ensuring that the masks are only
-     * computed once per puzzle and reused across tasks.
+     * Our pruning strategy relies on quickly determining which {@code true} cells are toggled by a
+     * given {@code prefix} of clicks. In order to make these checks efficient (and constant time), we
+     * use pre-computed masks where possible to avoid repeated calculations. Naturally, though, that
+     * means that we need to compute these masks at some point. This method does that, ensuring that the
+     * masks are only computed once per puzzle and reused across tasks.
      * </p>
      * 
      * <h3>Algorithm Details</h3>
      * <p>
      * The method first lazily checks if the masks are already initialized before entering a
-     * synchronized block, ensuring that one thread performs the initialization (but that multiple
-     * threads could call the method). Inside the synchronized block, it checks again if the masks are
-     * initialized to avoid redundant computation.
+     * {@code synchronized} block, ensuring that one thread performs the initialization (but that
+     * multiple threads could call the method). Inside the {@code synchronized} block, it checks again
+     * if the masks are initialized to avoid redundant computation.
      * </p>
      * 
      * <p>
-     * For each click cell, it constructs a bitmask of length <code>trueCells.length</code> where each
-     * bit represents whether the corresponding true cell is adjacent to the click cell. This is done by
-     * using the {@link #CLICK_ADJACENCY_MATRIX} to check adjacency. The resulting masks are stored in
-     * the {@link #TRUE_CELL_ADJACENCY_MASKS} array.
+     * For each click cell, it constructs a bitmask of length {@code trueCells.length} where each bit
+     * represents whether the corresponding {@code true} cell is adjacent to the click cell. This is
+     * done by using the {@link #CLICK_ADJACENCY_MATRIX} to check adjacency. The resulting masks are
+     * stored in the {@link #TRUE_CELL_ADJACENCY_MASKS} array.
      * </p>
      * 
      * <p>
@@ -1822,16 +1852,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * overhead.
      * </p>
      * 
-     * @param trueCells the array of indices of initially true cells in the grid.
+     * @param trueCells a {@code short[]} of initially {@code true} cells in the grid in
+     *                  {@link Grid.ValueFormat#Index Index} format.
      * @see #CLICK_ADJACENCY_MATRIX
      * @see #SUFFIX_OR_MASKS
      * @see #TRUE_CELL_ADJACENCY_MASKS
      * @see #initClickAdjacencyMatrix()
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @performance O({@link #numClicks} * m) where m is the number of initially true cells.
-     * @threading Thread-safe due to synchronized block and double-checked locking.
-     * @memory One long per cell for {@link #TRUE_CELL_ADJACENCY_MASKS} and one long per cell plus one
-     *         for {@link #SUFFIX_OR_MASKS}.
+     * @performance <code>O({@link #numClicks} × {@value Grid#NUM_CELLS})</code>.
+     * @threading Thread-safe due to {@code synchronized} block and double-checked locking.
+     * @memory One {@code long} per cell for {@link #TRUE_CELL_ADJACENCY_MASKS} and one {@code long} per
+     *         cell plus one for {@link #SUFFIX_OR_MASKS}.
      * @optimization Uses double-checked locking to minimize synchronization overhead, pre-computes
      *               masks once per puzzle to avoid recomputation.
      */
@@ -1891,7 +1922,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * The method first retrieves all available queues from the {@link CombinationQueueArray} and
      * selects a random starting index to avoid contention. It then iterates over the queues, attempting
      * to {@link CombinationQueue#add(WorkBatch) add} the batch to any available queue. If a queue
-     * accepts the batch, the method immediately returns <code>true</code>. If all queues are full, the
+     * accepts the batch, the method immediately returns {@code true}. If all queues are full, the
      * method {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting before
      * looping once more.
      * </p>
@@ -1931,16 +1962,19 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param batch the {@link WorkBatch} to flush.
-     * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
-     *         was interrupted.
+     * @return {@code true} if the batch was successfully flushed, {@code false} if the thread was
+     *         interrupted.
      * @see #queueArray
      * @see CombinationQueue#add(WorkBatch)
      * @see CombinationQueueArray#getAllQueues()
      * @see java.util.concurrent.ThreadLocalRandom
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full.
-     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
-     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting.
+     * @performance <code>O({@link CombinationQueueArray#getAllQueues() queues}.length)</code> per trial, with
+     *              a brief sleep if all queues are full.
+     * @threading Thread-safe due to local queue access and atomic operations in
+     *            {@link CombinationQueue#add(WorkBatch)}.
+     * @optimization Uses random starting index to minimize contention, brief sleep to avoid
+     *               busy-waiting.
      */
     private final boolean flushBatchFast(WorkBatch batch) {   
         CombinationQueue[] queues = queueArray.getAllQueues();
@@ -1995,9 +2029,11 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see TaskPool
      * @see TaskPool#put(CombinationGeneratorTask)
      * @since 2025.07.22 - Task Self-Recycling
-     * @performance O(1) for returning resources to the pools.
-     * @threading Thread-safe due to ForkJoinTask isolation and local context access.
-     * @optimization Avoids ThreadLocal access by using passed-in context, reuses existing pools.
+     * @performance {@code O(1)} for returning resources to the pools.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation
+     *            and local context access.
+     * @optimization Avoids {@code ThreadLocal} access by using passed-in context, reuses existing
+     *               pools.
      */
     private void recycleOwnResources(GeneratorContext ctx) {
         // No ThreadLocal access needed - use passed context
@@ -2019,11 +2055,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * <p>
      * To amortize the cost of flushing batches, we allow tasks to accumulate work in their
-     * <code>WorkBatch</code>es until they reach {@link #BATCH_SIZE}, flushing only after they reach
-     * this threshold. However, it is possible (and likely) that all tasks will complete with partially
-     * full batches remaining (leaving a maximum of <code>(BATCH_SIZE - 1) * (numThreads)) combinations
-     * left). To ensure that all generated combinations are tested, we need a way for the main thread to
-     * flush these remaining batches after all tasks are done, which is what this method does.
+     * {@code WorkBatch}es until they reach {@link #BATCH_SIZE}, flushing only after they reach this
+     * threshold. However, it is possible (and likely) that all tasks will complete with partially full
+     * batches remaining (leaving a maximum of <code>({@value #BATCH_SIZE} - 1) × numThreads / 2)</code>
+     * combinations left). To ensure that all generated combinations are tested, we need a way for the
+     * main thread to flush these remaining batches after all tasks are done, which is what this method
+     * does.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -2045,8 +2082,8 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see GeneratorContext#resetBatch()
      * @see WorkBatch
      * @since 2025.06.12 - Flush Batches when Full (or on Completion)
-     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues
-     *              are full.
+     * @performance <code>O({@link CombinationQueueArray#getAllQueues() queues}.length)</code>, with a
+     *              brief sleep if all queues are full.
      * @threading Thread-safe due to local context access and atomic operations in
      *            {@link CombinationQueue#add(WorkBatch)}.
      * @optimization Uses ForkJoinPool to leverage worker threads, checks for solution found or pool
@@ -2080,9 +2117,9 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * The method first retrieves all available queues from the {@link CombinationQueueArray} and
      * selects a random starting index to avoid contention. It then iterates over the queues, attempting
      * to {@link CombinationQueue#add(WorkBatch) add} the batch to any available queue. If a queue
-     * accepts the batch, the method immediately returns <code>true</code>. If all queues are full, the
+     * accepts the batch, the method immediately returns {@code true}. If all queues are full, the
      * method either {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting before
-     * looping once more, or returns <code>false</code> if not forcing a flush.
+     * looping once more, or returns {@code false} if not forcing a flush.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -2097,31 +2134,35 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * <p>
      * Since we now only use this method for the final flush operation, we could remove the two boolean
      * parameters and simplify the logic. In a similar vein, we could remove the
-     * <code>CombinationQueueArray</code> parameter and use the static {@link #queueArray} field
-     * instead. To fully optimize this method, we could remove all parameters and give it access to an
-     * array of all {@link GeneratorContext contexts} to flush all batches from all threads, though it
-     * would make more sense to remove this method altogether and integrate the logic directly into
-     * <code>flushAllPendingBatches()</code>.
+     * {@code CombinationQueueArray} parameter and use the static {@link #queueArray} field instead. To
+     * fully optimize this method, we could remove all parameters and give it access to an array of all
+     * {@link GeneratorContext contexts} to flush all batches from all threads, though it would make
+     * more sense to remove this method altogether and integrate the logic directly into
+     * {@code flushAllPendingBatches()}.
      * </p>
      * 
      * @param batch             the {@link WorkBatch} to flush.
      * @param queueArray        the {@link CombinationQueueArray} containing the {@link CombinationQueue
      *                          queues} to flush to.
      * @param checkCancellation On a failed attempt to flush, whether to check if a solution has been
-     *                          found and abort if so. This should be <code>true</code> when called from
-     *                          a generator task and <code>false</code> when called from the final flush
+     *                          found and abort if so. This should be {@code true} when called from a
+     *                          generator task and {@code false} when called from the final flush
      *                          operation.
-     * @param forceFlush On a failed attempt to flush, whether to sleep and retry or return <code>false</code>.
-     * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
-     *         was interrupted or if not forcing a flush and all queues were full.
+     * @param forceFlush        On a failed attempt to flush, whether to sleep and retry or return
+     *                          {@code false}.
+     * @return {@code true} if the batch was successfully flushed, {@code false} if the thread was
+     *         interrupted or if not forcing a flush and all queues were full.
      * @see CombinationQueueArray#getAllQueues()
      * @see java.util.concurrent.ThreadLocalRandom
      * @see java.util.concurrent.ThreadLocalRandom#current()
      * @see java.util.concurrent.ThreadLocalRandom#nextInt(int)
      * @since 2025.06.12 - Flush Batches when Full (or on Completion)
-     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full and forcing a flush.
-     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
-     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting when forcing a flush.
+     * @performance <code>O({@link CombinationQueueArray#getAllQueues() queues}.length</code>, with a
+     *              brief sleep if all queues are full and {@code forceFlush} is {@code true}.
+     * @threading Thread-safe due to local queue access and atomic operations in
+     *            {@link CombinationQueue#add(WorkBatch)}.
+     * @optimization Uses random starting index to minimize contention, brief sleep to avoid
+     *               busy-waiting when forcing a flush.
      */
     private static boolean flushBatchHelper(WorkBatch batch, CombinationQueueArray queueArray, boolean checkCancellation, boolean forceFlush) {
         CombinationQueue[] queues = queueArray.getAllQueues();

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -83,24 +83,24 @@ import java.util.concurrent.ThreadLocalRandom;
  * </ul>
  * </p>
  * 
+ * @see CombinationQueue
+ * @see TestClickCombination
+ * @see java.util.concurrent.ForkJoinTask
  * @since 2025.06.08 - Fork Join Refactor
+ * @performance The overall time complexity is O(n choose k) in the worst case, where n is the
+ *              number of cells and k is the number of clicks, but pruning and parallelism
+ *              significantly reduce the effective workload. Most bottlenecks arise from contention
+ *              on shared resources or the process of enqueuing batches.
+ * @threading Each task is isolated and thread-safe due to ForkJoinTask design. Pooled and shared
+ *            resources are handled by <code>ThreadLocal</code> contexts and static fields
+ *            respectively.
  * @algorithm Creates a tree of tasks, where each task represents a prefix of clicks. The root task
  *            generates subtasks for each possible first click, and each subtask recursively
  *            generates further subtasks for each subsequent click until the full combination length
  *            is reached. Leaf tasks generate the final combinations and add them to a WorkBatch,
  *            which is then flushed to a randomly chosen CombinationQueue for processing.
- * @threading Each task is isolated and thread-safe due to ForkJoinTask design. Pooled and shared
- *            resources are handled by <code>ThreadLocal</code> contexts and static fields
- *            respectively.
- * @performance The overall time complexity is O(n choose k) in the worst case, where n is the
- *              number of cells and k is the number of clicks, but pruning and parallelism
- *              significantly reduce the effective workload. Most bottlenecks arise from contention
- *              on shared resources or the process of enqueuing batches.
  * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
  *         in the hot path.
- * @see CombinationQueue
- * @see TestClickCombination
- * @see java.util.concurrent.ForkJoinTask
  */
 public class CombinationGeneratorTask extends RecursiveAction {
     /**
@@ -130,12 +130,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * bottlenecks, while decreasing it can help with generator bottlenecks.
      * </p>
      * 
-     * @since 2025.06.08 - Work-stealing introduction
      * @see #flushBatchFast(WorkBatch)
-     * @see GeneratorContext
-     * @see GeneratorContext#getOrCreateBatch()
      * @see CombinationQueue
      * @see CombinationQueue#add(WorkBatch)
+     * @see GeneratorContext
+     * @see GeneratorContext#getOrCreateBatch()
+     * @since 2025.06.08 - Work-stealing introduction
      */
     public static final int BATCH_SIZE = 8000;
     /**
@@ -176,10 +176,10 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * allocations.
      * </p>
      * 
-     * @since 2025.06.10 - Array Pooling Introduction
      * @see ArrayPool
-     * @see TaskPool
      * @see GeneratorContext
+     * @see TaskPool
+     * @since 2025.06.10 - Array Pooling Introduction
      */
     private static final int POOL_SIZE = 512;
 
@@ -201,16 +201,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * arrays and tasks respectively.
      * </p>
      * 
-     * @since 2025.07.26 - GeneratorContext Introduction
-     * @threading ThreadLocal - Each thread has its own instance of GeneratorContext, ensuring thread
-     *            safety and isolation of resources
-     * @performance O(1) access time for ThreadLocal.get()
-     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce overhead
-     * @memory ThreadLocal memory usage is minimized by pooling resources and recycling them
-     * @see GeneratorContext
      * @see ArrayPool
+     * @see GeneratorContext
      * @see TaskPool
      * @see WorkBatch
+     * @since 2025.07.26 - GeneratorContext Introduction
+     * @performance O(1) access time for ThreadLocal.get()
+     * @threading ThreadLocal - Each thread has its own instance of GeneratorContext, ensuring thread
+     *            safety and isolation of resources
+     * @memory ThreadLocal memory usage is minimized by pooling resources and recycling them
+     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce overhead
      */
     private static final ThreadLocal<GeneratorContext> context =
         ThreadLocal.withInitial(GeneratorContext::new);
@@ -268,45 +268,45 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * with larger pools reducing contention but increasing memory usage.
      * </p>
      * 
-     * @since 2025.07.26 - GeneratorContext Introduction
-     * @performance O(1) access time for pool operations.
-     * @memory Minimal memory footprint as a wrapper class, with pooled resources to minimize
-     *         allocations.
-     * @threading This class is not thread-safe, but is intended to be used in a thread-local manner. A
-     *            thread-local, static variable should be created to use this class.
-     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce
-     *               overhead.
+     * @see #context
      * @see ArrayPool
      * @see CombinationGeneratorTask
-     * @see CombinationGeneratorTask#context
      * @see TaskPool
      * @see WorkBatch
+     * @since 2025.07.26 - GeneratorContext Introduction
+     * @performance O(1) access time for pool operations.
+     * @threading This class is not thread-safe, but is intended to be used in a thread-local manner. A
+     *            thread-local, static variable should be created to use this class.
+     * @memory Minimal memory footprint as a wrapper class, with pooled resources to minimize
+     *         allocations.
+     * @optimization Consolidation of multiple ThreadLocals into a single context object to reduce
+     *               overhead.
      */
     private static class GeneratorContext {
         /**
          * An {@link ArrayPool} for storing click prefixes.
          * 
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @threading Thread-local - Each thread has its own instance of ArrayPool, ensuring thread safety.
-         * @performance O(1) amortized access time for get() and recycle().
-         * @optimization Pooling and reusing arrays to minimize allocations on the hot path.
-         * @memory Memory usage is optimized by reusing arrays and minimizing allocations.
+         * @see #context
+         * @see #numClicks
          * @see ArrayPool
-         * @see CombinationGeneratorTask#context
-         * @see CombinationGeneratorTask#numClicks
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @performance O(1) amortized access time for get() and recycle().
+         * @threading Thread-local - Each thread has its own instance of ArrayPool, ensuring thread safety.
+         * @memory Memory usage is optimized by reusing arrays and minimizing allocations.
+         * @optimization Pooling and reusing arrays to minimize allocations on the hot path.
          */
         final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE);
         /**
          * The {@link TaskPool} for recycling subtasks.
          * 
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @threading Thread-local - Each thread has its own instance of TaskPool, ensuring thread safety.
-         * @performance O(1) amortized access time for get() and recycle().
-         * @optimization Pooling and reusing tasks to minimize allocations on the hot path.
-         * @memory Memory usage is optimized by reusing tasks and minimizing allocations.
+         * @see TaskPool#TaskPool(int)
          * @see TaskPool#get()
          * @see TaskPool#put(CombinationGeneratorTask)
-         * @see TaskPool#TaskPool(int)
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @performance O(1) amortized access time for get() and recycle().
+         * @threading Thread-local - Each thread has its own instance of TaskPool, ensuring thread safety.
+         * @memory Memory usage is optimized by reusing tasks and minimizing allocations.
+         * @optimization Pooling and reusing tasks to minimize allocations on the hot path.
          */
         final TaskPool taskPool = new TaskPool(POOL_SIZE / 4);
         /**
@@ -330,14 +330,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * storage without the cost of multiple ThreadLocal accesses.
          * </p>
          * 
-         * @since 2025.07.01 - WorkBatch Introduction
-         * @threading Thread-local - Each thread has its own instance of WorkBatch, ensuring thread safety.
-         * @performance O(1) access time.
-         * @optimization Bundled into GeneratorContext to reduce ThreadLocal access overhead.
-         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @see #BATCH_SIZE
+         * @see #context
          * @see WorkBatch
-         * @see CombinationGeneratorTask#context
-         * @see CombinationGeneratorTask#BATCH_SIZE
+         * @since 2025.07.01 - WorkBatch Introduction
+         * @performance O(1) access time.
+         * @threading Thread-local - Each thread has its own instance of WorkBatch, ensuring thread safety.
+         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @optimization Bundled into GeneratorContext to reduce ThreadLocal access overhead.
          */
         WorkBatch currentBatch = null;
 
@@ -359,14 +359,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * </p>
          * 
          * @return The current <code>{@link WorkBatch}</code>, guaranteed to be non-null.
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
-         *            safety.
-         * @performance O(1) null check and access time.
-         * @optimization Caches current batch to avoid redundant allocations or pool calls.
+         * @see #context
          * @see #getNewBatchBlocking()
          * @see WorkBatch
-         * @see CombinationGeneratorTask#context
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @performance O(1) null check and access time.
+         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
+         *            safety.
+         * @optimization Caches current batch to avoid redundant allocations or pool calls.
          */
         WorkBatch getOrCreateBatch() {
             if (currentBatch == null) {
@@ -407,15 +407,15 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * </p>
          * 
          * @return A new <code>WorkBatch</code>, guaranteed to be non-null.
+         * @see CombinationQueueArray
+         * @see CombinationQueueArray#getWorkBatchPool()
+         * @see WorkBatch
          * @since 2025.07.26 - GeneratorContext Introduction
+         * @performance O(1) amortized access time, blocking if necessary.
          * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
          *           safety.
-         * @performance O(1) amortized access time, blocking if necessary.
-         * @optimization Uses a busy-wait loop with relaxed polling to avoid deadlocks and allow for cancellation.
          * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
-         * @see CombinationQueueArray#getWorkBatchPool()
-         * @see CombinationQueueArray
-         * @see WorkBatch
+         * @optimization Uses a busy-wait loop with relaxed polling to avoid deadlocks and allow for cancellation.
          */
         private WorkBatch getNewBatchBlocking() {
             WorkBatch batch;
@@ -437,12 +437,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * </p>
          * 
          * @return The new current <code>WorkBatch</code>, guaranteed to be non-null.
-         * @since 2025.07.26 - GeneratorContext Introduction
-         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread safety.
-         * @performance O(1) amortized access time, blocking if necessary.
-         * @optimization Combines batch reset and retrieval into a single operation to reduce overhead.
-         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
          * @see #getNewBatchBlocking()
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @performance O(1) amortized access time, blocking if necessary.
+         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread safety.
+         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @optimization Combines batch reset and retrieval into a single operation to reduce overhead.
          */
         WorkBatch resetBatch() {
             return currentBatch = getNewBatchBlocking();
@@ -459,15 +459,15 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * the combinations being generated.
      * </p>
      * 
-     * @since 2025.06.08 - Fork Join Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
-     * @performance O(1) access time.
-     * @optimization Static field to avoid redundant storage in each task instance.
-     * @memory Minimal memory usage as a primitive int.
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @see #compute()
      * @see #prefix
      * @see #prefixLength
-     * @see #compute()
-     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @since 2025.06.08 - Fork Join Refactor
+     * @performance O(1) access time.
+     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
+     * @memory Minimal memory usage as a primitive int.
+     * @optimization Static field to avoid redundant storage in each task instance.
      */
     private static int numClicks;
     /**
@@ -481,14 +481,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * queue array is constant for a given puzzle.
      * </p>
      * 
-     * @since 2025.06.08 - Fork Join Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
-     * @performance O(1) access time.
-     * @optimization Static field to avoid redundant storage in each task instance.
-     * @memory Minimal memory usage as a reference.
      * @see #flushBatchFast(WorkBatch)
      * @see CombinationQueue
      * @see java.util.concurrent.ThreadLocalRandom
+     * @since 2025.06.08 - Fork Join Refactor
+     * @performance O(1) access time.
+     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any subtasks are created.
+     * @memory Minimal memory usage as a reference.
+     * @optimization Static field to avoid redundant storage in each task instance.
      */
     private static CombinationQueueArray queueArray;
     /**
@@ -503,16 +503,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * given puzzle.
      * </p>
      * 
-     * @since 2025.06.11 - First Click Optimization
-     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any
-     *            subtasks are created.
-     * @performance O(1) access time.
-     * @optimization Static field to avoid redundant storage in each task instance.
-     * @memory Minimal memory usage as a primitive int.
      * @see #compute()
      * @see Grid
      * @see Grid#findFirstTrueAdjacents(com.github.mrgarbagegamer.Grid.ValueFormat)
      * @see Grid#findFirstTrueCell(com.github.mrgarbagegamer.Grid.ValueFormat)
+     * @since 2025.06.11 - First Click Optimization
+     * @performance O(1) access time.
+     * @threading Thread-safe due to ForkJoinTask isolation. Initialized in the root task before any
+     *            subtasks are created.
+     * @memory Minimal memory usage as a primitive int.
+     * @optimization Static field to avoid redundant storage in each task instance.
      */
     private static int maxFirstClickIndex;
 
@@ -548,20 +548,20 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * this is not currently feasible due to the maximum number of clicks exceeding 64.
      * </p>
      * 
-     * @since 2025.06.08 - Fork Join Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation. Ensure that prefix arrays are not
-     *            referenced after recycling to avoid concurrency issues.
-     * @performance O(1) for adding clicks, O(n) for copying to subtasks where n is the
-     *              {@link #prefixLength} at that point.
-     * @optimization Pooled and pre-allocated to minimize allocations on the hot path. Sized to
-     *               {@link #numClicks} to avoid resizing.
-     * @memory Uses <code>short</code> arrays to reduce memory usage while maintaining sufficient range.
      * @see #recycleOwnResources(GeneratorContext)
      * @see ArrayPool
      * @see ArrayPool#get()
      * @see ArrayPool#put(short[])
      * @see GeneratorContext
      * @see GeneratorContext#prefixArrayPool
+     * @since 2025.06.08 - Fork Join Refactor
+     * @performance O(1) for adding clicks, O(n) for copying to subtasks where n is the
+     *              {@link #prefixLength} at that point.
+     * @threading Thread-safe due to ForkJoinTask isolation. Ensure that prefix arrays are not
+     *            referenced after recycling to avoid concurrency issues.
+     * @memory Uses <code>short</code> arrays to reduce memory usage while maintaining sufficient range.
+     * @optimization Pooled and pre-allocated to minimize allocations on the hot path. Sized to
+     *               {@link #numClicks} to avoid resizing.
      */
     private short[] prefix;
     /**
@@ -584,14 +584,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * {@link #numClicks} field.
      * </p>
      * 
-     * @since 2025.06.08 - Fork Join Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(1) for updates and checks.
-     * @optimization Simple integer field to minimize overhead.
-     * @memory Minimal memory usage as a primitive int.
+     * @see #compute()
      * @see #numClicks
      * @see #prefix
-     * @see #compute()
+     * @since 2025.06.08 - Fork Join Refactor
+     * @performance O(1) for updates and checks.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @memory Minimal memory usage as a primitive int.
+     * @optimization Simple integer field to minimize overhead.
      */
     private int prefixLength;
     /**
@@ -621,18 +621,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * combinatorial tasks.
      * </p>
      * 
-     * @since 2025.07.15 - Cached adjacency state introduction
-     * @threading Thread-safe due to ForkJoinTask isolation
-     * @performance O(1) for updates, O(n) for initial computation where n is the prefixLength at that
-     *              point.
-     * @optimization Caches the state between tasks to avoid recomputing for every prefix.
-     * @memory Uses a long to represent the adjacency state, which is efficient for up to 64 initially
-     *         true cells.
-     * @see #skipConstraintsCheck
      * @see #canPotentiallySatisfyConstraints(int)
      * @see #ensureTrueCellMasks(short[])
-     * @see Grid#areAdjacent(short cellA, short cellB)
+     * @see #skipConstraintsCheck
+     * @see Grid#areAdjacent(short, short)
      * @see Grid#findTrueCells()
+     * @since 2025.07.15 - Cached adjacency state introduction
+     * @performance O(1) for updates, O(n) for initial computation where n is the prefixLength at that
+     *              point.
+     * @threading Thread-safe due to ForkJoinTask isolation
+     * @memory Uses a long to represent the adjacency state, which is efficient for up to 64 initially
+     *         true cells.
+     * @optimization Caches the state between tasks to avoid recomputing for every prefix.
      */
     private long cachedAdjacencyState = -1; // -1 means root task, -2 means constraints are skipped
     /**
@@ -657,13 +657,13 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * the paths based on this flag and perform a single check prior to dispatching to a subtask path.
      * </p>
      * 
-     * @since 2025.08.04 - Reduced Branching Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(1) for checks and updates.
-     * @optimization Reduces redundant constraint checks in deep branches of the generation tree.
-     * @memory Minimal memory usage as a primitive boolean.
      * @see #cachedAdjacencyState
      * @see #computeIntermediateSubtasks(GeneratorContext)
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @performance O(1) for checks and updates.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @memory Minimal memory usage as a primitive boolean.
+     * @optimization Reduces redundant constraint checks in deep branches of the generation tree.
      */
     private boolean skipConstraintsCheck = false; // If a prefix is known to satisfy constraints, we can skip checks for its children
 
@@ -696,15 +696,15 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * trillions of times.
      * </p>
      * 
-     * @since 2025.08.04 - Reduced Branching Refactor
-     * @threading Computed once in the root task and reused across all subtasks.
-     * @performance O(1) for checks, O(1) for initial computation in the root task.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
-     * @memory Uses a long to represent the target state, which is efficient for up to 64 initially true
-     *         cells.
      * @see #cachedAdjacencyState
      * @see #SUFFIX_OR_MASKS
      * @see #ensureTrueCellMasks(short[])
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @performance O(1) for checks, O(1) for initial computation in the root task.
+     * @threading Computed once in the root task and reused across all subtasks.
+     * @memory Uses a long to represent the target state, which is efficient for up to 64 initially true
+     *         cells.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
      */
     private static long targetMask;
     
@@ -729,10 +729,10 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
-     * @threading Volatile static field - Ensures visibility of changes across threads.
      * @performance O(1) access time.
-     * @optimization Static field for quick access without passing references.
+     * @threading Volatile static field - Ensures visibility of changes across threads.
      * @memory Minimal memory usage as a single reference.
+     * @optimization Static field for quick access without passing references.
      */
     private static volatile ForkJoinPool generatorPool;
 
@@ -748,13 +748,13 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * @param pool the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} to use for executing
      *             generator tasks.
+     * @see TestClickCombination#triggerGeneratorShutdown()
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
+     * @performance O(1) assignment.
      * @threading Thread-safe due to the use of a volatile static field, though this method should be
      *            called by one thread only.
-     * @performance O(1) assignment.
-     * @optimization Static field for quick access without passing references.
      * @memory Minimal memory usage as a single reference.
-     * @see TestClickCombination#triggerGeneratorShutdown()
+     * @optimization Static field for quick access without passing references.
      */
     public static void setForkJoinPool(ForkJoinPool pool) {
         CombinationGeneratorTask.generatorPool = pool;
@@ -770,12 +770,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * @return the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used for executing
      *         generator tasks.
-     * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
-     * @threading Thread-safe due to the use of a volatile static field.
-     * @performance O(1) access time.
-     * @optimization Static field for quick access without passing references.
-     * @memory Only gets a reference, so minimal memory usage.
      * @see TestClickCombination#triggerGeneratorShutdown()
+     * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
+     * @performance O(1) access time.
+     * @threading Thread-safe due to the use of a volatile static field.
+     * @memory Only gets a reference, so minimal memory usage.
+     * @optimization Static field for quick access without passing references.
      */
     public static ForkJoinPool getForkJoinPool() {
         return generatorPool;
@@ -817,14 +817,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @throws IllegalArgumentException if any of the parameters are invalid (<code>null</code> or out
      *                                  of range).
      * @since 2025.06.08 - Fork Join Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation. Static fields are initialized in the root
-     *            task before any subtasks are created.
      * @performance O(n) for initialization where n is the number of initially true cells, amortized
      *              over the entire generation process.
-     * @optimization Pre-computes masks and initializes static fields to reduce overhead during
-     *               generation. Uses pooled arrays for the prefix to minimize allocations.
+     * @threading Thread-safe due to ForkJoinTask isolation. Static fields are initialized in the root
+     *            task before any subtasks are created.
      * @memory Uses pooled arrays for the prefix to reduce memory usage. Static fields are minimal in
      *         size.
+     * @optimization Pre-computes masks and initializes static fields to reduce overhead during
+     *               generation. Uses pooled arrays for the prefix to minimize allocations.
      */
     public CombinationGeneratorTask(int numClicks, CombinationQueueArray queueArray, short[] trueCells,
             int maxFirstClickIndex) {
@@ -894,18 +894,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * instead of one.
      * </p>
      * 
-     * @since 2025.06.11 - Revamped Odd Adjacency Check
-     * @threading Statically initialized once in {@link #computeAdjacencyMaskFast(short)} by the root
-     *            task.
-     * @performance O(1) for checks, O(n) for initial computation where n is the number of adjacent
-     *              cells.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation. A
-     *               bitmask is used for compact representation.
-     * @memory Uses an array of two longs to represent the adjacency of the first true cell.
-     * @see #computeAdjacencyMaskFast(short)
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @see #computeAdjacencyMaskFast(short)
      * @see Grid#findAdjacents(short)
      * @see Grid#findFirstTrueCell(Grid.ValueFormat)
+     * @since 2025.06.11 - Revamped Odd Adjacency Check
+     * @performance O(1) for checks, O(n) for initial computation where n is the number of adjacent
+     *              cells.
+     * @threading Statically initialized once in {@link #computeAdjacencyMaskFast(short)} by the root
+     *            task.
+     * @memory Uses an array of two longs to represent the adjacency of the first true cell.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation. A
+     *               bitmask is used for compact representation.
      */
     private static long[] FIRST_TRUE_ADJACENTS;
     
@@ -935,14 +935,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * @param firstTrueCell The index of the first true cell in the grid, in
      *                      {@link Grid.ValueFormat#Index Index} format.
-     * @since 2025.06.11 - Bitmasked Leaf Pruning Introduction
-     * @threading Single-threaded during root task initialization, no synchronization needed.
-     * @performance O(n) where n is the number of adjacent cells to the first true cell.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
-     * @memory Uses an array of two <code>long</code>s to represent the adjacency of the first true
-     *         cell. Creates a temporary <code>short[]</code> array for adjacent cells.
      * @see #FIRST_TRUE_ADJACENTS
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @since 2025.06.11 - Bitmasked Leaf Pruning Introduction
+     * @performance O(n) where n is the number of adjacent cells to the first true cell.
+     * @threading Single-threaded during root task initialization, no synchronization needed.
+     * @memory Uses an array of two <code>long</code>s to represent the adjacency of the first true
+     *         cell. Creates a temporary <code>short[]</code> array for adjacent cells.
+     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
      */
     private static void computeAdjacencyMaskFast(short firstTrueCell) {
         short[] adjacents = Grid.findAdjacents(firstTrueCell);
@@ -967,12 +967,12 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * the {@link #init(short[], int, long, boolean) init()} method.
      * </p>
      * 
-     * @since 2025.07.11 - Task Pool Introduction
-     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
-     * @performance O(1) access time, since no allocations or operations are performed.
-     * @optimization Protected to prevent external allocations, enforcing the use of the task pool.
-     * @memory No memory usage, as no allocations are performed.
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @since 2025.07.11 - Task Pool Introduction
+     * @performance O(1) access time, since no allocations or operations are performed.
+     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
+     * @memory No memory usage, as no allocations are performed.
+     * @optimization Protected to prevent external allocations, enforcing the use of the task pool.
      */
     protected CombinationGeneratorTask() {}
 
@@ -1018,14 +1018,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * per task, something that can be amortized over the entire task's execution.
      * </p>
      * 
-     * @since 2025.06.08 - Work-stealing introduction
-     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
-     * @performance O(1) access time for ThreadLocal context, O(1) for dispatching.
-     * @optimization Multiple paths for different task types to reduce branches and conditionals.
-     * @memory Memory usage is minimized by recycling resources and using pools.
      * @see #recycleOwnResources(GeneratorContext)
      * @see GeneratorContext
-     * @see ThreadLocal#get()
+     * @see java.lang.ThreadLocal#get()
+     * @since 2025.06.08 - Work-stealing introduction
+     * @performance O(1) access time for ThreadLocal context, O(1) for dispatching.
+     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
+     * @memory Memory usage is minimized by recycling resources and using pools.
+     * @optimization Multiple paths for different task types to reduce branches and conditionals.
      */
     @Override
     protected void compute() {
@@ -1097,15 +1097,15 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param ctx the thread-local {@link GeneratorContext} containing resource pools.
-     * @since 2025.08.04 - Reduced Branching Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(n) where n is the number of valid first clicks.
-     * @optimization Limits the range of first clicks to reduce the number of subtasks. Piggybacks on
-     *               the thread-local nature of the context to avoid multiple ThreadLocal accesses.
-     * @memory Memory usage is minimized by recycling resources and using pools. No allocations should
-     *         occur in this method unless the pools are somehow empty.
      * @see #helpQuiesce()
      * @see #recycleOwnResources(GeneratorContext)
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @performance O(n) where n is the number of valid first clicks.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @memory Memory usage is minimized by recycling resources and using pools. No allocations should
+     *         occur in this method unless the pools are somehow empty.
+     * @optimization Limits the range of first clicks to reduce the number of subtasks. Piggybacks on
+     *               the thread-local nature of the context to avoid multiple ThreadLocal accesses.
      */
     private void computeRootSubtasks(GeneratorContext ctx) {
         final short start = 0;
@@ -1166,13 +1166,13 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @param prefixLength the length of the prefix array.
      * @param parentAdjacencyState the cached adjacency state from the parent task.
      * @param skipConstraints whether to skip constraint checks for this task and its children.
-     * @since 2025.07.11 - Task Pool Introduction
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(1) for assignments and reinitialization.
-     * @optimization Monomorphic method to avoid polymorphic call sites and improve JIT optimizations.
-     * @memory Memory usage is minimized by recycling task objects via a TaskPool. No allocations occur in this method.
      * @see #reinitialize()
      * @see TaskPool
+     * @since 2025.07.11 - Task Pool Introduction
+     * @performance O(1) for assignments and reinitialization.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @memory Memory usage is minimized by recycling task objects via a TaskPool. No allocations occur in this method.
+     * @optimization Monomorphic method to avoid polymorphic call sites and improve JIT optimizations.
      */
     public void init(short[] prefix, int prefixLength, long parentAdjacencyState, boolean skipConstraints) {
         this.prefix = prefix;
@@ -1243,18 +1243,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
+     * @see #FIRST_TRUE_ADJACENTS
+     * @see #flushBatchFast(WorkBatch)
+     * @see GeneratorContext#getOrCreateBatch()
      * @since 2025.07.03 - Splitting the Compute Method Into Paths
-     * @threading Thread-safe due to ForkJoinTask isolation.
      * @performance O({@link #prefixLength}) for prefix parity computation,
      *              O(<code>{@link Grid#NUM_CELLS} - {@link #prefix}[prefixLength - 1]</code>) for
      *              iterating over possible next clicks.
+     * @threading Thread-safe due to ForkJoinTask isolation.
      * @algorithm Iterates over the prefix to compute parity, then iterates over possible next clicks to
      *            find valid combinations based on the computed parity.
      * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
      *               tight loop with minimal branching to allow for aggressive JIT optimizations.
-     * @see #flushBatchFast(WorkBatch)
-     * @see #FIRST_TRUE_ADJACENTS
-     * @see GeneratorContext#getOrCreateBatch()
      * 
      */
     private final void computeLeafCombinations(GeneratorContext ctx){
@@ -1348,14 +1348,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
-     * @since 2025.08.04 - Reduced Branching Refactor
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(1) for dispatching.
-     * @optimization Monomorphic call sites for each path to reduce branching and conditionals in the hot path.
      * @see #skipConstraintsCheck
      * @see #compute()
-     * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
      * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
+     * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
+     * @since 2025.08.04 - Reduced Branching Refactor
+     * @performance O(1) for dispatching.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @optimization Monomorphic call sites for each path to reduce branching and conditionals in the hot path.
      */
     private void computeIntermediateSubtasks(GeneratorContext ctx) {
         if (skipConstraintsCheck) {
@@ -1403,15 +1403,15 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
-     * @since 2025.08.04 - Specialized Subtask Paths
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} - 
-     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
-     *              clicks.
-     * @optimization Removes constraint check branching, caches loop-invariant values, and uses a tight
-     *               loop with minimal branching to allow for aggressive JIT optimizations.
      * @see #skipConstraintsCheck
      * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
+     * @since 2025.08.04 - Specialized Subtask Paths
+     * @performance O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
+     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
+     *              clicks.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @optimization Removes constraint check branching, caches loop-invariant values, and uses a tight
+     *               loop with minimal branching to allow for aggressive JIT optimizations.
      */
     private void computeIntermediateSubtasksSkipPath(GeneratorContext ctx) {
         final short start = (short) (prefix[prefixLength - 1] + 1);
@@ -1479,17 +1479,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
-     * @since 2025.08.04 - Specialized Subtask Paths
-     * @threading Thread-safe due to ForkJoinTask isolation.
-     * @performance O(1) for the early constraint check,
-     *              O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} - 
-     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
-     *              clicks.
-     * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
-     *               tight loop with minimal branching to allow for aggressive JIT optimizations.
      * @see #canPotentiallySatisfyConstraints(int)
      * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
      * @see #ensureTrueCellMasks(short[])
+     * @since 2025.08.04 - Specialized Subtask Paths
+     * @performance O(1) for the early constraint check,
+     *              O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
+     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
+     *              clicks.
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
+     *               tight loop with minimal branching to allow for aggressive JIT optimizations.
      */
     private void computeIntermediateSubtasksConstraintPath(GeneratorContext ctx) {
         final short start = (short) (prefix[prefixLength - 1] + 1);
@@ -1585,21 +1585,21 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @param startIdx the index of the first possible next click (used for suffix OR checks)
      * @return <code>true</code> if the current prefix or any descendant can satisfy the constraints,
      *         <code>false</code> otherwise.
+     * @see #cachedAdjacencyState
+     * @see #SUFFIX_OR_MASKS
+     * @see #targetMask
+     * @see #TRUE_CELL_ADJACENCY_MASKS
+     * @see #ensureTrueCellMasks(short[])
+     * @see Grid#findAdjacents(short)
+     * @see Grid#findTrueCells(Grid.ValueFormat)
      * @since 2025.07.03 - Splitting the Compute Method Into Paths
-     * @threading Thread-safe due to ForkJoinTask isolation.
      * @performance O(1) for the check due to bitmask operations and pre-computed suffix OR masks.
+     * @threading Thread-safe due to ForkJoinTask isolation.
      * @algorithm Uses bitmask operations to determine if the current prefix or any descendant can
      *            satisfy the constraints and compares against a pre-computed target mask and
      *            pre-computed suffix OR masks.
      * @optimization Caches loop-invariant values, uses bitmask operations, and employs pre-computed
      *               suffix OR masks to reduce complexity.
-     * @see #TRUE_CELL_ADJACENCY_MASKS
-     * @see #SUFFIX_OR_MASKS
-     * @see #cachedAdjacencyState
-     * @see #targetMask
-     * @see #ensureTrueCellMasks(short[])
-     * @see Grid#findTrueCells(Grid.ValueFormat)
-     * @see Grid#findAdjacents(short)
      */
     private boolean canPotentiallySatisfyConstraints(int startIdx) {   
         // OPTIMIZATION: Call ensureTrueCellMasks once in the root task to avoid a call here.
@@ -1646,17 +1646,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * counts that are below this limit.
      * </p>
      * 
+     * @see #ensureTrueCellMasks(short[])
+     * @see #SUFFIX_OR_MASKS
+     * @see Grid#findAdjacents(short)
+     * @see Grid#findTrueCells(Grid.ValueFormat)
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
      * @performance O(1) for adjacency checks, O(n) for initial computation where n is the number of
      *              initially true cells
+     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
      * @memory One long per cell, guaranteeing a fixed memory footprint regardless of the number of true
      *         cells and avoiding object overhead.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
-     * @see #SUFFIX_OR_MASKS
-     * @see #ensureTrueCellMasks(short[])
-     * @see Grid#findAdjacents(short cell)
-     * @see Grid#findTrueCells(Grid.ValueFormat format)
      */
     private static long[] TRUE_CELL_ADJACENCY_MASKS = null;
     /**
@@ -1691,17 +1691,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * true counts that are below this limit.
      * </p>
      * 
+     * @see #canPotentiallySatisfyConstraints(int)
+     * @see #ensureTrueCellMasks(short[])
+     * @see #TRUE_CELL_ADJACENCY_MASKS
+     * @see Grid#findAdjacents(short)
      * @since 2025.07.14 - Suffix OR Masks Introduction
-     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
      * @performance O(1) for suffix OR checks, O(n) for initial computation where n is the number of cells
      *              in the grid.
+     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
      * @memory One long per cell, guaranteeing a fixed memory footprint regardless of the number of true
      *         cells and avoiding object overhead.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
-     * @see TRUE_CELL_ADJACENCY_MASKS
-     * @see #ensureTrueCellMasks(short[])
-     * @see #canPotentiallySatisfyConstraints(int)
-     * @see Grid#findAdjacents(short cell)
      */
     private static long[] SUFFIX_OR_MASKS = null;
     /**
@@ -1717,16 +1717,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * since this field pre-dates the creation of the bitmasked Grid state.
      * </p>
      * 
+     * @see #initClickAdjacencyMatrix()
+     * @see Grid#findAdjacents(short, Grid.ValueFormat)
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @threading Statically initialized once at class load time.
      * @performance O(1) for adjacency checks, O(n^2) for initial computation where n is the number of
      *              cells in the grid.
+     * @threading Statically initialized once at class load time.
      * @memory Fixed-size boolean matrix of size n x n, where n is the number of cells in the grid. This
      *         guarantees a fixed memory footprint and avoids object overhead.
      * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
      *               for efficient adjacency representation.
-     * @see #initClickAdjacencyMatrix()
-     * @see Grid#findAdjacents(short, Grid.ValueFormat)
      */
     private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix();
 
@@ -1755,16 +1755,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * 
      * @return a <code>boolean[][]</code> where <code>matrix[i][j]</code> is true if cell i is adjacent
      *         to cell j.
-     * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @threading Statically initialized once at class load time.
-     * @performance O(n^2) where n is the number of cells in the grid, due to nested iteration over
-     *              cells and their adjacents.
-     * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
-     *               for efficient adjacency representation.
-     * @memory Allocates a fixed-size boolean matrix of size n x n, where n is the number of cells in
-     *         the grid.
      * @see #CLICK_ADJACENCY_MATRIX
      * @see Grid#findAdjacents(short, Grid.ValueFormat)
+     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @performance O(n^2) where n is the number of cells in the grid, due to nested iteration over
+     *              cells and their adjacents.
+     * @threading Statically initialized once at class load time.
+     * @memory Allocates a fixed-size boolean matrix of size n x n, where n is the number of cells in
+     *         the grid.
+     * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
+     *               for efficient adjacency representation.
      */
     private static boolean[][] initClickAdjacencyMatrix() {
         boolean[][] matrix = new boolean[Grid.NUM_CELLS][Grid.NUM_CELLS];
@@ -1823,17 +1823,17 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param trueCells the array of indices of initially true cells in the grid.
+     * @see #CLICK_ADJACENCY_MATRIX
+     * @see #SUFFIX_OR_MASKS
+     * @see #TRUE_CELL_ADJACENCY_MASKS
+     * @see #initClickAdjacencyMatrix()
      * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @threading Thread-safe due to synchronized block and double-checked locking.
      * @performance O({@link #numClicks} * m) where m is the number of initially true cells.
+     * @threading Thread-safe due to synchronized block and double-checked locking.
      * @memory One long per cell for {@link #TRUE_CELL_ADJACENCY_MASKS} and one long per cell plus one
      *         for {@link #SUFFIX_OR_MASKS}.
      * @optimization Uses double-checked locking to minimize synchronization overhead, pre-computes
      *               masks once per puzzle to avoid recomputation.
-     * @see #TRUE_CELL_ADJACENCY_MASKS
-     * @see #SUFFIX_OR_MASKS
-     * @see #CLICK_ADJACENCY_MATRIX
-     * @see #initClickAdjacencyMatrix()
      */
     private static void ensureTrueCellMasks(short[] trueCells) {
         if (TRUE_CELL_ADJACENCY_MASKS == null | SUFFIX_OR_MASKS == null)
@@ -1933,14 +1933,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @param batch the {@link WorkBatch} to flush.
      * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
      *         was interrupted.
-     * @since 2025.06.08 - Fork Join Refactor
-     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
-     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full.
-     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting.
      * @see #queueArray
-     * @see ThreadLocalRandom
-     * @see CombinationQueueArray#getAllQueues()
      * @see CombinationQueue#add(WorkBatch)
+     * @see CombinationQueueArray#getAllQueues()
+     * @see java.util.concurrent.ThreadLocalRandom
+     * @since 2025.06.08 - Fork Join Refactor
+     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full.
+     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
+     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting.
      */
     private final boolean flushBatchFast(WorkBatch batch) {   
         CombinationQueue[] queues = queueArray.getAllQueues();
@@ -1988,16 +1988,16 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * </p>
      * 
      * @param ctx the {@link GeneratorContext} containing the resource pools.
-     * @since 2025.07.22 - Task Self-Recycling
-     * @threading Thread-safe due to ForkJoinTask isolation and local context access.
-     * @performance O(1) for returning resources to the pools.
-     * @optimization Avoids ThreadLocal access by using passed-in context, reuses existing pools.
      * @see #context
      * @see ArrayPool
      * @see ArrayPool#put(short[])
      * @see GeneratorContext
      * @see TaskPool
      * @see TaskPool#put(CombinationGeneratorTask)
+     * @since 2025.07.22 - Task Self-Recycling
+     * @performance O(1) for returning resources to the pools.
+     * @threading Thread-safe due to ForkJoinTask isolation and local context access.
+     * @optimization Avoids ThreadLocal access by using passed-in context, reuses existing pools.
      */
     private void recycleOwnResources(GeneratorContext ctx) {
         // No ThreadLocal access needed - use passed context
@@ -2039,18 +2039,18 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @param queueArray the {@link CombinationQueueArray} containing the {@link CombinationQueue
      *                   queues} to flush to.
      * @param pool       the {@link ForkJoinPool} to submit the flushing task to.
-     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
-     * @threading Thread-safe due to local context access and atomic operations in
-     *            {@link CombinationQueue#add(WorkBatch)}.
-     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues
-     *              are full.
-     * @optimization Uses ForkJoinPool to leverage worker threads, checks for solution found or pool
-     *               shutdown to avoid unnecessary work.
      * @see #context
      * @see #flushBatchHelper(WorkBatch, CombinationQueueArray, boolean, boolean)
-     * @see GeneratorContext#resetBatch()
      * @see CombinationQueueArray
+     * @see GeneratorContext#resetBatch()
      * @see WorkBatch
+     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
+     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues
+     *              are full.
+     * @threading Thread-safe due to local context access and atomic operations in
+     *            {@link CombinationQueue#add(WorkBatch)}.
+     * @optimization Uses ForkJoinPool to leverage worker threads, checks for solution found or pool
+     *               shutdown to avoid unnecessary work.
      */
     public static void flushAllPendingBatches(CombinationQueueArray queueArray, ForkJoinPool pool) {
         if (queueArray.solutionFound || pool.isShutdown()) return;
@@ -2114,14 +2114,14 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @param forceFlush On a failed attempt to flush, whether to sleep and retry or return <code>false</code>.
      * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
      *         was interrupted or if not forcing a flush and all queues were full.
-     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
-     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
-     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full and forcing a flush.
-     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting when forcing a flush.
      * @see CombinationQueueArray#getAllQueues()
      * @see java.util.concurrent.ThreadLocalRandom
      * @see java.util.concurrent.ThreadLocalRandom#current()
      * @see java.util.concurrent.ThreadLocalRandom#nextInt(int)
+     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
+     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full and forcing a flush.
+     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
+     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting when forcing a flush.
      */
     private static boolean flushBatchHelper(WorkBatch batch, CombinationQueueArray queueArray, boolean checkCancellation, boolean forceFlush) {
         CombinationQueue[] queues = queueArray.getAllQueues();

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -83,7 +83,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * </ul>
  * </p>
  * 
- * <h3>30/36 - ~83.3% of documentation completed (excluding GeneratorContext)</h3>
+ * <h3>35/36 - ~97.2% of documentation completed (excluding GeneratorContext)</h3>
  * 
  * @since 2025.06.08 - Fork Join Refactor
  * @algorithm Creates a tree of tasks, where each task represents a prefix of clicks. The root task
@@ -270,8 +270,6 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * with larger pools reducing contention but increasing memory usage.
      * </p>
      * 
-     * <h3>6/7 - ~85.7% of documentation completed</h3>
-     * 
      * @since 2025.07.26 - GeneratorContext Introduction
      * @performance O(1) access time for pool operations.
      * @memory Minimal memory footprint as a wrapper class, with pooled resources to minimize
@@ -372,10 +370,8 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * @see WorkBatch
          * @see CombinationGeneratorTask#context
          */
-        WorkBatch getOrCreateBatch()
-        {
-            if (currentBatch == null)
-            {
+        WorkBatch getOrCreateBatch() {
+            if (currentBatch == null) {
                 currentBatch = getNewBatchBlocking();
             }
             return currentBatch;
@@ -423,20 +419,34 @@ public class CombinationGeneratorTask extends RecursiveAction {
          * @see CombinationQueueArray
          * @see WorkBatch
          */
-        private WorkBatch getNewBatchBlocking()
-        {
+        private WorkBatch getNewBatchBlocking() {
             WorkBatch batch;
-            while ((batch = queueArray.getWorkBatchPool().relaxedPoll()) == null)
-            {
+            while ((batch = queueArray.getWorkBatchPool().relaxedPoll()) == null) {
                 // NOTE: Thread.onSpinWait() can not be used here since it doesn't respond to cancellation.
             }
             batch.clear(); // Ensure the recycled batch is clean before use
             return batch;
         }
 
-        // Handle the flushing of the current batch
-        WorkBatch resetBatch()
-        {
+        /**
+         * Resets the {@link #currentBatch current <code>WorkBatch</code>} by obtaining a new one from the pool.
+         * 
+         * <p>
+         * After a batch has been filled and flushed to the queue, we need to obtain a new batch to continue
+         * the generation process. This method performs that operation, obtaining a new batch from the pool
+         * and setting it as the current batch. The old batch should not be referenced after this call, as
+         * it may be recycled and used by another thread.
+         * </p>
+         * 
+         * @return The new current <code>WorkBatch</code>, guaranteed to be non-null.
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread safety.
+         * @performance O(1) amortized access time, blocking if necessary.
+         * @optimization Combines batch reset and retrieval into a single operation to reduce overhead.
+         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @see #getNewBatchBlocking()
+         */
+        WorkBatch resetBatch() {
             return currentBatch = getNewBatchBlocking();
         }
     }
@@ -560,17 +570,20 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * The current length of the {@link #prefix} array, representing the number of clicks made so far.
      * 
      * <p>
-     * Since we use pre-allocated, {@link ArrayPool pooled} arrays to store the prefix of clicks, we need a way to track the
-     * current length of the <code>prefix</code> array, as it may not be fully filled. This field serves that purpose, allowing us to
-     * keep track of how many clicks have been made so far and where to add the next click.
+     * Since we use pre-allocated, {@link ArrayPool pooled} arrays to store the prefix of clicks, we
+     * need a way to track the current length of the <code>prefix</code> array, as it may not be fully
+     * filled. This field serves that purpose, allowing us to keep track of how many clicks have been
+     * made so far and where to add the next click.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Using a separate field to track the length of the prefix allows for efficient addition of new clicks, as we can simply
-     * add the new click at the current length index and increment the length. This avoids the need to resize or copy the array,
-     * which would be expensive and could lead to excessive allocations and deallocations. It also simplifies the logic for determining
-     * whether a task is a leaf, root, or intermediate task, as we can simply compare the length to the {@link #numClicks} field.
+     * Using a separate field to track the length of the prefix allows for efficient addition of new
+     * clicks, as we can simply add the new click at the current length index and increment the length.
+     * This avoids the need to resize or copy the array, which would be expensive and could lead to
+     * excessive allocations and deallocations. It also simplifies the logic for determining whether a
+     * task is a leaf, root, or intermediate task, as we can simply compare the length to the
+     * {@link #numClicks} field.
      * </p>
      * 
      * @since 2025.06.08 - Fork Join Refactor
@@ -689,7 +702,8 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @threading Computed once in the root task and reused across all subtasks.
      * @performance O(1) for checks, O(1) for initial computation in the root task.
      * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
-     * @memory Uses a long to represent the target state, which is efficient for up to 64 initially true cells.
+     * @memory Uses a long to represent the target state, which is efficient for up to 64 initially true
+     *         cells.
      * @see #cachedAdjacencyState
      * @see #SUFFIX_OR_MASKS
      * @see #ensureTrueCellMasks(short[])
@@ -700,20 +714,20 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * The {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
      * 
      * <p>
-     * Since our code already leverages the fork-join framework for parallelism, we can skip
-     * explicit cancellation checks in the hot path by placing the responsibility of task
-     * cancellation on the pool itself, signaled by a {@link TestClickCombination monkey} when it
-     * finds a solution. For monkeys to be able to signal cancellation, however, they need
-     * access to the pool, which we provide via this static field.
+     * Since our code already leverages the fork-join framework for parallelism, we can skip explicit
+     * cancellation checks in the hot path by placing the responsibility of task cancellation on the
+     * pool itself, signaled by a {@link TestClickCombination monkey} when it finds a solution. For
+     * monkeys to be able to signal cancellation, however, they need access to the pool, which we
+     * provide via this static field.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Using a static field for the pool allows for quick and easy access from any task or
-     * monkey, without the need to pass references around or use ThreadLocals. This reduces
-     * overhead and simplifies the code, making it easier to maintain and understand. The volatile
-     * keyword ensures that changes to the pool reference are visible across threads, though the pool
-     * is best set once at the start of generation and left constant thereafter.
+     * Using a static field for the pool allows for quick and easy access from any task or monkey,
+     * without the need to pass references around or use ThreadLocals. This reduces overhead and
+     * simplifies the code, making it easier to maintain and understand. The volatile keyword ensures
+     * that changes to the pool reference are visible across threads, though the pool is best set once
+     * at the start of generation and left constant thereafter.
      * </p>
      * 
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
@@ -724,38 +738,112 @@ public class CombinationGeneratorTask extends RecursiveAction {
      */
     private static volatile ForkJoinPool generatorPool;
 
-    public static void setForkJoinPool(ForkJoinPool pool)
-    {
+    /**
+     * Sets the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
+     * 
+     * <p>
+     * This method is used to set the static {@link #generatorPool pool} field, allowing
+     * {@link TestClickCombination monkeys} to signal cancellation when they find a solution. The pool
+     * is best set once at the start of generation and left constant thereafter, as changing it
+     * mid-generation could lead to inconsistent behavior.
+     * </p>
+     * 
+     * @param pool the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} to use for executing
+     *             generator tasks.
+     * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
+     * @threading Thread-safe due to the use of a volatile static field, though this method should be
+     *            called by one thread only.
+     * @performance O(1) assignment.
+     * @optimization Static field for quick access without passing references.
+     * @memory Minimal memory usage as a single reference.
+     * @see TestClickCombination#triggerGeneratorShutdown()
+     */
+    public static void setForkJoinPool(ForkJoinPool pool) {
         CombinationGeneratorTask.generatorPool = pool;
     }
 
-    public static ForkJoinPool getForkJoinPool()
-    {
+    /**
+     * Gets the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
+     * 
+     * <p>
+     * This method provides access to the static {@link #generatorPool pool} field, allowing
+     * {@link TestClickCombination monkeys} to signal cancellation when they find a solution.
+     * </p>
+     * 
+     * @return the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used for executing
+     *         generator tasks.
+     * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
+     * @threading Thread-safe due to the use of a volatile static field.
+     * @performance O(1) access time.
+     * @optimization Static field for quick access without passing references.
+     * @memory Only gets a reference, so minimal memory usage.
+     * @see TestClickCombination#triggerGeneratorShutdown()
+     */
+    public static ForkJoinPool getForkJoinPool() {
         return generatorPool;
     }
 
     // Root task constructor
-    public CombinationGeneratorTask(int numClicks, CombinationQueueArray queueArray,
-                                   short[] trueCells, int maxFirstClickIndex)
-    {
+    /**
+     * Constructs a new root task with the specified parameters. The root task is expected to be a
+     * singleton, as it initializes static fields used by all subtasks, but we do not enforce this
+     * restriction in code.
+     * 
+     * <p>
+     * The root task initializes static fields that are shared across all tasks, such as the
+     * {@link #numClicks number of clicks}, the {@link #queueArray queue array}, and the
+     * {@link #maxFirstClickIndex maximum first click index}. It also initializes instance fields like
+     * the {@link #prefix prefix array} and {@link #prefixLength prefix length} for the root task (with
+     * the prefix length taking a value of 0). The root task also pre-computes the {@link #targetMask
+     * target mask} for {@link #canPotentiallySatisfyConstraints(int) constraint checks} and the
+     * {@link #FIRST_TRUE_ADJACENTS first true adjacency mask} for the
+     * {@link #computeLeafCombinations(GeneratorContext) odd adjacency check}.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since the root task is only created once per puzzle, we can afford to perform some expensive
+     * initialization operations here without impacting overall performance. Pre-computing masks and
+     * initializing static fields helps reduce overhead during the generation process, allowing subtasks
+     * to focus on generating combinations efficiently. The use of pooled arrays for the prefix helps
+     * minimize allocations and deallocations, reducing garbage collection pressure and improving
+     * throughput.
+     * </p>
+     * 
+     * @param numClicks          the number of clicks in each combination.
+     * @param queueArray         the {@link CombinationQueueArray} to which generated combinations will
+     *                           be flushed.
+     * @param trueCells          an array of initially true cells in {@link Grid.ValueFormat#Index
+     *                           Index} format.
+     * @param maxFirstClickIndex the maximum index for the first click in a combination.
+     * @throws IllegalArgumentException if any of the parameters are invalid (<code>null</code> or out
+     *                                  of range).
+     * @since 2025.06.08 - Fork Join Refactor
+     * @threading Thread-safe due to ForkJoinTask isolation. Static fields are initialized in the root
+     *            task before any subtasks are created.
+     * @performance O(n) for initialization where n is the number of initially true cells, amortized
+     *              over the entire generation process.
+     * @optimization Pre-computes masks and initializes static fields to reduce overhead during
+     *               generation. Uses pooled arrays for the prefix to minimize allocations.
+     * @memory Uses pooled arrays for the prefix to reduce memory usage. Static fields are minimal in
+     *         size.
+     */
+    public CombinationGeneratorTask(int numClicks, CombinationQueueArray queueArray, short[] trueCells,
+            int maxFirstClickIndex) {
         // Check for valid inputs
-        if (numClicks <= 0 || numClicks > Grid.NUM_CELLS)
-        {
+        if (numClicks <= 0 || numClicks > Grid.NUM_CELLS) {
             throw new IllegalArgumentException("Invalid number of clicks: " + numClicks);
         }
 
-        if (queueArray == null)
-        {
+        if (queueArray == null) {
             throw new IllegalArgumentException("Queue array must not be null.");
         }
 
-        if (trueCells == null || trueCells.length == 0)
-        {
+        if (trueCells == null || trueCells.length == 0) {
             throw new IllegalArgumentException("True cells must be initialized before generating combinations.");
         }
 
-        if (maxFirstClickIndex < 0 || maxFirstClickIndex >= Grid.NUM_CELLS)
-        {
+        if (maxFirstClickIndex < 0 || maxFirstClickIndex >= Grid.NUM_CELLS) {
             throw new IllegalArgumentException("Invalid max first click index: " + maxFirstClickIndex);
         }
 
@@ -768,8 +856,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
         
         // Initialize the instance fields
         this.prefix = context.get().prefixArrayPool.get(); // FIX: Get the initial empty prefix from the thread-local context to avoid allocation.
-        if (this.prefix == null)
-        {
+        if (this.prefix == null) {
             this.prefix = new short[numClicks]; // Safeguard if pool is empty (though it shouldn't be)
         }
         this.prefixLength = 0;
@@ -871,7 +958,25 @@ public class CombinationGeneratorTask extends RecursiveAction {
         FIRST_TRUE_ADJACENTS = mask;
     }
 
-    public CombinationGeneratorTask() {}
+    /**
+     * Constructs a new non-root task with the specified parameters.
+     * 
+     * <p>
+     * The golden rule of JVM optimizations is <b>don't allocate.</b> Since tasks are pre-allocated by
+     * {@link TaskPool} and reused, we designate this constructor as <code>protected</code> to prevent
+     * external code from calling it and potentially causing allocations. Instead, external code must
+     * obtain tasks from the pool via {@link TaskPool#get()} and assign their instance fields through
+     * the {@link #init(short[], int, long, boolean) init()} method.
+     * </p>
+     * 
+     * @since 2025.07.11 - Task Pool Introduction
+     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
+     * @performance O(1) access time, since no allocations or operations are performed.
+     * @optimization Protected to prevent external allocations, enforcing the use of the task pool.
+     * @memory No memory usage, as no allocations are performed.
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     */
+    protected CombinationGeneratorTask() {}
 
     /**
      * The main task dispatcher method, as required by the {@link java.util.concurrent.ForkJoinTask}
@@ -1154,8 +1259,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see GeneratorContext#getOrCreateBatch()
      * 
      */
-    private final void computeLeafCombinations(GeneratorContext ctx)
-    {
+    private final void computeLeafCombinations(GeneratorContext ctx){
         // ULTRA-OPTIMIZED: Pre-compute all loop-invariant values and cache array references
         final int start = prefix[prefixLength - 1] + 1;
         final int pLen = prefixLength;
@@ -1208,7 +1312,6 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
     }
     
-    // PURE HOT PATH SEPARATION: Dispatch once per task, not per loop iteration
     /**
      * Dispatches to the appropriate subtask computation method based on the
      * {@link #skipConstraintsCheck constraint check flag}. This method is called by {@link #compute()}
@@ -1264,7 +1367,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
     }
     
-    // PURE HOT PATH 1: Zero branches, zero conditionals - for descendants of constraint-satisfied tasks
+    // PURE HOT PATH 1:
     /**
      * Computes and forks subtasks for the next clicks, skipping constraint checks.
      * 
@@ -1336,7 +1439,7 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
     }
     
-    // PURE HOT PATH 2: Zero branches in loop, pure constraint logic
+    // PURE HOT PATH 2:
     /**
      * Computes and forks subtasks for the next clicks, performing checks to prune invalid paths early.
      * 
@@ -1603,7 +1706,31 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see Grid#findAdjacents(short cell)
      */
     private static long[] SUFFIX_OR_MASKS = null;
-    private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix(); // Stored in index format
+    /**
+     * Adjacency matrix representing which cells are adjacent to each other. Used for initializing
+     * {@link #TRUE_CELL_ADJACENCY_MASKS}.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This matrix is technically only used for the initialization of
+     * {@link #TRUE_CELL_ADJACENCY_MASKS}, meaning that it could be replaced by direct calls to
+     * {@link Grid#findAdjacents(short, Grid.ValueFormat)} (or the creation of a method to expose the
+     * cache behind {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}), though we've kept it
+     * since this field pre-dates the creation of the bitmasked Grid state.
+     * </p>
+     * 
+     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @threading Statically initialized once at class load time.
+     * @performance O(1) for adjacency checks, O(n^2) for initial computation where n is the number of
+     *              cells in the grid.
+     * @memory Fixed-size boolean matrix of size n x n, where n is the number of cells in the grid. This
+     *         guarantees a fixed memory footprint and avoids object overhead.
+     * @optimization Pre-computed once at class load time to avoid recomputation, uses boolean matrix
+     *               for efficient adjacency representation.
+     * @see #initClickAdjacencyMatrix()
+     * @see Grid#findAdjacents(short, Grid.ValueFormat)
+     */
+    private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix();
 
     // This method is used to initialize the click adjacency matrix, and is static
     /**

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -4,6 +4,29 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * [Class Name] - [Worker Purpose - e.g., "ForkJoin recursive combination generator"]
+ * 
+ * <p>[High-level description of what this worker does in the algorithm.
+ * Explain its role in the concurrent processing pipeline.]</p>
+ * 
+ * <h2>Execution Model</h2>
+ * <p>[How this task executes - recursive subdivision, work-stealing, etc.
+ * Include task granularity and splitting criteria.]</p>
+ * 
+ * <h2>Resource Management</h2>
+ * <p>[How resources are acquired, used, and cleaned up. Pool usage patterns.]</p>
+ * 
+ * <h2>Performance Critical Paths</h2>
+ * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
+ * 
+ * <h3>0/37 - 0% of documentation completed (excluding GeneratorContext)</h3>
+ * 
+ * @algorithm [Detailed algorithm description with complexity analysis]
+ * @threading [Concurrency model and synchronization approach]
+ * @performance [Performance characteristics and bottleneck analysis]
+ * @see [Related worker classes and coordination mechanisms]
+ */
 public class CombinationGeneratorTask extends RecursiveAction
 {
     public static final int BATCH_SIZE = 8000; // The maximum size of a batch before it is flushed to the queue. Batches will try to be flushed when they reach the FLUSH_THRESHOLD, but will always be flushed when they reach this size.
@@ -11,6 +34,31 @@ public class CombinationGeneratorTask extends RecursiveAction
     private static final int POOL_SIZE = 2048; // Reduced since we're using more efficient pools
 
     // REPLACE: Multiple ThreadLocals with single context
+    /**
+     * GeneratorContext - [Performance Purpose - e.g., "High-performance memory pool"]
+     * 
+     * <h1>P0 - Core Architecture</h1>
+     * 
+     * <p>[Detailed description of the performance problem this class solves.
+     * Include before/after metrics where applicable.]</p>
+     * 
+     * <h2>Optimization Strategy</h2>
+     * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
+     * Explain trade-offs made for performance gains.]</p>
+     * 
+     * <h2>Usage Patterns</h2>
+     * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+     * 
+     * <h2>Memory Management</h2>
+     * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+     * 
+     * <h3>0/6 - 0% of documentation completed</h3>
+     * 
+     * @performance [Specific performance characteristics and measurements]
+     * @memory [Memory usage patterns and optimizations]
+     * @threading [Thread safety model]
+     * @since [When introduced and why]
+     */
     private static final ThreadLocal<GeneratorContext> context =
         ThreadLocal.withInitial(GeneratorContext::new);
 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * <h2>Performance Critical Paths</h2>
  * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
  * 
- * <h3>8/36 - ~22% of documentation completed (excluding GeneratorContext)</h3>
+ * <h3>15/36 - ~41.7% of documentation completed (excluding GeneratorContext)</h3>
  * 
  * @algorithm [Detailed algorithm description with complexity analysis]
  * @threading [Concurrency model and synchronization approach]
@@ -179,7 +179,7 @@ public class CombinationGeneratorTask extends RecursiveAction
      * [Memory allocation patterns, GC implications, sizing considerations.]
      * </p>
      * 
-     * <h3>1/7 - ~15% of documentation completed</h3>
+     * <h3>3/7 - ~42.9% of documentation completed</h3>
      * 
      * @performance [Specific performance characteristics and measurements]
      * @memory [Memory usage patterns and optimizations]
@@ -222,6 +222,33 @@ public class CombinationGeneratorTask extends RecursiveAction
          */
         WorkBatch currentBatch = null;
 
+        /**
+         * Gets the {@link #currentBatch current <code>WorkBatch</code>}, obtaining a new one if necessary.
+         * 
+         * <p>
+         * We need to ensure that we always have a valid <code>{@link WorkBatch}</code> to add combinations
+         * to. If the current batch is null (either because it hasn't been created yet or because it was
+         * flushed), we need some mechanism to "create" a new one. This method serves that purpose,
+         * performing a simple null check and creating a new batch if necessary.
+         * </p>
+         * 
+         * <h3>Performance Considerations</h3>
+         * <p>
+         * This method is designed to be fast and efficient, as it is called frequently during the
+         * combination generation process. The null check is a simple and quick operation, and creating a
+         * new batch is also efficient due to the use of a pool.
+         * </p>
+         * 
+         * @return The current <code>{@link WorkBatch}</code>, guaranteed to be non-null.
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
+         *            safety.
+         * @performance O(1) null check and access time.
+         * @optimization Caches current batch to avoid redundant allocations or pool calls.
+         * @see #getNewBatchBlocking()
+         * @see WorkBatch
+         * @see CombinationGeneratorTask#context
+         */
         WorkBatch getOrCreateBatch()
         {
             if (currentBatch == null)
@@ -231,8 +258,48 @@ public class CombinationGeneratorTask extends RecursiveAction
             return currentBatch;
         }
 
-        // OPTIMIZATION: This is now a blocking call. It will wait until a batch is
-        // available, creating backpressure on the producers instead of allocating.
+        /**
+         * Obtains a new <code>{@link WorkBatch}</code> from {@link CombinationQueueArray#getWorkBatchPool()
+         * the pool}, blocking if necessary until one is available.
+         * 
+         * <p>
+         * After all the combinations in a batch have been processed, the batch is recycled into a separate
+         * queue for reuse. This method retrieves a batch from that queue, blocking if necessary until one
+         * is available. Since batches have pre-allocated buffers for combinations, we need to ensure that
+         * the batches themselves are recycled to avoid excessive allocations and deallocations on the hot
+         * path. This method serves that purpose, providing a way to obtain a new batch in a blocking manner
+         * from the queue.
+         * </p>
+         * 
+         * <h3>Performance Considerations</h3>
+         * <p>
+         * This method is internally used often during the generation process, so it needs to be fast and
+         * efficient while maintaining thread safety and allowing for signaling. Crucially, we need to
+         * ensure that the method can be exited if the task is cancelled, which is why we use a while loop
+         * with a {@link org.jctools.queues.MpmcArrayQueue#relaxedPoll() relaxed poll} instead of a blocking
+         * poll method to avoid deadlocks at the cost of busy-waiting. Crucially, we avoid calling
+         * {@link Thread#onSpinWait()} in the loop since it does not respond to cancellation (for some
+         * reason, at least in my testing).
+         * </p>
+         * 
+         * <p>
+         * An improvement could implement some form of {@link ForkJoinPool.ManagedBlocker} to allow other
+         * threads to make progress working on non-leaf tasks while this is blocked, but that would add a
+         * lot of complexity and potentially create concerns regarding the creation of extra contexts for
+         * additional threads. For now, we leave this as a simple busy-wait loop.
+         * </p>
+         * 
+         * @return A new <code>WorkBatch</code>, guaranteed to be non-null.
+         * @since 2025.07.26 - GeneratorContext Introduction
+         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
+         *           safety.
+         * @performance O(1) amortized access time, blocking if necessary.
+         * @optimization Uses a busy-wait loop with relaxed polling to avoid deadlocks and allow for cancellation.
+         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
+         * @see CombinationQueueArray#getWorkBatchPool()
+         * @see CombinationQueueArray
+         * @see WorkBatch
+         */
         private WorkBatch getNewBatchBlocking()
         {
             WorkBatch batch;
@@ -459,9 +526,59 @@ public class CombinationGeneratorTask extends RecursiveAction
 
     public CombinationGeneratorTask() {}
 
+    /**
+     * The main task dispatcher method, as required by the {@link java.util.concurrent.ForkJoinTask}
+     * framework.
+     * 
+     * <p>
+     * The ForkJoinPool framework requires that we implement the {@link RecursiveAction#compute()}
+     * method to define the task's execution logic. Per the framework's design, we want to break
+     * combinations into subtasks and recursively process them in parallel. Depending on the
+     * {@link #prefixLength}, we need to determine which path to take:
+     * <ul>
+     * <li><code>prefixLength == 0</code>: This is the root task, which will
+     * {@link #computeRootSubtasks(GeneratorContext) compute and fork subtasks for the first clicks} and
+     * await their completion.</li>
+     * <li><code>prefixLength == {@link #numClicks} - 1</code>: This is a leaf task, which will
+     * {@link #computeLeafCombinations(GeneratorContext) compute the combinations for the last click} and
+     * add them to a {@link WorkBatch} for processing.</li>
+     * <li><code>0 &lt; prefixLength &lt; numClicks - 1</code>: This is an intermediate task, which will
+     * {@link #computeIntermediateSubtasks(GeneratorContext) compute and fork subtasks} for the next
+     * clicks.</li>
+     * </ul>
+     * </p>
+     * 
+     * <p>
+     * The method also contains logic for recycling resources and cleaning up after itself, ensuring
+     * that memory is managed efficiently and that resources are returned to the appropriate pools.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Creating multiple paths for different task types allows us to optimize the execution flow,
+     * letting the JVM handle optimizations for each path separately. This reduces the number of
+     * branches and conditionals in the hot paths, granting more readable code and allowing the JIT
+     * compiler to optimize them more effectively.
+     * </p>
+     * 
+     * <p>
+     * We also minimize the number of {@link ThreadLocal} accesses by passing down the context directly
+     * to methods, which reduces the overhead of accessing <code>ThreadLocal</code> variables. The
+     * bundled context object allows us to access all necessary resources with only one expensive call
+     * per task, something that can be amortized over the entire task's execution.
+     * </p>
+     * 
+     * @since 2025.06.08 - Work-stealing introduction
+     * @threading Isolated by the ForkJoinTask framework, each task runs in its own thread.
+     * @performance O(1) access time for ThreadLocal context, O(1) for dispatching.
+     * @optimization Multiple paths for different task types to reduce branches and conditionals.
+     * @memory Memory usage is minimized by recycling resources and using pools.
+     * @see #recycleOwnResources(GeneratorContext)
+     * @see GeneratorContext
+     * @see ThreadLocal#get()
+     */
     @Override
-    protected void compute()
-    {
+    protected void compute() {
         // Single ThreadLocal access per task - pass context down to all methods
         final GeneratorContext ctx = context.get();
         
@@ -529,7 +646,80 @@ public class CombinationGeneratorTask extends RecursiveAction
     }
 
     // LEAF TASK PATH:
-    // Compute combinations for the leaf task
+    /**
+     * Computes all valid combinations for the leaf task and adds to
+     * {@link GeneratorContext#currentBatch the current batch}. If the batch is full, it is
+     * {@link #flushBatchFast(WorkBatch) flushed} and replaced.
+     * 
+     * <p>
+     * In a leaf task, the prefix is at its maximum length, and we need to compute all valid
+     * combinations stemming from it. At this point, our tasks are at the optimal size for direct
+     * computation, and we can start checking them for validity. We do this by iterating over all
+     * possible next clicks, observing to see if they satisfy the parity condition for the first true
+     * cell (ensuring that there are an odd number of toggles of the first true cell) and adding them to
+     * the current batch.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * Before iterating over the possible next clicks, we have to compute the parity of the prefix. We
+     * do this by iterating over the prefix and checking if the current cell is adjacent to the first
+     * true cell. If it is, we toggle the boolean parity variable. After we finish iterating, the parity
+     * variable will be in one of two states:
+     * </p>
+     * 
+     * <ul>
+     * <li><code><b>true</b></code>: The prefix has an odd number of toggles of the first true cell (we
+     * need to ensure that the final click doesn't toggle the first true cell)</li>
+     * <li><code><b>false</b></code>: The prefix has an even number of toggles of the first true cell
+     * (we need to ensure that the final click toggles the first true cell)</li>
+     * </ul>
+     * 
+     * <p>
+     * The parity of the final click must be the opposite of the prefix parity to ensure that the first
+     * true cell is toggled correctly. Therefore, we iterate over all possible next clicks and check if
+     * the click's adjacency to the first true cell matches the prefix parity. If it doesn't, then we
+     * add it to the current batch, flushing the batch if full.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is highly optimized for the hot path of the combination generation process. Our goal
+     * is to minimize branching and conditionals, allowing the JIT compiler to perform aggressive
+     * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
+     * calculations and array dereferences. Originally, there was a separate method for performing the
+     * quick parity check, but this was manually inlined into this method to flatten the call stack and
+     * reduce redundant cache lookups.
+     * </p>
+     * 
+     * <p>
+     * Leaf-level pruning checks are a nuanced matter, as late-stage pruning cannot be amortized over
+     * multiple descendants. If a task makes it to this level, all of its descendant combinations will
+     * be tested, incurring a conditional check for every single one of them. However, the removal of
+     * this check would cause a performance regression from an increased number of queue operations (and
+     * an increase in non-viable combinations that each monkey would have to test). For now, we've kept
+     * this check in place, but it may be removed or lessened in the future. A potential idea is to take
+     * the approach of {@link #cachedAdjacencyState} and perform the parity checks on each task to
+     * divide the cost of the check across tasks. Another route would be to skip the parity check
+     * altogether if the prefix is known to satisfy the constraints, but that would add branching to the
+     * method, which we want to avoid in the hot path.
+     * </p>
+     * 
+     * @param ctx - the {@link GeneratorContext} containing the current batch and resource pools.
+     * @since 2025.07.03 - Splitting the Compute Method Into Paths
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O({@link #prefixLength}) for prefix parity computation,
+     *              O(<code>{@link Grid#NUM_CELLS} - {@link #prefix}[prefixLength - 1]</code>) for
+     *              iterating over possible next clicks.
+     * @algorithm Iterates over the prefix to compute parity, then iterates over possible next clicks to
+     *            find valid combinations based on the computed parity.
+     * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
+     *               tight loop with minimal branching to allow for aggressive JIT optimizations.
+     * @see #flushBatchFast(WorkBatch)
+     * @see #FIRST_TRUE_ADJACENTS
+     * @see GeneratorContext#getOrCreateBatch()
+     * 
+     */
     private final void computeLeafCombinations(GeneratorContext ctx)
     {
         // ULTRA-OPTIMIZED: Pre-compute all loop-invariant values and cache array references
@@ -545,11 +735,13 @@ public class CombinationGeneratorTask extends RecursiveAction
         // OPTIMIZED: Compute prefix parity with cached mask values
         // TODO: Consider tracking prefix parity per task and passing down the values to avoid recomputing and to condense this method
         boolean prefixParity = false; // Track parity of the prefix
-        for (int j = 0; j < pLen; j++)
+        for (int j = 0; j < pLen; j++) // For each cell in the prefix
         {
             final int c = prefix[j];
-            final long maskValue = (c < 64) ? mask0 : mask1;
-            final int bitPos = c & 63;
+            final long maskValue = (c < 64) ? mask0 : mask1; // Find the mask the cell belongs to
+            final int bitPos = c & 63; // Find the bit position within the mask
+
+            // Check if the cell exists within the mask (if it toggles the first true cell)
             if ((maskValue & (1L << bitPos)) != 0)
             {
                 prefixParity ^= true; // Toggle parity (XOR with true is the same as toggling)
@@ -575,8 +767,7 @@ public class CombinationGeneratorTask extends RecursiveAction
             {
                 if (flushBatchFast(batch))
                 {
-                    ctx.resetBatch();
-                    batch = ctx.currentBatch;
+                    batch = ctx.resetBatch();
                     batch.add(prefix, pLen, (short) i);
                 }
             }
@@ -594,6 +785,53 @@ public class CombinationGeneratorTask extends RecursiveAction
     }
     
     // PURE HOT PATH 1: Zero branches, zero conditionals - for descendants of constraint-satisfied tasks
+    /**
+     * Computes and forks subtasks for the next clicks, skipping constraint checks.
+     * 
+     * <p>
+     * In the fork-join architecture, tasks that are too large to be directly computed are split into
+     * smaller subtasks that can be processed in parallel. In our program, these are non-leaf tasks
+     * (tasks where the {@link #prefixLength} is less than <code>{@link #numClicks} - 1</code>). This
+     * method computes the next clicks for the current prefix and forks subtasks for each valid next
+     * click.
+     * </p>
+     * 
+     * <p>
+     * This form of the method is specifically for tasks where the prefix is already known to satisfy
+     * the constraints, allowing us to skip constraint checks for all descendants. This simplifies the
+     * loop significantly, increasing the likelihood of JIT optimizations and reducing the overall
+     * footprint of the method.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is optimized for the hot path of the combination generation process. Our goal is to
+     * minimize branching and conditionals, allowing the JIT compiler to perform aggressive
+     * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
+     * calculations and array dereferences. Since this method is only called when
+     * {@link #skipConstraintsCheck} is true, we can avoid the early constraint check to further reduce
+     * the footprint.
+     * </p>
+     * 
+     * <p>
+     * We could consider removing the array allocation safeguard and assume that the array pool will
+     * always return a non-null array. This would allow us to remove the null check and the array
+     * allocation in the loop at the cost of having to ensure that the array pool is properly sized at
+     * initialization. Since we already do this anyways, it may be worth exploring to simplify the code
+     * and make it smaller for better JIT optimization.
+     * </p>
+     * 
+     * @param ctx - the {@link GeneratorContext} containing the current batch and resource pools.
+     * @since 2025.08.04 - Specialized Subtask Paths
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} - 
+     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
+     *              clicks.
+     * @optimization Removes constraint check branching, caches loop-invariant values, and uses a tight
+     *               loop with minimal branching to allow for aggressive JIT optimizations.
+     * @see #skipConstraintsCheck
+     * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
+     */
     private void computeIntermediateSubtasksSkipPath(GeneratorContext ctx)
     {
         final short start = (short) (prefix[prefixLength - 1] + 1);
@@ -620,6 +858,59 @@ public class CombinationGeneratorTask extends RecursiveAction
     }
     
     // PURE HOT PATH 2: Zero branches in loop, pure constraint logic
+    /**
+     * Computes and forks subtasks for the next clicks, performing checks to prune invalid paths early.
+     * 
+     * <p>
+     * In the fork-join architecture, tasks that are too large to be directly computed are split into
+     * smaller subtasks that can be processed in parallel. In our program, these are non-leaf tasks
+     * (tasks where the {@link #prefixLength} is less than <code>{@link #numClicks} - 1</code>). This
+     * method computes the next clicks for the current prefix and forks subtasks for each valid next
+     * click.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is optimized for the hot path of the combination generation process. Our goal is to
+     * minimize branching and conditionals, allowing the JIT compiler to perform aggressive
+     * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
+     * calculations and array dereferences. In this method, we also perform an early constraint check
+     * before loop entry to ensure the validity of the current prefix. We make sure to propagate the
+     * parent's {@link #skipConstraintsCheck} flag to the children to allow them to skip checks if the
+     * prefix is already known to satisfy constraints.
+     * </p>
+     * 
+     * <p>
+     * As part of the optimization to minimize conditionals, we calculate the child adjacency state
+     * every time in this method, even if the constraint check finds that the prefix directly satisfies
+     * the constraints. While this does avoid branching in the loop, it adds an unnecessary XOR
+     * operation. It may be worth considering an optimization where we check the
+     * {@link #skipConstraintsCheck} flag after performing the early check and execute
+     * {@link #computeIntermediateSubtasksSkipPath(GeneratorContext)} if the flag is set, but this may
+     * add additional method complexity.
+     * </p>
+     * 
+     * <p>
+     * In a different vein, we could consider removing the array allocation safeguard and assume that
+     * the array pool will always return a non-null array. This would allow us to remove the null check
+     * and the array allocation in the loop at the cost of having to ensure that the array pool is
+     * properly sized at initialization. Since we already do this anyways, it may be worth exploring to
+     * simplify the code and make it smaller for better JIT optimization.
+     * </p>
+     * 
+     * @param ctx - the {@link GeneratorContext} containing the current batch and resource pools.
+     * @since 2025.08.04 - Specialized Subtask Paths
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(1) for the early constraint check,
+     *              O(<code>{@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} - 
+     *              {@link #prefix}[prefixLength - 1] + 1</code>) for iterating over possible next
+     *              clicks.
+     * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
+     *               tight loop with minimal branching to allow for aggressive JIT optimizations.
+     * @see #canPotentiallySatisfyConstraints(int)
+     * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
+     * @see #ensureTrueCellMasks(short[])
+     */
     private void computeIntermediateSubtasksConstraintPath(GeneratorContext ctx)
     {
         final short start = (short) (prefix[prefixLength - 1] + 1);
@@ -639,7 +930,7 @@ public class CombinationGeneratorTask extends RecursiveAction
         final boolean skipConstraints = this.skipConstraintsCheck; // Cache field read
         
         // Pure loop - no conditionals inside, all branching resolved outside loop
-        for (short i = start; i < max; i++)
+        for (short i = start; i < max; i++) // loops from prefix[prefixLength - 1] + 1 to Grid.NUM_CELLS - (numClicks - prefixLength) + 1
         {
             short[] newPrefix = prefixPool.get();
             if (newPrefix == null) newPrefix = new short[numClicks]; // Safeguard if pool is empty
@@ -648,6 +939,7 @@ public class CombinationGeneratorTask extends RecursiveAction
             newPrefix[prefixLength] = i;
 
             // No conditional - pure XOR calculation every time
+            // TODO: Double check that you're supposed to XOR and not OR here (since XORing represents a toggle rather than a set)
             long childAdjacencyState = currentAdjacencyState ^ masks[i];
             
             // All parameters determined - perfect for JIT constant propagation
@@ -658,10 +950,77 @@ public class CombinationGeneratorTask extends RecursiveAction
             subtask.fork();
         }
     }
+    
     /**
-     * Ultra-fast constraint checking using pre-computed bitmasks.
-     * Uses incremental state tracking to avoid recomputing XORs.
-     * Assumes that trueCells are initialized and non-empty.
+     * Checks if the current prefix (or the prefix of a descendant task) can satisfy the constraints.
+     * 
+     * <p>
+     * Though fork-join tasks are designed to be small and fast, too many of them can lead to
+     * performance degradation due to the overhead of task management and scheduling in addition to
+     * extra queue pressure. We want to avoid creating tasks that are guaranteed to fail, and due to the
+     * recursive nature of generation, we want to perform this pruning as early as possible. This method
+     * facilitates that.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * To start, we need to understand the constraints of the puzzle. We know that a solution must
+     * toggle all initially true cells in order to be valid. While it is also a requirement that those
+     * cells are toggled an odd number of times, we can simplify our checks at the moment by focusing on
+     * whether the cells are toggled at all.
+     * </p>
+     * 
+     * <p>
+     * Since this check concerns itself with only the initially true cells, we can simplify the grid to
+     * a target bitmask representing the toggled state of those cells. We can then XOR this target mask
+     * with the current adjacency state to find which bits need to be flipped to satisfy the
+     * constraints. If all of the initially true cells are toggled, the XOR result will be zero and we
+     * can skip further checks, returning true and setting the {@link #skipConstraintsCheck} flag.
+     * </p>
+     * 
+     * <p>
+     * As we're performing these checks very early on, it's possible that the current prefix may not be
+     * long enough to satisfy the constraints but a descendant task may be able to. To handle this, we
+     * use {@link #SUFFIX_OR_MASKS pre-computed OR masks} to quickly check if any of the remaining
+     * clicks could satisfy the constraints. If this mask ANDed with the needed bits is equal to the
+     * needed bits (the mask contains all bits that need to be flipped), we can assume that at least one
+     * descendant can satisfy the constraints and return true.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method employs several optimizations to ensure that it runs as fast as possible while being
+     * strict. We cache all loop-invariant values at the start of the method to minimize repeated
+     * calculations and array dereferences. The use of bitmasks allows us to perform set operations
+     * quickly and efficiently, reducing the complexity of the checks. The pre-computed suffix OR masks
+     * allow us to avoid O(n) checks for each prefix, reducing the complexity to O(1).
+     * </p>
+     * 
+     * <p>
+     * If a prefix is found to directly satisfy the constraints, we set the
+     * {@link #skipConstraintsCheck} flag to true to skip future checks for all descendants. This
+     * optimization is crucial for performance, as it allows us to avoid redundant checks and create an
+     * optimized path for valid prefixes.
+     * </p>
+     * 
+     * @param startIdx - the index of the first possible next click (used for suffix OR checks)
+     * @return <code>true</code> if the current prefix or any descendant can satisfy the constraints,
+     *         <code>false</code> otherwise.
+     * @since 2025.07.03 - Splitting the Compute Method Into Paths
+     * @threading Thread-safe due to ForkJoinTask isolation.
+     * @performance O(1) for the check due to bitmask operations and pre-computed suffix OR masks.
+     * @algorithm Uses bitmask operations to determine if the current prefix or any descendant can
+     *            satisfy the constraints and compares against a pre-computed target mask and
+     *            pre-computed suffix OR masks.
+     * @optimization Caches loop-invariant values, uses bitmask operations, and employs pre-computed
+     *               suffix OR masks to reduce complexity.
+     * @see #TRUE_CELL_ADJACENCY_MASKS
+     * @see #SUFFIX_OR_MASKS
+     * @see #cachedAdjacencyState
+     * @see #targetMask
+     * @see #ensureTrueCellMasks(short[])
+     * @see Grid#findTrueCells(Grid.ValueFormat)
+     * @see Grid#findAdjacents(short)
      */
     private boolean canPotentiallySatisfyConstraints(int startIdx)
     {   
@@ -787,8 +1146,62 @@ public class CombinationGeneratorTask extends RecursiveAction
         return matrix;
     }
 
-    // Lazy initialization of true cell masks when first needed
-    // This method is called once in the root task's constructor
+    /**
+     * Initializes the {@link #TRUE_CELL_ADJACENCY_MASKS} and {@link #SUFFIX_OR_MASKS} if they are not
+     * already initialized.
+     * 
+     * <p>
+     * Our pruning strategy relies on quickly determining which true cells are toggled by a given prefix
+     * of clicks. In order to make these checks efficient (and constant time), we use pre-computed masks
+     * where possible to avoid repeated calculations. Naturally, though, that means that we need to
+     * compute these masks at some point. This method does that, ensuring that the masks are only
+     * computed once per puzzle and reused across tasks.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The method first lazily checks if the masks are already initialized before entering a
+     * synchronized block, ensuring that one thread performs the initialization (but that multiple
+     * threads could call the method). Inside the synchronized block, it checks again if the masks are
+     * initialized to avoid redundant computation.
+     * </p>
+     * 
+     * <p>
+     * For each click cell, it constructs a bitmask of length <code>trueCells.length</code> where each
+     * bit represents whether the corresponding true cell is adjacent to the click cell. This is done by
+     * using the {@link #CLICK_ADJACENCY_MATRIX} to check adjacency. The resulting masks are stored in
+     * the {@link #TRUE_CELL_ADJACENCY_MASKS} array.
+     * </p>
+     * 
+     * <p>
+     * After computing the main masks, it computes the {@link #SUFFIX_OR_MASKS} by iterating backwards
+     * over the {@link #TRUE_CELL_ADJACENCY_MASKS} and performing a cumulative OR operation. This allows
+     * us to quickly check if any of the remaining clicks can satisfy the constraints in a constant
+     * timeframe.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be called once per puzzle, so its performance is not as critical as
+     * other parts of the program. However, we still want to ensure that it runs efficiently and does
+     * not introduce unnecessary overhead. The double-checked locking pattern ensures that the masks
+     * aren't computed multiple times in a multi-threaded environment while minimizing synchronization
+     * overhead.
+     * </p>
+     * 
+     * @param trueCells - the array of indices of initially true cells in the grid.
+     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @threading Thread-safe due to synchronized block and double-checked locking.
+     * @performance O({@link #numClicks} * m) where m is the number of initially true cells.
+     * @memory One long per cell for {@link #TRUE_CELL_ADJACENCY_MASKS} and one long per cell plus one
+     *         for {@link #SUFFIX_OR_MASKS}.
+     * @optimization Uses double-checked locking to minimize synchronization overhead, pre-computes
+     *               masks once per puzzle to avoid recomputation.
+     * @see #TRUE_CELL_ADJACENCY_MASKS
+     * @see #SUFFIX_OR_MASKS
+     * @see #CLICK_ADJACENCY_MATRIX
+     * @see #initClickAdjacencyMatrix()
+     */
     private static void ensureTrueCellMasks(short[] trueCells) 
     {
         if (TRUE_CELL_ADJACENCY_MASKS == null | SUFFIX_OR_MASKS == null)
@@ -828,6 +1241,75 @@ public class CombinationGeneratorTask extends RecursiveAction
         }
     }
 
+    /**
+     * Flushes the given {@link WorkBatch batch} to any available {@link CombinationQueue queue},
+     * sleeping briefly if all queues are full.
+     * 
+     * <p>
+     * Our program's architecture relies on an equal number of generators and
+     * {@link TestClickCombination monkeys} to generate and test combinations in parallel. Communication
+     * between these two components is handled through an array of {@link CombinationQueue queues}, but
+     * we need some mechanism to enqueue these batches of work for the monkeys to process while
+     * maintaining backpressure mechanisms to prevent queue overload or busy-waiting. This method aims
+     * to do that.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The method first retrieves all available queues from the {@link CombinationQueueArray} and
+     * selects a random starting index to avoid contention. It then iterates over the queues, attempting
+     * to {@link CombinationQueue#add(WorkBatch) add} the batch to any available queue. If a queue
+     * accepts the batch, the method immediately returns <code>true</code>. If all queues are full, the
+     * method {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting before
+     * looping once more.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be called frequently by generator tasks, so its performance is
+     * critical. We use {@link ThreadLocalRandom} to select a random starting index to try to balance
+     * the load across queues and minimize contention. The brief sleep when all queues are full provides
+     * a backpressure mechanism to prevent busy-waiting while still allowing for quick retries.
+     * </p>
+     * 
+     * <p>
+     * While it may seem tempting to only make one attempt to enqueue the batch before giving up, this
+     * violates the fundamental rule of our program: No combinations should be dropped before being
+     * properly tested. By looping until successful, we ensure that all generated combinations are
+     * eventually tested, even if it means waiting briefly for an available queue.
+     * </p>
+     * 
+     * <p>
+     * Since this method's progress depends on the state of the queues, we stop making progress if all
+     * queues consistently get filled up. A future optimization could be to implement a more
+     * sophisticated approach that can spin up extra generators to work through non-leaf tasks if the
+     * queues are full (see {@link ForkJoinPool.ManagedBlocker}).
+     * </p>
+     * 
+     * <p>
+     * Another area of potential optimization is to use a backoff strategy that can block the task when
+     * queues are full rather than sleeping. This would be more efficient and reduce the need for
+     * constant awakenings, but this is easier said than done. We would need some type of way to signal
+     * to the generators when a queue has space available and wake them up for this purpose, but
+     * blocking queues block on all operations. Also, how can we ensure that one generator is woken up
+     * when any queue has space (since you can't block on multiple queues at once)? That may require the
+     * need for an SPMC queue structure, which wouldn't be awful but would create complexity. All of
+     * these considerations are left for future work, but are worth noting as areas for great
+     * improvement.
+     * </p>
+     * 
+     * @param batch - the {@link WorkBatch} to flush.
+     * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
+     *         was interrupted.
+     * @since 2025.06.08 - Fork Join Refactor
+     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
+     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full.
+     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting.
+     * @see #queueArray
+     * @see ThreadLocalRandom
+     * @see CombinationQueueArray#getAllQueues()
+     * @see CombinationQueue#add(WorkBatch)
+     */
     private final boolean flushBatchFast(WorkBatch batch) 
     {   
         CombinationQueue[] queues = queueArray.getAllQueues();

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -5,378 +5,225 @@ import java.util.concurrent.RecursiveAction;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * A recursive combination generator using the {@link ForkJoinPool} framework.
+ * A {@link RecursiveAction} that generates combinations of clicks for the Lights Out puzzle solver.
  * 
  * <p>
- * Generators produce combinations of clicks, stored as {@code short[]} arrays, and add them to a
- * {@link CombinationQueue queue} for processing by {@link TestClickCombination monkeys}. The
- * generators use a recursive, divide-and-conquer approach to generate combinations in parallel,
- * leveraging the {@link ForkJoinPool} framework for efficient task management and work-stealing.
- * While monkeys handle the more {@link TestClickCombination#satisfiesOddAdjacency(short[]) in-depth
- * odd adjacency checks}, the generators perform {@link #canPotentiallySatisfyConstraints(int)
- * constraint checks} at each branch to prune combinations early and increase the time spent on
- * potentially valid combinations.
+ * This class is the "producer" in a producer-consumer pattern, using a {@link ForkJoinPool} to
+ * recursively explore the solution space. It generates potential solutions (combinations of clicks)
+ * as {@code short[]} arrays and hands them off in {@link WorkBatch} objects to a
+ * {@link CombinationQueue} for consumption by {@link TestClickCombination "monkeys"}.
  * </p>
  * 
  * <h2>Execution Model</h2>
  * <p>
- * We use a tree structure to represent the combination generation process, where each node in the
- * tree has a {@link #prefix} representing the clicks made so far. The root task generates subtasks
- * for each possible first click, and each subtask recursively generates further subtasks for each
- * subsequent click until the full {@link #numClicks combination length} is reached. Leaf tasks
- * generate the final combinations and add them to a {@link WorkBatch}, which is then
- * {@link #flushBatchFast(WorkBatch) flushed} to a randomly chosen {@link CombinationQueue queue}
- * for processing.
- * </p>
- * 
- * <p>
- * The task execution is managed by the {@link ForkJoinPool} framework, which handles task
- * scheduling and work-stealing. Task specific data is stored in instance fields, ensuring thread
- * safety and isolation between tasks, while shared resources are managed via {@link ThreadLocal}
- * contexts to avoid contention.
+ * The generation process is a tree-based, divide-and-conquer algorithm. Each task represents a
+ * {@link #prefix} of clicks. The root task {@link #computeRootSubtasks(GeneratorContext) forks
+ * subtasks} for each possible first click, and these subtasks recursively
+ * {@link #computeIntermediateSubtasks(GeneratorContext) fork children} until the desired
+ * {@link #numClicks combination length} is reached. To optimize performance, this class implements
+ * two key strategies:
+ * <ul>
+ * <li><b>Constraint Pruning:</b> At each branching point,
+ * {@link #canPotentiallySatisfyConstraints(int)} uses bitmasks to check if a path can possibly lead
+ * to a valid solution, pruning entire branches early.</li>
+ * <li><b>Batching:</b> Leaf tasks group thousands of generated combinations into a
+ * {@code WorkBatch} before {@link #flushBatchFast(WorkBatch) flushing} it to a queue. This
+ * drastically reduces queue contention, a major bottleneck in previous designs.</li>
+ * </ul>
  * </p>
  * 
  * <h2>Resource Management</h2>
  * <p>
- * The fundamental rule of JVM optimizations is: <b>Don't allocate.</b> Fork-join architectures rely
- * on the creation of many small tasks that are executed in parallel, but allocating new resources
- * for every task would lead to excessive garbage collection pressure and performance degradation.
- * In addition, we can't solely use primitive types to represent the {@code prefix}es, as the
- * maximum number of clicks is {@value Grid#NUM_CELLS}, larger than the 64 bits available in a
- * {@code long}. This means we need to allocate arrays to store the prefixes, which could lead to
- * trillions of allocations, murdering performance.
+ * To avoid performance degradation from excessive garbage collection, this class adheres to a
+ * strict "don't allocate" policy in its hot paths. All critical resources, including
+ * {@code short[]} {@code prefix} arrays and the tasks themselves, are recycled using
+ * {@link ThreadLocal thread-local} pools managed by the {@link GeneratorContext}. This design
+ * reduces heap allocations to nearly zero during the main generation loop.
  * </p>
  * 
- * <p>
- * To mitigate this, we pool resources per thread using the {@link GeneratorContext} class, which
- * provides access to various resource pools like {@link ArrayPool} and {@link TaskPool}. Each
- * thread has its own context, and the pools are sized to balance memory usage and contention.
- * Through this and pre-allocation, we can significantly reduce the number of allocations and
- * deallocations on the hot path to virtually none.
- * </p>
- * 
- * <h2>Performance Critical Paths</h2>
- * <p>
- * The interdependent nature of generators and monkeys creates a complex performance profile,
- * meaning that any bottleneck in one could drag the system down to a halt. We want to avoid
- * bottlenecks at all costs and minimize the footprint of the hot paths to allow the JIT compiler to
- * optimize them effectively. To accomplish this, we try to keep the hot paths as simple as
- * possible, reducing branching and conditionals, and extracting complex logic into separate methods
- * that can be optimized independently.
- * </p>
- * 
- * <p>
- * The hottest methods in this class are:
- * <ul>
- * <li>{@link #compute()} - the dispatcher for all tasks, directing them to one of three paths</li>
- * <li>{@link #computeIntermediateSubtasks(GeneratorContext)} - the path for intermediate tasks,
- * dispatching to one of two paths depending on constraint check status</li>
- * <li>{@link #canPotentiallySatisfyConstraints(int)} - the constraint check, pruning invalid
- * branches as early as possible</li>
- * <li>{@link #computeLeafCombinations(GeneratorContext)} - the path for leaf tasks, generating the
- * final combinations that are added to a batch</li>
- * <li>{@link #flushBatchFast(WorkBatch)} - the hand-off method, giving the generators' work to a
- * monkey</li>
- * <li>{@link #recycleOwnResources(GeneratorContext)} - the self-cleanup method, recycling the
- * resources used by a task back to the pools</li>
- * </ul>
- * </p>
- * 
- * @see CombinationQueue
- * @see TestClickCombination
  * @see java.util.concurrent.ForkJoinTask
- * @since 2025.06.08 - Fork Join Refactor
- * @performance The overall time complexity is
- *              <code>O({@link Grid#NUM_CELLS NUM_CELLS} choose {@link #numClicks})</code> in the
- *              worst case, but pruning and parallelism significantly reduce the effective workload.
- *              Most bottlenecks arise from contention on shared resources or the process of
- *              enqueuing batches.
- * @threading Each task is isolated and thread-safe due to {@link java.util.concurrent.ForkJoinTask
- *            ForkJoinTask} design. Pooled and shared resources are handled by {@code ThreadLocal}
- *            contexts and static fields respectively.
- * @algorithm Creates a tree of tasks, where each task represents a {@code prefix} of clicks. The
- *            root task generates subtasks for each possible first click, and each subtask
- *            recursively generates further subtasks for each subsequent click until the full
- *            combination length is reached. Leaf tasks generate the final combinations and add them
- *            to a {@link WorkBatch}, which is then flushed to a randomly chosen
- *            {@link CombinationQueue} for processing.
- * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
- *         in the hot path.
+ * @since 2025.06 - Fork Join Refactor
+ * @performance The theoretical complexity is {@code O(C(Grid.NUM_CELLS, numClicks))}. However,
+ *              aggressive bitmask-based pruning and parallel execution significantly reduce the
+ *              practical workload.
+ * @threading Tasks are isolated by the {@code ForkJoinTask} framework. Shared resources are managed
+ *            via a {@link #context ThreadLocal} {@link GeneratorContext} to ensure thread safety
+ *            and eliminate contention.
+ * @algorithm A recursive, divide-and-conquer approach. Tasks form a generation tree where each node
+ *            is a click prefix. Subtasks are {@link #computeIntermediateSubtasks(GeneratorContext)
+ *            forked} until a {@link #numClicks target length} is reached. Leaf tasks
+ *            {@link #computeLeafCombinations(GeneratorContext) generate} final combinations, which
+ *            are batched and {@link #flushBatchFast(WorkBatch) queued} for validation.
+ * @memory Object allocations are minimized through extensive use of {@link ArrayPool} and
+ *         {@link TaskPool}, managed by a thread-local {@code GeneratorContext}.
  */
 public class CombinationGeneratorTask extends RecursiveAction {
     /**
-     * The maximum size of a batch before it is flushed to {@link CombinationQueue a queue}.
+     * The target number of combinations to store in a {@link WorkBatch} before
+     * {@link #flushBatchFast(WorkBatch)} flushing it to a {@link CombinationQueue}.
      * 
      * <p>
-     * To amortize the cost of queue operations, we bundle combinations into {@link WorkBatch} objects
-     * and {@link #flushBatchFast(WorkBatch) flush} them to the queue as one. Naturally, this means that
-     * we have to define a maximum size for each batch.
+     * Batching is a critical optimization that amortizes the high cost of concurrent queue operations.
+     * Instead of enqueuing millions of individual combinations, generators group them into large
+     * batches, reducing queue contention by several orders of magnitude.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The batch size is a compromise between multiple factors. Larger batches reduce the overhead of
-     * queue operations and allow for generators and {@link TestClickCombination monkeys} to work for
-     * longer periods of time without interruption, but they increase the memory footprint and can cause
-     * longer monkey pauses as they wait for new batches to process. Smaller batches are more responsive
-     * and can give monkeys more frequent tasks, but they increase the overhead and time spent on queue
-     * operations, which can cause contention and reduce overall throughput.
+     * The batch size is a trade-off:
+     * <ul>
+     * <li><b>Larger batches:</b> Reduce queue-related overhead and improve throughput by allowing
+     * generators and {@link TestClickCombination monkeys} to work uninterrupted for longer. However,
+     * they increase memory footprint and can lead to work-distribution latency.</li>
+     * <li><b>Smaller batches:</b> Provide a more even flow of work to monkeys, but increase the
+     * frequency of high-contention queue operations, which can become a bottleneck.</li>
+     * </ul>
+     * A value of {@value} was found to be a good balance for the development system.
      * </p>
      * 
-     * <p>
-     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a batch size of
-     * {@value #BATCH_SIZE} seems to be a good compromise between these factors. I originally included a
-     * flush threshold to encourage more frequent flushing of batches to the queue, but the overhead of
-     * {@code size} checks made it less helpful. Batch size is not a silver bullet, but increasing the
-     * size can sometimes help with monkey bottlenecks, while decreasing it can help with generator
-     * bottlenecks.
-     * </p>
-     * 
-     * @see #flushBatchFast(WorkBatch)
-     * @see CombinationQueue
-     * @see CombinationQueue#add(WorkBatch)
-     * @see GeneratorContext
      * @see GeneratorContext#getOrCreateBatch()
-     * @since 2025.06.08 - Work-stealing introduction
+     * @since 2025.06 - Work-stealing introduction
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Minimal memory footprint of 4 bytes as an {@code int}.
      */
     public static final int BATCH_SIZE = 8000;
     /**
-     * The size of resource pools used in each thread's {@link #context}.
+     * The pre-allocated size of the {@link ThreadLocal thread-local} resource pools in
+     * {@link GeneratorContext}.
      * 
      * <p>
-     * The golden rule of JVM optimizations: <b>Don't allocate.</b> This is especially true for
-     * high-performance applications like this one, where we need to minimize the number of allocations
-     * and deallocations to avoid garbage collection pauses and improve throughput. The fork-join
-     * architecture, which is used in this application, relies heavily on the creation of several tasks
-     * that are executed in parallel, but creating a new task with new resources for every step of the
-     * combination generation process would lead to trillions of allocations and deallocations, which
-     * would be catastrophic for performance.
-     * </p>
-     * 
-     * <p>
-     * Resource pooling and pre-allocation are key strategies to mitigate this issue. We use the custom
-     * {@link ArrayPool} and {@link TaskPool} classes to manage pools of arrays and tasks, and share
-     * access to these pools via the {@link GeneratorContext} class. To prevent contention and ensure
-     * that we have enough resources available for each thread, we need to define a size for these
-     * pools.
+     * To avoid heap allocations in the hot path, this class relies on object pooling for both
+     * {@code prefix} arrays (via {@link ArrayPool}) and {@code CombinationGeneratorTask} objects (via
+     * {@link TaskPool}). This constant defines the capacity of those pools.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since pools pre-allocate resources, the size of the pool directly affects the memory footprint of
-     * the application. A smaller pool size reduces memory usage, but increases the likelihood of
-     * contention and accidental allocations, which can lead to performance degradation. A larger pool
-     * size is the opposite: it reduces contention and makes accidental allocations less likely, but at
-     * the cost of increased memory usage.
+     * The pool size balances memory footprint against pool misses.
+     * <ul>
+     * <li><b>Larger pools:</b> Reduce the chance of a pool miss (which would force a new allocation) at
+     * the cost of higher upfront memory usage.</li>
+     * <li><b>Smaller pools:</b> Conserve memory but risk contention or misses if the task recursion
+     * depth exceeds the pool capacity.</li>
+     * </ul>
+     * The value {@value} was chosen as a safe capacity that prevents pool misses under typical
+     * conditions without excessive memory overhead.
      * </p>
      * 
-     * <p>
-     * For my system (Intel Core i7-13700K with 16 cores and 48GB of RAM), a pool size of
-     * {@value #POOL_SIZE} seems to be a good compromise between these factors. It allows for enough
-     * resources to be available for each thread without causing excessive memory usage or contention.
-     * Tuning the sizes of the pools can help with memory usage and cache locality, but must be done
-     * carefully to avoid accidental allocations.
-     * </p>
-     * 
-     * @see ArrayPool
-     * @see GeneratorContext
-     * @see TaskPool
-     * @since 2025.06.10 - Array Pooling Introduction
+     * @since 2025.06 - Array Pooling Introduction
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Minimal memory footprint of 4 bytes as an {@code int}.
      */
     private static final int POOL_SIZE = 512;
 
     /**
-     * A {@link java.lang.ThreadLocal ThreadLocal} context containing references to resource pools.
+     * A {@link ThreadLocal} container for the {@link GeneratorContext}.
      * 
      * <p>
-     * Recycling resources is crucial for performance in the JVM, but maintaining multiple
-     * {@code ThreadLocal}s is expensive, especially with the frequent access patterns in this class. To
-     * optimize this, we consolidate all {@code ThreadLocal} data into a single context object that can
-     * be passed down to all methods.
+     * This provides each generator thread with its own isolated set of resources ({@link ArrayPool
+     * array pools}, {@link TaskPool task pools}, and the current {@link WorkBatch}). Using a single
+     * {@code ThreadLocal} to hold a context object is a key optimization that avoids the high cost of
+     * multiple {@link ThreadLocal#get()} calls in the hot path. The context is fetched once at the
+     * start of {@link #compute()} and then passed down as a parameter.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * The context is stored in a {@code ThreadLocal} variable to ensure that each thread has its own
-     * instance, allowing for efficient resource management without contention. This context holds
-     * references to various resource pools, such as the {@link GeneratorContext#prefixArrayPool prefix
-     * array pool} and {@link GeneratorContext#taskPool task pool}, which are used to recycle arrays and
-     * tasks respectively.
-     * </p>
-     * 
-     * @see ArrayPool
-     * @see GeneratorContext
-     * @see TaskPool
-     * @see WorkBatch
-     * @since 2025.07.26 - {@code GeneratorContext} Introduction
-     * @performance {@code O(1)} access time for {@link java.lang.ThreadLocal#get() ThreadLocal.get()}
-     * @threading {@code ThreadLocal} - Each thread has its own instance of {@code GeneratorContext},
-     *            ensuring thread safety and isolation of resources
-     * @memory {@code ThreadLocal} memory usage is minimized by pooling resources and recycling them
-     * @optimization Consolidation of multiple {@code ThreadLocal}s into a single context object to
-     *               reduce overhead
+     * @since 2025.07 - {@code GeneratorContext} Introduction
+     * @performance {@code O(BATCH_SIZE)} on creation (due to pre-allocation); {@code O(1)} access time.
+     * @threading Thread-local; each thread has its own instance of the context obtained via
+     *            {@code context.get()}.
+     * @memory Fixed memory footprint of 4 bytes as a reference.
      */
     private static final ThreadLocal<GeneratorContext> context =
         ThreadLocal.withInitial(GeneratorContext::new);
 
     /**
-     * A thread-local context for managing resource pools and state.
-     * 
+     * A container for all {@link ThreadLocal thread-local} resources used by a generator.
+     *
      * <p>
-     * A core part of the fork-join architecture is work-stealing, where each worker has a double-ended
-     * queue of tasks to process, allowing them to steal work from others when their deque is empty. We
-     * create a task for every step of the combination generation process, which is great for
-     * work-stealing, but violates the golden rule of JVM optimizations: <b>Don't allocate.</b>
-     * </p>
-     * 
-     * <p>
-     * Recycling is necessary to avoid excessive allocations and deallocations, and we give each thread
-     * its own pool of resources to work with. However, we can't pass down these references directly
-     * since the task may be executed by a different thread than the one that created it. This problem
-     * is solvable via ThreadLocals, which allow us to store thread-specific data, but the
-     * {@link ThreadLocal#get()} method is expensive to call. We need to minimize the number of calls to
-     * this method by consolidating all {@link java.lang.ThreadLocal ThreadLocal} data into a single
-     * context object that can be passed down to all methods. {@code GeneratorContext} provides us with
-     * a way to do that.
+     * This class is a key part of the resource management strategy. It consolidates all expensive,
+     * thread-specific objects into a single container. An instance of this context is stored in a
+     * {@link #context ThreadLocal}, ensuring that each thread in the {@link ForkJoinPool} has its own
+     * set of resource pools and a dedicated {@link WorkBatch}.
      * </p>
      * 
      * <h2>Optimization Strategy</h2>
      * <p>
-     * Other than the {@link WorkBatch}, all resources used by a task are pooled, pre-allocated, and
-     * recycled. The context provides access to these pools, allowing tasks to obtain and recycle
-     * resources as needed. Batches are not pooled since they are passed to the queue.
+     * By fetching this context object only once per task via {@code context.get()}, we avoid the
+     * performance penalty of multiple {@code ThreadLocal} lookups in the hot path. The context is then
+     * passed as a parameter to downstream methods, providing fast, contention-free access to:
+     * <ul>
+     * <li>An {@link #prefixArrayPool} for recycling {@code short[]} arrays.</li>
+     * <li>A {@link #taskPool} for recycling {@code CombinationGeneratorTask} objects.</li>
+     * <li>The {@link #currentBatch} being filled by the thread.</li>
+     * </ul>
+     * This pattern is crucial for achieving near-zero allocation during combination generation.
      * </p>
      * 
-     * <h2>Usage Patterns</h2>
-     * <p>
-     * This context is meant to be stored in a {@link ThreadLocal} variable, ensuring that each thread
-     * has its own instance. It is passed down to all methods that need access to the resource pools,
-     * allowing for efficient resource management without contention. Tasks should obtain resources from
-     * the pools as needed and recycle them when they are no longer needed. After batches are filled and
-     * are flushed to the queue, {@link #resetBatch()} should be called to obtain a new batch. Do not
-     * reference the old batch after flushing, as it may be recycled and used by another thread.
-     * </p>
-     * 
-     * <h2>Memory Management</h2>
-     * <p>
-     * The context itself is stored in a {@code ThreadLocal} variable, which means that it will be
-     * garbage collected when the thread is terminated. The resources within the context are pooled and
-     * recycled, which helps to minimize memory usage and reduce garbage collection pressure. However,
-     * care must be taken to ensure that resources are recycled properly to avoid memory leaks.
-     * </p>
-     * 
-     * <p>
-     * As a wrapper class, {@code GeneratorContext} has a small memory footprint, but the resources it
-     * manages can be significant. The {@link CombinationGeneratorTask#POOL_SIZE size of the pools}
-     * should be tuned to balance memory usage and contention, with larger pools reducing contention but
-     * increasing memory usage.
-     * </p>
-     * 
-     * @see #context
-     * @see ArrayPool
-     * @see CombinationGeneratorTask
-     * @see TaskPool
-     * @see WorkBatch
-     * @since 2025.07.26 - {@code GeneratorContext} Introduction
-     * @performance {@code O(1)} access time for pool operations.
-     * @threading This class is not thread-safe, but is intended to be used in a thread-local manner. A
-     *            thread-local, static variable should be created to use this class.
-     * @memory Minimal memory footprint as a wrapper class, with pooled resources to minimize
-     *         allocations.
-     * @optimization Consolidation of multiple {@code ThreadLocal}s into a single context object to
-     *               reduce overhead.
+     * @since 2025.07 - {@code GeneratorContext} Introduction
+     * @performance {@code O(1)} access time after initial allocation.
+     * @threading This class is NOT thread-safe, but is intended to be used in a thread-local manner.
+     * @memory Minimal memory footprint of two fixed-capacity pools and a batch reference.
      */
     private static class GeneratorContext {
         /**
-         * An {@link ArrayPool} for storing click {@code prefix}es.
+         * A {@link ThreadLocal thread-local} {@link ArrayPool pool} for recycling {@code short[]} arrays
+         * used for {@code prefix}es.
          * 
-         * @see #context
-         * @see #numClicks
          * @see ArrayPool
-         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @since 2025.07 - {@code GeneratorContext} Introduction
          * @performance {@code O(1)} amortized access time for {@link ArrayPool#get()} and
          *              {@link ArrayPool#put(short[])}.
-         * @threading Thread-local - Each thread has its own instance of {@code ArrayPool}, ensuring thread
-         *            safety.
-         * @memory Memory usage is optimized by reusing arrays and minimizing allocations.
-         * @optimization Pooling and reusing arrays to minimize allocations on the hot path.
+         * @threading Not thread-safe, should be used in a thread-local manner.
+         * @memory Fixed footprint of ~4 bytes as a reference.
          */
         final ArrayPool prefixArrayPool = new ArrayPool(POOL_SIZE);
         /**
-         * The {@link TaskPool} for recycling subtasks.
+         * A {@link ThreadLocal thread-local} {@link TaskPool pool} for recycling
+         * {@link CombinationGeneratorTask} instances.
          * 
-         * @see TaskPool#TaskPool(int)
-         * @see TaskPool#get()
-         * @see TaskPool#put(CombinationGeneratorTask)
-         * @since 2025.07.26 - {@code GeneratorContext} Introduction
+         * @since 2025.07 - {@code GeneratorContext} Introduction
          * @performance {@code O(1)} amortized access time for {@link TaskPool#get()} and
          *              {@link TaskPool#put(CombinationGeneratorTask)}.
-         * @threading Thread-local - Each thread has its own instance of {@code TaskPool}, ensuring thread
-         *            safety.
-         * @memory Memory usage is optimized by reusing tasks and minimizing allocations.
-         * @optimization Pooling and reusing tasks to minimize allocations on the hot path.
+         * @threading Not thread-safe, should be used in a thread-local manner.
+         * @memory Fixed footprint of ~4 bytes as a reference.
          */
         final TaskPool taskPool = new TaskPool(POOL_SIZE / 4);
         /**
-         * The current {@link WorkBatch} being processed by this thread.
+         * The {@link WorkBatch} currently being filled by this thread.
          * 
          * <p>
-         * Generators produce combinations in batches to amortize the cost of queue operations, making the
-         * generation process more efficient. Since work batches are sized greater than the maximum number
-         * of combinations that can be generated in a single task, we need a way to preserve the current
-         * batch between tasks. We could make work batches thread-safe, but that would come at the cost of
-         * performance. Instead, we bundle the current batch into the {@link ThreadLocal thread-local}
-         * context, giving each thread its own batch to work with.
-         * </p>
-         * 
-         * <h3>Performance Considerations</h3>
-         * <p>
-         * By keeping the current batch in the thread-local context, we avoid contention and locking
-         * overhead, allowing each thread to work independently. This design also simplifies the logic for
-         * managing batches, as each thread can handle its own batch without needing to coordinate with
-         * others. Bundling the batch into the context gives us the benefit of {@code ThreadLocal} storage
-         * without the cost of multiple {@code ThreadLocal} accesses.
+         * Each generator thread works on its own batch, which is preserved across multiple tasks executed
+         * by that thread. When the batch is full, it is flushed to a queue, and a new, clean batch is
+         * obtained from a central pool. Storing the batch here, within the {@link ThreadLocal thread-local}
+         * context, eliminates contention and simplifies batch management.
          * </p>
          * 
          * @see #BATCH_SIZE
-         * @see #context
-         * @see WorkBatch
-         * @since 2025.07.01 - {@code WorkBatch} Introduction
-         * @performance {@code O(1)} access time.
-         * @threading Thread-local - Each thread has its own instance of {@code WorkBatch}, ensuring thread
-         *            safety.
-         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
-         * @optimization Bundled into {@code GeneratorContext} to reduce {@code ThreadLocal} access
-         *               overhead.
+         * @see #getOrCreateBatch()
+         * @since 2025.07 - {@code WorkBatch} Introduction
+         * @performance {@code O(1)} access and update time.
+         * @threading Not thread-safe. References to this batch should not be kept after flushing.
+         * @memory Fixed footprint of ~4 bytes as a reference.
          */
         WorkBatch currentBatch = null;
 
         /**
-         * Gets the {@link #currentBatch current WorkBatch}}, obtaining a new one if necessary.
+         * Returns the {@link #currentBatch current} {@link WorkBatch} for this thread,
+         * {@link #getNewBatchBlocking() obtaining} a new one from
+         * {@link CombinationQueueArray#getWorkBatchPool() the central pool} if one doesn't exist.
          * 
          * <p>
-         * We need to ensure that we always have a valid {@link WorkBatch} to add combinations to. If the
-         * current batch is {@code null} (either because it hasn't been created yet or because it was
-         * flushed), we need some mechanism to "create" a new one. This method serves that purpose,
-         * performing a simple null check and creating a new batch if necessary.
+         * This method ensures a generator task always has a valid batch to write to. It performs a fast
+         * {@code null} check and, if needed, calls the blocking {@code getNewBatchBlocking()} method to
+         * retrieve a recycled batch instance.
          * </p>
          * 
-         * <h3>Performance Considerations</h3>
-         * <p>
-         * This method is designed to be fast and efficient, as it is called frequently during the
-         * combination generation process. The {@code null} check is a simple and quick operation, and
-         * creating a new batch is also efficient due to the use of a pool.
-         * </p>
-         * 
-         * @return The current {@link WorkBatch}, guaranteed to be non-{@code null}.
-         * @see #context
-         * @see #getNewBatchBlocking()
-         * @see WorkBatch
-         * @since 2025.07.26 - {@code GeneratorContext} Introduction
-         * @performance {@code O(1)} null check and access time.
-         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
-         *            safety.
-         * @optimization Caches current batch to avoid redundant allocations or pool calls.
+         * @return The current, non-{@code null} {@code WorkBatch}.
+         * @since 2025.07 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} null check and amortized {@code O(1)} for batch retrieval.
+         * @threading Not thread-safe. Each thread should manage its own context instance.
          */
         WorkBatch getOrCreateBatch() {
             if (currentBatch == null) {
@@ -386,47 +233,24 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
 
         /**
-         * Obtains a new {@link WorkBatch} from {@link CombinationQueueArray#getWorkBatchPool() the pool},
-         * "blocking" (spinning) if necessary until one is available.
+         * Retrieves a new {@link WorkBatch} from the {@link CombinationQueueArray#getWorkBatchPool() global
+         * pool}, spinning until one is available.
          * 
          * <p>
-         * After all the combinations in a batch have been processed, the batch is recycled into a
-         * {@link CombinationQueueArray#workBatchPool separate queue} for reuse. This method retrieves a
-         * batch from that queue, spinning if necessary until one is available. Since batches have
-         * pre-allocated buffers for combinations, we need to ensure that the batches themselves are
-         * recycled to avoid excessive allocations and deallocations on the hot path. This method serves
-         * that purpose, providing a way to obtain a new batch in a "blocking" manner from the queue.
+         * When a {@link TestClickCombination monkey} finishes with a {@code WorkBatch}, it returns it to a
+         * central pool for recycling. This method retrieves a batch from that pool. It uses a non-blocking,
+         * busy-wait (spin) loop with a {@link org.jctools.queues.MpmcArrayQueue#relaxedPoll()
+         * relaxedPoll()} to ensure the generator thread remains responsive to cancellation signals from the
+         * {@link ForkJoinPool}, which a standard {@link Thread#onSpinWait()} call would prevent.
          * </p>
          * 
-         * <h3>Performance Considerations</h3>
-         * <p>
-         * This method is internally used often during the generation process, so it needs to be fast and
-         * efficient while maintaining thread safety and allowing for signaling. Crucially, we need to
-         * ensure that the method can be exited if the task is cancelled, which is why we use a
-         * {@code while} loop with a {@link org.jctools.queues.MpmcArrayQueue#relaxedPoll() relaxed poll}
-         * instead of a blocking {@code poll} method to avoid deadlocks at the cost of busy-waiting.
-         * Crucially, we avoid calling {@link Thread#onSpinWait()} in the loop since it does not respond to
-         * cancellation (for some reason, at least in my testing).
-         * </p>
-         * 
-         * <p>
-         * An improvement could implement some form of {@link ForkJoinPool.ManagedBlocker} to allow other
-         * threads to make progress working on non-leaf tasks while this is blocked, but that would add a
-         * lot of complexity and potentially create concerns regarding the creation of extra contexts for
-         * additional threads. For now, we leave this as a simple busy-wait loop.
-         * </p>
-         * 
-         * @return A new {@code WorkBatch}, guaranteed to be non-{@code null}.
-         * @see CombinationQueueArray
+         * @return A clean, recycled {@code WorkBatch}.
          * @see CombinationQueueArray#getWorkBatchPool()
-         * @see WorkBatch
-         * @since 2025.07.26 - {@code GeneratorContext} Introduction
-         * @performance {@code O(1)} amortized access time, blocking if necessary.
-         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
-         *            safety.
-         * @memory Memory usage is minimized by reusing WorkBatch instances from the pool.
-         * @optimization Uses a busy-wait loop with relaxed polling to avoid deadlocks and allow for
-         *               cancellation.
+         * @since 2025.07 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} amortized access time, spinning if necessary.
+         * @threading Thread-safe interactions with the global pool, but the method itself is not
+         *            thread-safe.
+         * @memory Does not allocate; reuses existing batches in the pool.
          */
         private WorkBatch getNewBatchBlocking() {
             WorkBatch batch;
@@ -438,23 +262,22 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
 
         /**
-         * Resets the {@link #currentBatch current WorkBatch} by obtaining a new one from the pool.
+         * Replaces the {@link #currentBatch} with a new one obtained from the
+         * {@link CombinationQueueArray#getWorkBatchPool() central pool}.
          * 
          * <p>
-         * After a batch has been filled and flushed to the queue, we need to obtain a new batch to continue
-         * the generation process. This method performs that operation, obtaining a new batch from the pool
-         * and setting it as the current batch. The old batch should not be referenced after this call, as
-         * it may be recycled and used by another thread.
+         * This is called after the current {@link WorkBatch batch} is successfully
+         * {@link CombinationGeneratorTask#flushBatchFast(WorkBatch) flushed}. It discards the reference to
+         * the old batch and retrieves a new, clean one, ensuring the generator thread can immediately start
+         * filling it.
          * </p>
          * 
-         * @return The new current {@code WorkBatch}, guaranteed to be non-{@code null}.
+         * @return The new, non-{@code null} {@code WorkBatch}.
          * @see #getNewBatchBlocking()
-         * @since 2025.07.26 - {@code GeneratorContext} Introduction
-         * @performance {@code O(1)} amortized access time, blocking if necessary.
-         * @threading Thread-local - Each thread has its own instance of this context, ensuring thread
-         *            safety.
-         * @memory Memory usage is minimized by reusing {@link WorkBatch} instances from the pool.
-         * @optimization Combines batch reset and retrieval into a single operation to reduce overhead.
+         * @since 2025.07 - {@code GeneratorContext} Introduction
+         * @performance {@code O(1)} amortized access time, spinning if necessary.
+         * @threading Not thread-safe. Each thread should manage its own context instance.
+         * @memory Does not allocate; reuses existing batches in the pool.
          */
         WorkBatch resetBatch() {
             return currentBatch = getNewBatchBlocking();
@@ -463,104 +286,72 @@ public class CombinationGeneratorTask extends RecursiveAction {
 
     // Static fields
     /**
-     * The total number of clicks in each combination.
+     * The target length of the combinations to be generated.
      * 
      * <p>
-     * This field is {@code static} and shared across all tasks, as the number of clicks is constant for
-     * a given puzzle. It is initialized in the root task and used by all subtasks to determine the
-     * length of the combinations being generated.
+     * This is a {@code static} field shared by all tasks. It is initialized by the root task and
+     * defines the recursion depth for the generation process.
      * </p>
      * 
-     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
-     * @see #compute()
      * @see #prefix
      * @see #prefixLength
-     * @since 2025.06.08 - Fork Join Refactor
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @see #compute()
+     * @since 2025.06 - Fork Join Refactor
      * @performance {@code O(1)} access time.
-     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     *            Initialized in the root task before any subtasks are created.
-     * @memory Minimal memory usage as a primitive {@code int}.
-     * @optimization {@code Static} field to avoid redundant storage in each task instance.
+     * @threading Thread-safe due to immutability after initialization.
+     * @memory Minimal memory footprint of 4 bytes as an {@code int}.
      */
     private static int numClicks;
     /**
-     * A {@link CombinationQueueArray} from which to randomly select a queue to which to flush.
+     * The {@link CombinationQueueArray array of queues} used to distribute {@link WorkBatch} objects to
+     * {@link TestClickCombination monkeys}.
      * 
      * <p>
-     * Generators produce combinations and add them to a {@link CombinationQueue queue} for processing
-     * by {@link TestClickCombination monkeys}. To balance the load between multiple monkeys, we use a
-     * {@link CombinationQueueArray} that holds multiple queues and allows us to randomly select one to
-     * which to flush the generated combinations. This field is {@code static} and shared across all
-     * tasks, as the queue array is constant for a given puzzle.
+     * To balance the workload, generators randomly select a {@link CombinationQueue queue} from this
+     * array when {@link #flushBatchFast(WorkBatch) flushing} a batch. This {@code static} field is
+     * initialized by the root task.
      * </p>
      * 
-     * @see #flushBatchFast(WorkBatch)
-     * @see CombinationQueue
-     * @see java.util.concurrent.ThreadLocalRandom
-     * @since 2025.06.08 - Fork Join Refactor
+     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
+     * @since 2025.06 - Fork Join Refactor
      * @performance {@code O(1)} access time.
-     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     *            Initialized in the root task before any subtasks are created.
-     * @memory Minimal memory usage as a reference.
-     * @optimization {@code Static} field to avoid redundant storage in each task instance.
+     * @threading Thread-safe due to immutability after initialization.
+     * @memory Minimal memory footprint of 4 bytes as a reference.
      */
     private static CombinationQueueArray queueArray;
     /**
-     * The maximum index for the first click in a combination.
+     * The maximum index allowed for the first click in any combination.
      * 
      * <p>
-     * Since combinations are generated in lexicographical order, we can optimize the generation process
-     * by limiting the range of possible first clicks. The maximum index for the first click is
-     * determined by the final adjacent cell to the {@link Grid#findFirstTrueCell(Grid.ValueFormat)
-     * first true cell} in the grid, as any combinations starting with a click beyond this point would
-     * not be able to toggle the first {@code true} cell. This field is {@code static} and shared across
-     * all tasks, as the maximum first click index is constant for a given puzzle.
+     * This is a simple but effective pruning optimization. Since combinations are generated in
+     * lexicographical order, we know that the first initially {@code true} cell must be toggled by one
+     * of the clicks in the combination. This value is pre-calculated as the highest-indexed cell
+     * adjacent to the first {@code true} cell, effectively pruning any combinations that start with a
+     * click beyond this point.
      * </p>
      * 
      * @see #compute()
-     * @see Grid
      * @see Grid#findFirstTrueAdjacents(com.github.mrgarbagegamer.Grid.ValueFormat)
-     * @see Grid#findFirstTrueCell(com.github.mrgarbagegamer.Grid.ValueFormat)
-     * @since 2025.06.11 - First Click Optimization
+     * @since 2025.06 - First Click Optimization
      * @performance {@code O(1)} access time.
-     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     *            Initialized in the root task before any subtasks are created.
-     * @memory Minimal memory usage as a primitive {@code int}.
-     * @optimization {@code Static} field to avoid redundant storage in each task instance.
+     * @threading Thread-safe due to immutability after initialization.
+     * @memory Minimal memory footprint of 4 bytes as an {@code int}.
      */
     private static int maxFirstClickIndex;
 
     // Cached data between tasks
     /**
-     * A {@code short[]} representing the current prefix of clicks in {@link Grid.ValueFormat#Index
-     * Index} format.
+     * The sequence of clicks made so far, forming the base for sub-tasks or final combinations.
      * 
      * <p>
-     * Each task in the fork-join architecture represents a prefix of clicks, which is built up as we
-     * descend the tree. This prefix is stored in a {@code short[]} array, which is passed down to
-     * subtasks as they are created. These arrays are {@link ArrayPool#get() pooled} and
-     * {@link ArrayPool#ArrayPool(int) pre-allocated} to avoid excessive allocations and deallocations
-     * on the hot path, sized to {@link #numClicks} for the sake of ensuring the proper amount of space
-     * is available. The current length of {@code prefix} is tracked via the {@link #prefixLength}
-     * field.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using arrays allows for efficient storage and manipulation of {@code prefix}, as we can easily
-     * add new clicks and pass the array down to subtasks. The use of primitive types also helps reduce
-     * memory footprint and improve cache locality. Pooling and pre-allocation help minimize the number
-     * of allocations and deallocations, reducing garbage collection pressure and improving overall
-     * throughput.
-     * </p>
-     * 
-     * <p>
-     * We use {@code short} instead of {@code int} to reduce memory usage, as the maximum number of
-     * cells is {@value Grid#NUM_CELLS}, which fits within the range of a {@code short}. This helps
-     * improve cache locality and reduce memory footprint, which is important in a high-performance
-     * application like this one. If we found a way to represent the prefix using only primitive types
-     * without arrays, we could potentially improve performance further and remove the need for pooling,
-     * but this is not currently feasible due to the maximum number of clicks exceeding 64.
+     * Each task is defined by its {@code prefix}. For an intermediate task, it will
+     * {@link #computeIntermediateSubtasks(GeneratorContext) fork new tasks} by appending a new click to
+     * this {@code prefix}. For a leaf task, it will {@link #computeLeafCombinations(GeneratorContext)
+     * generate final combinations} by appending a final click. The {@code short[]} holding the
+     * {@code prefix} is obtained from a pre-allocated {@link ArrayPool} to prevent heap allocation. To
+     * prevent array resizing, we always allocate arrays of size {@link #numClicks}, tracking the
+     * current length of the {@code prefix} with {@link #prefixLength}.
      * </p>
      * 
      * @see #recycleOwnResources(GeneratorContext)
@@ -569,193 +360,118 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * @see ArrayPool#put(short[])
      * @see GeneratorContext
      * @see GeneratorContext#prefixArrayPool
-     * @since 2025.06.08 - Fork Join Refactor
-     * @performance {@code O(1)} for adding clicks, <code>O({@link #prefixLength})</code> for copying to
-     *              subtasks.
+     * @since 2025.06 - Fork Join Refactor
+     * @performance {@code O(1)} for adding clicks, {@code O(prefixLength)} for copying to subtasks.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     *            Ensure that prefix arrays are not referenced after recycling to avoid concurrency
-     *            issues.
-     * @memory Uses {@code short} arrays to reduce memory usage while maintaining sufficient range.
-     * @optimization Pooled and pre-allocated to minimize allocations on the hot path. Sized to
-     *               {@link #numClicks} to avoid resizing.
+     * @memory Fixed memory footprint of ~{@code numClicks * 2} bytes per task, using pooling to avoid
+     *         allocations.
      */
     private short[] prefix;
     /**
-     * The current length of the {@link #prefix} array, representing the number of clicks made so far.
+     * The current length of the {@link #prefix} array.
      * 
      * <p>
-     * Since we use pre-allocated, {@link ArrayPool pooled} arrays to store the prefix of clicks, we
-     * need a way to track the current length of the {@code prefix} array, as it may not be fully
-     * filled. This field serves that purpose, allowing us to keep track of how many clicks have been
-     * made so far and where to add the next click.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a separate field to track the length of the {@code prefix} allows for efficient addition of
-     * new clicks, as we can simply add the new click at the current length index and increment the
-     * length. This avoids the need to resize or copy the array, which would be expensive and could lead
-     * to excessive allocations and deallocations. It also simplifies the logic for determining whether
-     * a task is a leaf, root, or intermediate task, as we can simply compare the length to the
-     * {@link #numClicks} field.
+     * This value determines the task's position in the generation tree (root, intermediate, or
+     * leaf) and is used as an index for appending the next click, since {@code prefix} arrays are always
+     * sized to {@link #numClicks}.
      * </p>
      * 
      * @see #compute()
-     * @see #numClicks
      * @see #prefix
-     * @since 2025.06.08 - Fork Join Refactor
-     * @performance {@code O(1)} for updates and checks.
+     * @since 2025.06 - Fork Join Refactor
+     * @performance {@code O(1)} access time.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @memory Minimal memory usage as a primitive {@code int}.
-     * @optimization Simple {@code int} field to minimize overhead.
+     * @memory Minimal memory footprint of 4 bytes as an {@code int}.
      */
     private int prefixLength;
     /**
-     * A bitmask representing the adjacency state of the current {@link #prefix}. Each bit corresponds
-     * to an initially true cell in the grid, and a bit is set if the cell is toggled by the current
-     * {@code prefix}. The use of a {@code long} limits us to 64 initially true cells, but all puzzles
-     * in this game have initial true counts that are below this limit.
+     * A bitmask representing the set of initially {@code true} cells toggled by the current
+     * {@link #prefix}.
      * 
      * <p>
-     * A click on a cell only toggles the cells adjacent to it. This provides us with an important
-     * property of the puzzle's solution: The solution must toggle all initially true cells. This
-     * property allows us to prune combinations early by seeing what true cells are toggled by the
-     * current {@code prefix} and checking if the remaining clicks could toggle the remaining true
-     * cells.
+     * This is a critical field for early-stage pruning. Instead of recomputing which {@code true} cells
+     * are affected by a {@code prefix}, each task inherits the state from its parent and updates it
+     * incrementally with a single {@code XOR} operation. This state is then used in
+     * {@link #canPotentiallySatisfyConstraints(int)} to determine if the current path is viable. A
+     * value of {@code -1} indicates an uninitialized state, used only by the root task.
      * </p>
      * 
      * <p>
-     * We want to prune combinations as early as possible to increase the time spent on potentially
-     * valid combinations, but recomputing the adjacency state for every {@code prefix} would be too
-     * expensive. Therefore, we cache the adjacency state of the current {@code prefix} and
-     * incrementally update it as we add new clicks to the {@code prefix}.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Incremental updates amortize the cost of recomputation, allowing us to maintain a low overhead.
-     * Bitwise operations are fast and efficient, making this approach suitable for high-performance
-     * combinatorial tasks.
+     * The use of a {@code long} limits this check to puzzles with 64 or fewer initially {@code true}
+     * cells, but all puzzles simulated in this project fall under this limit.
      * </p>
      * 
      * @see #skipConstraintsCheck
+     * @see #TRUE_CELL_ADJACENCY_MASKS
      * @see #canPotentiallySatisfyConstraints(int)
      * @see #ensureTrueCellMasks(short[])
      * @see Grid#areAdjacent(short, short)
      * @see Grid#findTrueCells()
-     * @since 2025.07.15 - Cached adjacency state introduction
-     * @performance {@code O(1)} for updates, <code>O({@link #prefixLength})</code> for initial
-     *              computation.
-     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation
-     * @memory Uses a {@code long} to represent the adjacency state, which is efficient for up to 64
-     *         initially {@code true} cells.
-     * @optimization Caches the state between tasks to avoid recomputing for every {@link #prefix}.
+     * @since 2025.07 - Cached adjacency state introduction
+     * @performance {@code O(prefixLength)} for initial computation, and {@code O(1)} for updates.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @memory Minimal memory footprint of 8 bytes as a {@code long}.
      */
     private long cachedAdjacencyState = -1;
     /**
-     * A flag indicating whether to skip constraint checks for this task and its children.
+     * A flag indicating that this task and all its descendants are guaranteed to satisfy the
+     * constraints, allowing future checks to be skipped.
      * 
      * <p>
-     * Since {@link #prefix prefixes} are built up incrementally and our
-     * {@link #canPotentiallySatisfyConstraints(int) constraint checks} are monotonic, if a
-     * {@code prefix} is known to satisfy the constraints, we know that all of its children will also
-     * satisfy the constraints. To optimize performance and reduce redundant checks, we can skip
-     * constraint checks for a task and its children if its parent has been verified to satisfy the
-     * constraints. This flag serves that purpose, facilitating the separation of paths in intermediate
-     * task generation.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Skipping constraint checks for tasks that are guaranteed to satisfy them reduces the number of
-     * checks performed, allowing more time to be spent on potentially valid combinations. This
-     * optimization is particularly effective in deep branches of the generation tree, where many tasks
-     * can be skipped. It also simplifies the logic for intermediate task generation, as we can separate
-     * the paths based on this flag and perform a single check prior to dispatching to a subtask path.
+     * This flag is set to {@code true} by {@link #canPotentiallySatisfyConstraints(int)} when a
+     * {@link #prefix} is found to toggle every initially {@code true} cell. Because additional clicks
+     * cannot "un-satisfy" this condition, all child tasks spawned from this point can inherit this flag
+     * and bypass the expensive constraint check. This enables a much faster, branch-free generation
+     * path in {@link #computeIntermediateSubtasksSkipPath(GeneratorContext)}.
      * </p>
      * 
      * @see #cachedAdjacencyState
      * @see #computeIntermediateSubtasks(GeneratorContext)
-     * @since 2025.08.04 - Reduced Branching Refactor
+     * @since 2025.08 - Reduced Branching Refactor
      * @performance {@code O(1)} for checks and updates.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @memory Minimal memory usage as a primitive {@code boolean}.
-     * @optimization Reduces redundant constraint checks in deep branches of the generation tree.
+     * @memory Minimal memory footprint of 1 byte as a {@code boolean}.
      */
     private boolean skipConstraintsCheck = false;
 
     /**
-     * A bitmask representing the target {@code true} adjacency state for the current task. Initialized
-     * in the root task to avoid recomputation in constraint checks.
+     * A bitmask where each bit corresponds to an initially {@code true} cell, and all bits are set to
+     * 1.
      * 
      * <p>
-     * Constraint checks are performed to ensure that the current {@code prefix} or one of its
-     * descendants can satisfy the constraint of touching each initially true cell at least once. For
-     * compact representation in {@link #canPotentiallySatisfyConstraints(int)}, we make a long bitmask
-     * to represent the prefix's {@link #cachedAdjacencyState current adjacency state}, with the bitmask
-     * being sized to the number of initially true cells, and each {@code 1} corresponding to a true
-     * cell.
-     * </p>
+     * This mask represents the goal state for the {@link #canPotentiallySatisfyConstraints(int)} check.
+     * A {@link #prefix} is considered to have directly satisfied the constraints when its
+     * {@link #cachedAdjacencyState} is equal to this {@code targetMask}. It is computed once by the
+     * root task and shared {@code static}ally to avoid re-computation in the hot path.
      * 
-     * <p>
-     * The target mask for the constraint check contains all bits set to 1, but we can't define this as
-     * a {@code static final} constant since the number of initially {@code true} cells can vary between
-     * puzzles. To resolve this, we initialize this mask in the root task constructor, where we have
-     * access to the initially {@code true} cells. This lets us avoid recomputing the mask in every
-     * single constraint check, giving a minor performance boost.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Recomputing the mask each time isn't too complicated, but it adds undesirable overhead to our
-     * constraint checks, increasing the size of the checks and reducing the likelihood of JIT
-     * optimizations. It would also require us to pass an array of the {@code true} cells to every
-     * constraint check call. Optimizations like this appear small, but add up quickly when performed
-     * billions or trillions of times.
-     * </p>
-     * 
-     * @see #cachedAdjacencyState
      * @see #SUFFIX_OR_MASKS
      * @see #ensureTrueCellMasks(short[])
-     * @since 2025.08.04 - Reduced Branching Refactor
-     * @performance {@code O(1)} for checks, {@code O(1)} for initial computation in the root task.
-     * @threading Computed once in the root task and reused across all subtasks.
-     * @memory Uses a {@code long} to represent the target state, which is efficient for up to 64
-     *         initially {@code true} cells.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @since 2025.08 - Reduced Branching Refactor
+     * @performance {@code O(trueCells.length)} for initial computation, and {@code O(1)} for checks.
+     * @threading Thread-safe due to immutability after initialization.
+     * @memory Minimal memory footprint of 8 bytes as a {@code long}.
      */
     private static long targetMask;
     
     /**
-     * The {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
+     * The {@link ForkJoinPool} that executes the generator tasks.
      * 
      * <p>
-     * Since our code already leverages the fork-join framework for parallelism, we can skip explicit
-     * cancellation checks in the hot path by placing the responsibility of task cancellation on the
-     * pool itself, signaled by a {@link TestClickCombination monkey} when it finds a solution. For
-     * monkeys to be able to signal cancellation, however, they need access to the pool, which we
-     * provide via this {@code static} field.
+     * A {@code static} reference to the pool is maintained so that a {@link TestClickCombination}
+     * thread can signal a global shutdown by calling {@link ForkJoinPool#shutdownNow()} on it as soon
+     * as a solution is found. This is the primary mechanism for terminating the search.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a {@code static} field for the pool allows for quick and easy access from any task or
-     * monkey, without the need to pass references around or use {@code ThreadLocal}s. This reduces
-     * overhead and simplifies the code, making it easier to maintain and understand. The
-     * {@code volatile} keyword ensures that changes to the pool reference are visible across threads,
-     * though the pool is best set once at the start of generation and left constant thereafter.
-     * </p>
-     * 
-     * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
+     * @see TestClickCombination#triggerGeneratorShutdown()
+     * @since 2025.07 - Self-Cleanup and Cancellation Refactor
      * @performance {@code O(1)} access time.
-     * @threading {@code static volatile} field - Ensures visibility of changes across threads.
-     * @memory Minimal memory usage as a single reference.
-     * @optimization Static field for quick access without passing references.
+     * @threading Thread-safe due to the use of a {@code static volatile} field.
+     * @memory Minimal memory footprint of 4 bytes as a reference.
      */
     private static volatile ForkJoinPool generatorPool;
 
     /**
-     * Sets the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
+     * Sets the {@link ForkJoinPool} used to execute generator tasks.
      * 
      * <p>
      * This method is used to set the static {@link #generatorPool pool} field, allowing
@@ -764,36 +480,32 @@ public class CombinationGeneratorTask extends RecursiveAction {
      * mid-generation could lead to inconsistent behavior.
      * </p>
      * 
-     * @param pool the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} to use for executing
-     *             generator tasks.
+     * @param pool the {@link ForkJoinPool} to use for executing generator tasks.
      * @see TestClickCombination#triggerGeneratorShutdown()
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
      * @performance {@code O(1)} assignment.
      * @threading Thread-safe due to the use of a {@code static volatile} field, though this method
      *            should be called by one thread only.
-     * @memory Minimal memory usage as a single reference.
-     * @optimization Static field for quick access without passing references.
+     * @memory Does not allocate.
      */
     public static void setForkJoinPool(ForkJoinPool pool) {
         CombinationGeneratorTask.generatorPool = pool;
     }
 
     /**
-     * Gets the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used to execute generator tasks.
+     * Gets the {@link ForkJoinPool} used to execute generator tasks.
      * 
      * <p>
      * This method provides access to the static {@link #generatorPool pool} field, allowing
      * {@link TestClickCombination monkeys} to signal cancellation when they find a solution.
      * </p>
      * 
-     * @return the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} used for executing generator
-     *         tasks.
+     * @return the {@link ForkJoinPool} used for executing generator tasks.
      * @see TestClickCombination#triggerGeneratorShutdown()
      * @since 2025.07.22 - Self-Cleanup and Cancellation Refactor
      * @performance {@code O(1)} access time.
      * @threading Thread-safe due to the use of a {@code static volatile} field.
-     * @memory Only gets a reference, so minimal memory usage.
-     * @optimization Static field for quick access without passing references.
+     * @memory Does not allocate.
      */
     public static ForkJoinPool getForkJoinPool() {
         return generatorPool;
@@ -801,48 +513,27 @@ public class CombinationGeneratorTask extends RecursiveAction {
 
     // Root task constructor
     /**
-     * Constructs a new root task with the specified parameters. The root task is expected to be a
-     * singleton, as it initializes {@code static} fields used by all subtasks, but we do not enforce
-     * this restriction in code.
+     * Constructs the root task for combination generation.
      * 
      * <p>
-     * The root task initializes {@code static} fields that are shared across all tasks, such as the
-     * {@link #numClicks number of clicks}, the {@link #queueArray queue array}, and the
-     * {@link #maxFirstClickIndex maximum first click index}. It also initializes instance fields like
-     * the {@link #prefix prefix array} and {@link #prefixLength prefix length} for the root task (with
-     * {@code prefixLength = 0}). The root task also pre-computes the {@link #targetMask target mask}
-     * for {@link #canPotentiallySatisfyConstraints(int) constraint checks} and the
-     * {@link #FIRST_TRUE_ADJACENTS first true adjacency mask} for the
-     * {@link #computeLeafCombinations(GeneratorContext) odd adjacency check}.
+     * This special constructor is called only once per puzzle run. It is responsible for initializing
+     * all {@code static} fields that are shared across all generator tasks, including
+     * {@link #numClicks}, {@link #queueArray}, and {@link #maxFirstClickIndex}. It also performs
+     * critical one-time pre-computations, such as building the various bitmasks ({@link #targetMask},
+     * {@link #TRUE_CELL_ADJACENCY_MASKS}, etc.) that are essential for performance.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Since the root task is only created once per puzzle, we can afford to perform some expensive
-     * initialization operations here without impacting overall performance. Pre-computing masks and
-     * initializing {@code static} fields helps reduce overhead during the generation process, allowing
-     * subtasks to focus on generating combinations efficiently. The use of pooled arrays for
-     * {@code prefix} helps minimize allocations and deallocations, reducing garbage collection pressure
-     * and improving throughput.
-     * </p>
-     * 
-     * @param numClicks          the number of clicks in each combination.
-     * @param queueArray         the {@link CombinationQueueArray} to which generated combinations will
-     *                           be flushed.
-     * @param trueCells          a {@code short[]} of initially true cells in
-     *                           {@link Grid.ValueFormat#Index Index} format.
-     * @param maxFirstClickIndex the maximum index for the first click in a combination.
-     * @throws IllegalArgumentException if any of the parameters are invalid ({@code null} or out of
-     *                                  range).
-     * @since 2025.06.08 - Fork Join Refactor
+     * @param numClicks          The target number of clicks per combination.
+     * @param queueArray         The {@link CombinationQueueArray array of queues} for distributing
+     *                           work.
+     * @param trueCells          A {@code short[]} of the initially {@code true} cell indices.
+     * @param maxFirstClickIndex The pre-calculated maximum index for the first click.
+     * @throws IllegalArgumentException if parameters are invalid.
+     * @since 2025.06 - Fork Join Refactor
      * @performance {@code O(trueCells.length)} for initialization, amortized over the entire generation
      *              process.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     *            Static fields are initialized in the root task before any subtasks are created.
-     * @memory Uses pooled arrays for {@code prefix} to reduce memory usage. Static fields are minimal in
-     *         size.
-     * @optimization Pre-computes masks and initializes {@code static} fields to reduce overhead during
-     *               generation. Uses pooled arrays for the prefix to minimize allocations.
+     * @memory Does not allocate unless pools are empty (except for the root task).
      */
     public CombinationGeneratorTask(int numClicks, CombinationQueueArray queueArray, short[] trueCells,
             int maxFirstClickIndex) {
@@ -890,79 +581,51 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * A mask representing the adjacency of the first {@code true} cell to other cells.
+     * A bitmask representing the cells adjacent to the first initially {@code true} cell.
      * 
      * <p>
-     * While the {@link TestClickCombination monkeys} handle the more in-depth odd adjacency checks and
-     * the generators perform constraint checks at each branch, we still want some kind of fast check to
-     * be performed at the "leaf" of the generation tree (when a full-length combination has been
-     * built). We therefore create a slimmed-down version of the
-     * {@link TestClickCombination#satisfiesOddAdjacency(short[]) odd adjacency} check that operates
-     * only on the first {@code true} cell. To do this, we need to be able to quickly determine which
-     * cells are adjacent to the first {@code true} cell, which we can do by pre-computing a bitmask for
-     * it.
+     * This mask is used in a lightweight, leaf-level pruning check inside
+     * {@link #computeLeafCombinations(GeneratorContext)}. The check ensures that the first {@code true}
+     * cell is toggled an odd number of times, which is a requirement for a valid solution. It is
+     * {@link #computeAdjacencyMaskFast(short) pre-computed} once by the
+     * {@link #CombinationGeneratorTask(int, CombinationQueueArray, short[], int) root task's
+     * constructor}.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
      * <p>
-     * We use bitmasks for their efficiency in representing sets of toggled cells; other formats like
-     * arrays or lists would be too slow and memory-intensive, and {@link java.util.BitSet BitSet}s
-     * incur abstraction penalties. Since {@code long}s are 64-bit and our {@link Grid} is
-     * {@value Grid#NUM_CELLS} cells, we need two {@code long}s to represent first {@code true}
-     * adjacency for the whole grid. This isn't particularly awful, but it's a limitation that forces us
-     * to perform two checks per final cell instead of one.
+     * A {@code long[2]} array is used to represent the bitmask for all {@value Grid#NUM_CELLS} cells,
+     * as a single {@code long} is insufficient. This allows for fast, cache-friendly bitwise operations
+     * at the cost of requiring two checks per cell in the leaf task loop.
      * </p>
      * 
-     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
-     * @see #computeAdjacencyMaskFast(short)
      * @see Grid#findAdjacents(short)
      * @see Grid#findFirstTrueCell(Grid.ValueFormat)
-     * @since 2025.06.11 - Revamped Odd Adjacency Check
-     * @performance {@code O(1)} for checks, <code>O({@link Grid#findFirstTrueAdjacents()
-     *              Grid.findFirstTrueAdjacents().length}</code> for initial computation.
-     * @threading Statically initialized once in {@link #computeAdjacencyMaskFast(short)} by the root
-     *            task.
-     * @memory Uses an array of two {@code long}s to represent the adjacency of the first {@code true}
-     *         cell.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation. A
-     *               bitmask is used for compact representation.
+     * @see Grid.ValueFormat#Bitmask
+     * @since 2025.06 - Revamped Odd Adjacency Check
+     * @performance {@code O(Grid.findFirstTrueAdjacents().length)} for initial computation, and
+     *              {@code O(1)} for checks.
+     * @threading Thread-safe due to immutability after initialization.
+     * @memory Fixed memory footprint of ~16 bytes as two {@code long}s.
      */
     private static long[] FIRST_TRUE_ADJACENTS;
     
     /**
-     * Computes and caches the adjacency mask for the first true cell.
+     * Computes and caches the bitmask for {@link #FIRST_TRUE_ADJACENTS}.
      * 
      * <p>
-     * For the odd adjacency check done during {@link #computeLeafCombinations(GeneratorContext) leaf
-     * combination generation}, we need a fast way to determine which cells are adjacent to the first
-     * initially {@code true} cell. Bitmasks are a compact and efficient way to represent sets of
-     * toggled cells and worked well in the initial version of that check, but recomputing the mask for
-     * every combination would be too costly. Since we're looking at the initial state of the
-     * {@link Grid grid}, which never changes, we can pre-compute {@link #FIRST_TRUE_ADJACENTS this
-     * mask} during root task initialization and reuse it for all combinations.
+     * This is a one-time operation performed by the root task. It finds all cells adjacent to the first
+     * {@code true} cell and sets the corresponding bits in the static mask, making it available for all
+     * subsequent leaf-level checks.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is called only once per puzzle during root task initialization, so the overhead of
-     * computing the mask is negligible. The use of bitwise operations helps keep the computation fast
-     * and efficient. We use a temporary {@code short[]} array to hold the adjacent cells, and create a
-     * new {@code long[2]} for our mask. Synchronization isn't necessary since this method is called
-     * once during the initialization of the root task, which is single-threaded, guaranteeing that no
-     * other threads will access the {@code static} field during this time.
-     * </p>
-     * 
-     * @param firstTrueCell The index of the first true cell in the grid, in
-     *                      {@link Grid.ValueFormat#Index Index} format.
-     * @see #FIRST_TRUE_ADJACENTS
+     * @param firstTrueCell The index of the first true cell.
      * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
-     * @since 2025.06.11 - Bitmasked Leaf Pruning Introduction
-     * @performance <code>O({@link Grid#findAdjacents(short) Grid.findAdjacents(firstTrueCell)}.length)</code> for
-     *              initial computation.
+     * @see Grid.ValueFormat#Bitmask
+     * @since 2025.06 - Bitmasked Leaf Pruning Introduction
+     * @performance {@code O(Grid.findAdjacents(short).length)} for initial computation.
      * @threading Single-threaded during root task initialization, no synchronization needed.
-     * @memory Uses an array of two {@code long}s to represent the adjacency of the first true cell.
-     *         Creates a temporary {@code short[]} array for adjacent cells.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @memory Allocates a fixed size {@code long[2]} array with a minimal footprint of ~16 bytes.
+     *         Creates a temporary {@code short[]} for adjacent cells.
      */
     private static void computeAdjacencyMaskFast(short firstTrueCell) {
         short[] adjacents = Grid.findAdjacents(firstTrueCell);
@@ -977,78 +640,45 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Constructs a new non-root task with the specified parameters.
+     * A {@code protected} constructor for non-root tasks, used exclusively by the {@link TaskPool}.
      * 
      * <p>
-     * The golden rule of JVM optimizations is <b>don't allocate.</b> Since tasks are pre-allocated by
-     * {@link TaskPool} and reused, we designate this constructor as {@code protected} to prevent
-     * external code from calling it and potentially causing allocations. Instead, external code must
-     * obtain tasks from the pool via {@link TaskPool#get()} and assign their instance fields through
-     * the {@link #init(short[], int, long, boolean) init()} method.
+     * To prevent heap allocations, new tasks are never created directly. Instead, they are recycled
+     * from a {@link TaskPool}. This constructor is therefore made {@code protected} to enforce the
+     * pooling pattern. Task state is configured via the {@link #init} method.
      * </p>
      * 
-     * @see #CombinationGeneratorTask(int, CombinationQueueArray, short[], int)
-     * @since 2025.07.11 - Task Pool Introduction
-     * @performance {@code O(1)} access time, since no allocations or operations are performed.
-     * @threading Isolated by the {@link java.util.concurrent.ForkJoinTask ForkJoinTask} framework, each
-     *            task runs in its own thread.
-     * @memory No memory usage, as no allocations are performed.
-     * @optimization Protected to prevent external allocations, enforcing the use of the task pool.
+     * @since 2025.07 - Task Pool Introduction
+     * @performance {@code O(1)} allocation.
+     * @threading Isolated by the {@link java.util.concurrent.ForkJoinTask ForkJoinTask} framework.
+     * @memory Allocates a {@code CombinationGeneratorTask} instance.
      */
     protected CombinationGeneratorTask() {}
 
     /**
-     * The main task dispatcher method, as required by the {@link java.util.concurrent.ForkJoinTask}
-     * framework.
+     * The main computation method for the {@link RecursiveAction}.
      * 
      * <p>
-     * The {@code ForkJoinTask} interface requires that we implement the
-     * {@link RecursiveAction#compute()} method to define the task's execution logic. Per the
-     * framework's design, we want to break combinations into subtasks and recursively process them in
-     * parallel. Depending on the {@link #prefixLength}, we need to determine which path to take:
+     * This method acts as a dispatcher, determining the task's role based on its {@link #prefixLength}
+     * and delegating to the appropriate computation path:
      * <ul>
-     * <li>{@code prefixLength == 0}: This is the root task, which will
-     * {@link #computeRootSubtasks(GeneratorContext) compute and fork subtasks for the first clicks} and
-     * await their completion.</li>
-     * <li>{@code prefixLength == {@link #numClicks} - 1}: This is a leaf task, which will
-     * {@link #computeLeafCombinations(GeneratorContext) compute the combinations for the last click}
-     * and add them to a {@link WorkBatch} for processing.</li>
-     * <li>{@code 0 < prefixLength < numClicks - 1}: This is an intermediate task, which will
-     * {@link #computeIntermediateSubtasks(GeneratorContext) compute and fork subtasks} for the next
-     * clicks.</li>
+     * <li><b>Root Task</b> ({@code prefixLength == 0}): Invokes
+     * {@link #computeRootSubtasks(GeneratorContext)}.</li>
+     * <li><b>Leaf Task</b> ({@code prefixLength == numClicks - 1}): Invokes
+     * {@link #computeLeafCombinations(GeneratorContext)}.</li>
+     * <li><b>Intermediate Task</b> (otherwise): Invokes
+     * {@link #computeIntermediateSubtasks(GeneratorContext)}.</li>
      * </ul>
+     * A {@code finally} block ensures that {@link #recycleOwnResources(GeneratorContext)} is always
+     * called to return the task and its prefix array to their respective pools. The
+     * {@link GeneratorContext context} is {@link ThreadLocal#get() fetched} once at the start to
+     * minimize {@link ThreadLocal} access overhead.
      * </p>
      * 
-     * <p>
-     * The method also contains logic for recycling resources and cleaning up after itself, ensuring
-     * that memory is managed efficiently and that resources are returned to the appropriate pools.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Creating multiple paths for different task types allows us to optimize the execution flow,
-     * letting the JVM handle optimizations for each path separately. This reduces the number of
-     * branches and conditionals in the hot paths, granting more readable code and allowing the JIT
-     * compiler to optimize them more effectively.
-     * </p>
-     * 
-     * <p>
-     * We also minimize the number of {@link ThreadLocal} accesses by passing down the context directly
-     * to methods, which reduces the overhead of accessing {@code ThreadLocal} variables. The bundled
-     * context object allows us to access all necessary resources with only one expensive call per task,
-     * something that can be amortized over the entire task's execution.
-     * </p>
-     * 
-     * @see #recycleOwnResources(GeneratorContext)
-     * @see GeneratorContext
-     * @see java.lang.ThreadLocal#get()
-     * @since 2025.06.08 - Work-stealing introduction
-     * @performance {@code O(1)} access time for {@code ThreadLocal} context, {@code O(1)} for
-     *              dispatching.
-     * @threading Isolated by the {@link java.util.concurrent.ForkJoinTask ForkJoinTask} framework, each
-     *            task runs in its own thread.
-     * @memory Memory usage is minimized by recycling resources and using pools.
-     * @optimization Multiple paths for different task types to reduce branches and conditionals.
+     * @since 2025.06 - Work-stealing introduction
+     * @performance {@code O(1)} context access, and {@code O(1)} dispatching.
+     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
+     * @memory Does not allocate; uses pooled resources.
      */
     @Override
     protected void compute() {
@@ -1080,57 +710,35 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Computes and forks subtasks for each possible first click, then awaits their completion.
+     * Computes and forks the first level of subtasks from the root task.
      * 
      * <p>
-     * The root task is responsible for generating the initial set of subtasks that will explore all
-     * possible combinations of clicks. It does this by iterating over all valid first clicks and
-     * forking a new subtask for each one. Each subtask is initialized with a {@link #prefix} containing
-     * the first click and the appropriate {@link #cachedAdjacencyState cached adjacency state}.
+     * This method iterates through all valid first clicks, creating and forking a new subtask for each
+     * one. The range of iteration is limited by {@link #maxFirstClickIndex} as a pruning optimization.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
+     * <h3>The {@code helpQuiesce()} Workaround</h3>
      * <p>
-     * Forking subtasks for each first click allows us to leverage the parallelism of the
-     * {@link java.util.concurrent.ForkJoinPool ForkJoinPool} framework, distributing the workload
-     * across multiple threads. We limit the range of first clicks to the specified
-     * {@link #maxFirstClickIndex} to reduce the number of subtasks, which can help with memory usage
-     * and contention.
+     * After forking all subtasks, this method calls {@link #helpQuiesce()}. This is a critical
+     * workaround for a surprising behavior in {@link ForkJoinPool}:
+     * {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)} does not wait for tasks
+     * forked by the task it was invoked on. If we didn't block here, the main thread would un-park
+     * prematurely, long before the search is complete.
      * </p>
-     * 
      * <p>
-     * After forking all subtasks, we call {@link #helpQuiesce()} to wait for their completion. This is
-     * because {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)
-     * ForkJoinPool.awaitQuiescence()} is stupid. For some dumb reason, it doesn't consider forked tasks
-     * as part of its global quiescence check, allowing it to return early if the root task completes
-     * before its children, even if those children are still running. The recycling infrastructure
-     * relies on each task cleaning up after itself, and if the root task finishes before its children
-     * and exits early, the main thread will be unparked and will think that generation is complete (or
-     * that the solution is found), which is obviously wrong. To block the main thread until all
-     * subtasks are complete, we need a way to wait for quiescence that considers forked tasks, which is
-     * what {@link #helpQuiesce()} does. In particular, since the root task is
-     * {@link ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask) invoked} by the main thread, it
-     * will keep the main thread parked until either generation is complete or the solution is found.
+     * Using {@code helpQuiesce()} forces the root task (and by extension, the main thread that
+     * {@link ForkJoinPool#invoke(ForkJoinTask) invoked} it) to participate in work-stealing until all
+     * its descendant tasks are complete. It's a strange quirk, but this is the correct way to ensure
+     * the entire computation tree finishes before the program exits.
      * </p>
      * 
-     * <p>
-     * The idea that a {@code ForkJoinTask}'s {@code awaitQuiescence()} method doesn't account for
-     * forked tasks is silly. The fact that {@code helpQuiesce()} works properly makes me believe
-     * that this is an oversight or bug in the JDK, since it proves that the {@code ForkJoinPool} can
-     * track forked tasks. Oh well.
-     * </p>
-     * 
-     * @param ctx the thread-local {@link GeneratorContext} containing resource pools.
-     * @see #helpQuiesce()
+     * @param ctx The thread-local {@link GeneratorContext}.
      * @see #recycleOwnResources(GeneratorContext)
-     * @since 2025.08.04 - Reduced Branching Refactor
+     * @see StartYourMonkeys#main(String[])
+     * @since 2025.08 - Reduced Branching Refactor
      * @performance {@code O(N)} where {@code N} is the number of valid first clicks.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @memory Memory usage is minimized by recycling resources and using pools. No allocations should
-     *         occur in this method unless the pools are somehow empty.
-     * @optimization Limits the range of first clicks to reduce the number of subtasks. Piggybacks on
-     *               the thread-local nature of the context to avoid multiple
-     *               {@link java.lang.ThreadLocal ThreadLocal} accesses.
+     * @memory Does not allocate unless pools are empty.
      */
     private void computeRootSubtasks(GeneratorContext ctx) {
         final short start = 0;
@@ -1160,45 +768,31 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
     
     /**
-     * Initializes the task with the given parameters, preparing it for execution.
+     * Initializes a recycled task with a new {@link #prefix} and state.
      * 
      * <p>
-     * To avoid excessive allocations and deallocations, we recycle task objects via a {@link TaskPool},
-     * avoiding the need to allocate a new task for every step of the combination generation process.
-     * However, recycling tasks means that we need a way to reinitialize them with new parameters before
-     * execution. This method serves that purpose, taking in the necessary parameters and setting the
-     * task's fields accordingly.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is designed to be fast and efficient, as it is called frequently during the
-     * combination generation process. The method simply assigns the provided parameters to the task's
-     * fields and calls the underlying {@link #reinitialize()} method to reset any derived state,
-     * allowing the task to be resubmitted without causing issues with the {@link ForkJoinPool}
-     * framework.
+     * This method is central to the object pooling strategy. Instead of creating a new task, we recycle
+     * an existing one from the {@link TaskPool} and re-initialize it with a new }{@code prefix} and
+     * state. It assigns the given parameters and calls {@link #reinitialize()} to reset the
+     * {@link java.util.concurrent.ForkJoinTask ForkJoinTask} state, making the task ready for
+     * re-submission.
      * </p>
      * 
      * <p>
-     * Previously, we had separate {@code init()} methods for tasks that would and wouldn't
-     * {@link #skipConstraintsCheck skip constraint checks}, but this created a polymorphic call site
-     * that hindered JVM optimizations. By consolidating the {@code init} methods into a single
-     * monomorphic method, we can improve performance and allow the JIT compiler to perform more
-     * aggressive optimizations, with the trade-off being an unnecessary assignment in some cases.
+     * This method was intentionally designed as a single, monomorphic call site. Previous versions had
+     * multiple {@code init} overloads, which hindered JIT compiler optimizations. By consolidating them
+     * into one method, we improve performance and allow for greater JIT optimizations, at the small
+     * cost of the occasional unnecessary assignment.
      * </p>
      * 
-     * @param prefix               a {@code short[]} representing the current combination state.
-     * @param prefixLength         the length of {@code prefix}.
-     * @param parentAdjacencyState the {@link #cachedAdjacencyState} from the parent task.
-     * @param skipConstraints      whether to skip constraint checks for this task and its children.
-     * @see #reinitialize()
-     * @see TaskPool
-     * @since 2025.07.11 - Task Pool Introduction
+     * @param prefix               The prefix {@code short[]} for the new task.
+     * @param prefixLength         The length of the {@code prefix}.
+     * @param parentAdjacencyState The {@link #cachedAdjacencyState} from the parent task.
+     * @param skipConstraints      A flag indicating if constraint checks can be skipped.
+     * @since 2025.07 - Task Pool Introduction
      * @performance {@code O(1)} for assignments and reinitialization.
-     * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @memory Memory usage is minimized by recycling task objects via a {@code TaskPool}. No
-     *         allocations occur in this method.
-     * @optimization Monomorphic method to avoid polymorphic call sites and improve JIT optimizations.
+     * @threading Not thread-safe; must be called by only one thread at a time on a given task.
+     * @memory Does not allocate; uses pooled resources.
      */
     public void init(short[] prefix, int prefixLength, long parentAdjacencyState, boolean skipConstraints) {
         this.prefix = prefix;
@@ -1210,80 +804,57 @@ public class CombinationGeneratorTask extends RecursiveAction {
 
     // LEAF TASK PATH:
     /**
-     * Computes all valid combinations for the leaf task and adds to
-     * {@link GeneratorContext#currentBatch the current batch}. If the batch is full, it is
-     * {@link #flushBatchFast(WorkBatch) flushed} and replaced.
+     * Generates the final combinations for a leaf task by iterating through all possible final clicks.
      * 
      * <p>
-     * In a leaf task, the {@link #prefix} is at its maximum length ({@code numClicks - 1}), and we need
-     * to compute all valid combinations stemming from it. At this point, our tasks are at the optimal
-     * size for direct computation, and we can start checking them for validity. We do this by iterating
-     * over all possible next clicks, observing to see if they satisfy the parity condition for the
-     * first {@code true} cell (ensuring an odd number of toggles of the first {@code true} cell) and
-     * adding them to the current batch.
+     * This is the final, non-recursive step in the generation process. When a task's
+     * {@link #prefixLength} is one short of the target {@link #numClicks}, this method takes over. It
+     * calculates all valid final clicks and adds the resulting complete combinations to the current
+     * {@link WorkBatch}.
      * </p>
      * 
-     * <h3>Algorithm Details</h3>
+     * <h3>Algorithm and Pruning</h3>
      * <p>
-     * Before iterating over the possible next clicks, we have to compute the parity of the prefix. We
-     * do this by iterating over the prefix and checking if the current cell is adjacent to the first
-     * {@code true} cell. If it is, we toggle the {@code boolean parity} variable. After we finish
-     * iterating, {@code parity} will be in one of two states:
+     * The primary optimization here is a lightweight parity check. For a solution to be valid, the
+     * first initially {@code true} cell must be toggled an odd number of times. This method first
+     * computes the parity of the existing {@link #prefix} (whether it toggles that cell an even or odd
+     * number of times). It then iterates through all possible final clicks, adding only those that
+     * result in a correct final parity. Incidentally, this means including clicks that have an opposite
+     * parity to the {@code prefix} (i.e., if the {@code prefix} has even parity, we need a final click
+     * with odd parity, and vice versa).
      * </p>
      * 
-     * <ul>
-     * <li><b>{@code true}</b>: The prefix has an odd number of toggles of the first {@code true} cell
-     * (we need to ensure that the final click doesn't toggle the first {@code true} cell)</li>
-     * <li><b>{@code false}</b>: The prefix has an even number of toggles of the first {@code true} cell
-     * (we need to ensure that the final click toggles the first {@code true} cell)</li>
-     * </ul>
-     * 
+     * <h3>Performance and Inlining</h3>
      * <p>
-     * The parity of the final click must be the opposite of the prefix parity to ensure that the first
-     * {@code true} cell is toggled correctly. Therefore, we iterate over all possible next clicks and
-     * check if the click's adjacency to the first {@code true} cell matches the prefix parity. If it
-     * doesn't, then we add it to the current batch, flushing the batch if full.
+     * This is a critical hot path. The parity calculation was deliberately inlined into this method to
+     * flatten the call stack, helping the JIT compiler with optimizations like loop unrolling. The
+     * trade-off is that this check runs for every single potential final click, which is expensive.
+     * However, removing it could flood the queues with non-viable combinations, shifting the burden to
+     * the monkeys and degrading overall performance.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
+     * <h3>Future Optimization Ideas</h3>
      * <p>
-     * This method is highly optimized for the hot path of the combination generation process. Our goal
-     * is to minimize branching and conditionals, allowing the JIT compiler to perform aggressive
-     * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
-     * calculations and array dereferences. Originally, there was a separate method for performing the
-     * quick parity check, but this was manually inlined into this method to flatten the call stack and
-     * reduce redundant cache lookups.
+     * The cost of this check could be amortized by tracking parity incrementally, similar to
+     * {@link #cachedAdjacencyState}. This would involve passing the parity down from parent to child,
+     * adding a small overhead to intermediate tasks but making this leaf method faster. For now, the
+     * current implementation represents a stable balance of trade-offs.
      * </p>
      * 
-     * <p>
-     * Leaf-level pruning checks are a nuanced matter, as late-stage pruning cannot be amortized over
-     * multiple descendants. If a task makes it to this level, all of its descendant combinations will
-     * be tested, incurring a conditional check for every single one of them. However, the removal of
-     * this check would cause a performance regression from an increased number of queue operations (and
-     * an increase in non-viable combinations that each {@link TestClickCombination monkey} would have
-     * to test). For now, we've kept this check in place, but it may be removed or lessened in the
-     * future. A potential idea is to take the approach of {@link #cachedAdjacencyState} and perform
-     * parity checks on each task to divide the cost of the check across tasks. Another route would be
-     * to skip the parity check altogether if the prefix is known to satisfy the constraints, but that
-     * would add branching to the method, which we want to avoid in the hot path.
-     * </p>
-     * 
-     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
+     * @param ctx The thread-local {@link GeneratorContext}.
      * @see #FIRST_TRUE_ADJACENTS
      * @see #flushBatchFast(WorkBatch)
      * @see GeneratorContext#getOrCreateBatch()
-     * @since 2025.07.03 - Splitting the Compute Method Into Paths
-     * @performance <code>O({@link #prefixLength})</code> for prefix parity computation,
-     *              <code>O({@link Grid#NUM_CELLS NUM_CELLS} - {@link #prefix}[{@link #prefixLength} - 1])
-     *              </code> for iterating over possible next clicks.
+     * @since 2025.07 - Splitting the Compute Method Into Paths
+     * @performance {@code O(prefixLength)} for {@code prefix} parity computation, and
+     *              {@code O(NUM_CELLS - prefix[prefixLength - 1])} for iterating over possible next
+     *              clicks.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @algorithm Iterates over the prefix to compute parity, then iterates over possible next clicks to
-     *            find valid combinations based on the computed parity.
-     * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
-     *               tight loop with minimal branching to allow for aggressive JIT optimizations.
-     * 
+     * @algorithm Iterates over {@code prefix} to compute parity, then iterates over possible next
+     *            clicks to find valid combinations based on the computed parity.
+     * @memory Does not allocate unless pools are empty; uses pooled resources.
      */
-    private final void computeLeafCombinations(GeneratorContext ctx){
+    private final void computeLeafCombinations(GeneratorContext ctx) {
         // ULTRA-OPTIMIZED: Pre-compute all loop-invariant values and cache array references
         final int start = prefix[prefixLength - 1] + 1;
         final int pLen = prefixLength;
@@ -1337,52 +908,39 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
     
     /**
-     * Dispatches to the appropriate subtask computation method based on the
-     * {@link #skipConstraintsCheck constraint check flag}. This method is called by {@link #compute()}
-     * for intermediate tasks and directs the flow accordingly.
+     * Dispatches to the appropriate intermediate subtask computation method based on the
+     * {@link #skipConstraintsCheck} flag.
      * 
      * <p>
-     * Intermediate tasks are those that are neither the root task nor leaf tasks. They have a
-     * {@link #prefixLength} less than <code>{@link #numClicks} - 1</code> and are responsible for
-     * computing and forking subtasks for the next clicks. {@link #canPotentiallySatisfyConstraints(int)
-     * Pruning logic} is applied in our code to eliminate invalid paths for generators early, but the
-     * nature of our tasks means that if a {@code prefix} is known to satisfy the constraints, all of
-     * its descendants must also satisfy the constraints. Therefore, tracking whether a {@code prefix}
-     * satisfies the constraints allows us to avoid redundant checks for all descendants, which can
-     * significantly improve the performance of subtask computation. However, this introduces branching
-     * and conditionals into the hot path, which we want to avoid.
+     * This method serves as a simple, fast dispatcher for all intermediate tasks (i.e., non-root,
+     * non-leaf). Its sole purpose is to route control to one of two specialized computation paths,
+     * which is a critical optimization for the JIT compiler.
      * </p>
      * 
+     * <h3>Monomorphic Call Site Optimization</h3>
      * <p>
-     * To resolve this, we separate the subtask computation into two distinct methods:
-     * {@link #computeIntermediateSubtasksSkipPath(GeneratorContext) one for prefixes that satisfy the
-     * constraints} and {@link #computeIntermediateSubtasksConstraintPath(GeneratorContext) one for
-     * prefixes that require constraint checks}. This allows us to maintain a monomorphic call site for
-     * each path, reducing branching and conditionals in the hot path and allowing the JIT compiler to
-     * perform more aggressive optimizations.
+     * A key performance goal is to avoid branching inside the hot loops where subtasks are forked. If a
+     * task's {@link #prefix} is already known to satisfy the {@link #canPotentiallySatisfyConstraints
+     * constraint check}, all its descendants can skip that check. Instead of handling this with an
+     * {@code if} statement inside a single, large method, we use two separate methods:
+     * <ul>
+     * <li>{@link #computeIntermediateSubtasksConstraintPath(GeneratorContext)}: The "slow" path that
+     * includes the pruning check.</li>
+     * <li>{@link #computeIntermediateSubtasksSkipPath(GeneratorContext)}: The "fast" path that omits
+     * the check entirely.</li>
+     * </ul>
+     * This dispatcher creates a <strong>monomorphic call site</strong> for each path. The JIT compiler
+     * can more aggressively optimize these separate, branch-free methods than it could a single method
+     * containing a conditional check, leading to significant performance gains. It also simplifies the
+     * code for {@link #compute()}, designating a clear input method for intermediate tasks without an
+     * additional conditional.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is intentionally kept simple to minimize overhead. While a previous version of the
-     * code implemented the constraint check logic directly into {@code compute()}, this created a
-     * bifurcation of the call site that hindered optimizations. Implementing it into any of the
-     * computation methods would introduce branching into the hot path, forcing a conditional check and
-     * redundant pieces of code into the hot path. By separating the paths into distinct methods and
-     * using a simple dispatcher, we can maintain monomorphic call sites for each path, increasing the
-     * likelihood of JIT optimizations and improving overall performance.
-     * </p>
-     * 
-     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
-     * @see #skipConstraintsCheck
-     * @see #compute()
-     * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
-     * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
-     * @since 2025.08.04 - Reduced Branching Refactor
+     * @param ctx The thread-local {@link GeneratorContext}.
+     * @since 2025.08 - Reduced Branching Refactor
      * @performance {@code O(1)} for dispatching.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @optimization Monomorphic call sites for each path to reduce branching and conditionals in the
-     *               hot path.
+     * @memory Does not allocate.
      */
     private void computeIntermediateSubtasks(GeneratorContext ctx) {
         if (skipConstraintsCheck) {
@@ -1394,51 +952,31 @@ public class CombinationGeneratorTask extends RecursiveAction {
     
     // PURE HOT PATH 1:
     /**
-     * Computes and forks subtasks for the next clicks, skipping constraint checks.
+     * Forks subtasks for an intermediate task, skipping the constraint check.
      * 
      * <p>
-     * In the fork-join architecture, tasks that are too large to be directly computed are split into
-     * smaller subtasks that can be processed in parallel. In our program, these are non-leaf tasks
-     * (tasks where the {@link #prefixLength} is less than <code>{@link #numClicks} - 1</code>). This
-     * method computes the next clicks for the current {@code prefix} and forks subtasks for each valid
-     * next click.
+     * This is the "fast path" for intermediate tasks. It is invoked when the current task's
+     * {@link #prefix} has already been proven to satisfy the {@link #canPotentiallySatisfyConstraints
+     * constraint check}, meaning all its descendants are also guaranteed to be on a valid path.
      * </p>
      * 
      * <p>
-     * This form of the method is specifically for tasks where the {@code prefix} is already known to
-     * satisfy the constraints, allowing us to skip constraint checks for all descendants. This
-     * simplifies the loop significantly, increasing the likelihood of JIT optimizations and reducing
-     * the overall footprint of the method.
-     * </p>
+     * This method contains a highly optimized, branch-free loop. It iterates through all possible next
+     * clicks, gets a recycled task and {@code prefix} from the pools,
+     * {@link #init(short[], int, long, boolean) initializes them}, and {@link #fork() forks} them for
+     * execution. Because no pruning checks are needed, the loop body is minimal and extremely friendly
+     * to JIT compiler optimizations. A small safeguard exists to allocate a new array if the
+     * {@link ArrayPool} is exhausted, though this is not expected in normal operation and could be
+     * removed for a slight performance gain at the cost of robustness.
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is optimized for the hot path of the combination generation process. Our goal is to
-     * minimize branching and conditionals, allowing the JIT compiler to perform aggressive
-     * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
-     * calculations and array dereferences. Since this method is only called when
-     * {@link #skipConstraintsCheck} is true, we can avoid the early constraint check to further reduce
-     * the footprint.
-     * </p>
-     * 
-     * <p>
-     * We could consider removing the array allocation safeguard and assume that the {@link ArrayPool}
-     * will always return a non-{@code null} array. This would allow us to remove the {@code null} check
-     * and the conditional allocation in the loop at the cost of having to ensure that the pool is
-     * properly sized at initialization. Since we already do this anyways, it may be worth exploring to
-     * simplify the code and make it smaller for better JIT optimization.
-     * </p>
-     * 
-     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
+     * @param ctx The thread-local {@link GeneratorContext} containing the resource pools.
      * @see #skipConstraintsCheck
      * @see #computeIntermediateSubtasksConstraintPath(GeneratorContext)
-     * @since 2025.08.04 - Specialized Subtask Paths
-     * @performance <code>O({@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
-     *              {@link #prefix}[prefixLength - 1] + 1)</code> for iterating over possible next
-     *              clicks.
+     * @since 2025.08 - Specialized Subtask Paths
+     * @performance {@code O(Grid.NUM_CELLS - numClicks + prefixLength - prefix[prefixLength - 1] + 1)}
+     *              for iterating over possible next clicks.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @optimization Removes constraint check branching, caches loop-invariant values, and uses a tight
-     *               loop with minimal branching to allow for aggressive JIT optimizations.
+     * @memory Does not allocate unless pools are empty; uses pooled resources.
      */
     private void computeIntermediateSubtasksSkipPath(GeneratorContext ctx) {
         final short start = (short) (prefix[prefixLength - 1] + 1);
@@ -1466,57 +1004,37 @@ public class CombinationGeneratorTask extends RecursiveAction {
     
     // PURE HOT PATH 2:
     /**
-     * Computes and forks subtasks for the next clicks, performing checks to prune invalid paths early.
+     * Forks subtasks for an intermediate task, performing a constraint check to prune invalid branches.
      * 
      * <p>
-     * In the fork-join architecture, tasks that are too large to be directly computed are split into
-     * smaller subtasks that can be processed in parallel. In our program, these are non-leaf tasks
-     * (tasks where the {@link #prefixLength} is less than <code>{@link #numClicks} - 1</code>). This
-     * method computes the next clicks for the current {@code prefix} and forks subtasks for each valid
-     * next click.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is optimized for the hot path of the combination generation process. Our goal is to
-     * minimize branching and conditionals, allowing the JIT compiler to perform aggressive
-     * optimizations. We cache all loop-invariant values at the start of the method to minimize repeated
-     * calculations and array dereferences. In this method, we also perform an early constraint check
-     * before loop entry to ensure the validity of the current {@code prefix}. We make sure to propagate
-     * the parent's {@link #skipConstraintsCheck} flag to the children to allow them to skip checks if
-     * the {@code prefix} is known to satisfy constraints.
+     * This is the "slow path" for intermediate tasks. It is invoked when the current task's
+     * {@link #prefix} has not yet been proven to satisfy all constraints. Before forking subtasks, it
+     * performs a critical pruning step by calling {@link #canPotentiallySatisfyConstraints(int)}. If
+     * that check determines that no possible descendant of this task can form a valid solution, the
+     * entire branch is pruned, saving a massive amount of wasted computation.
      * </p>
      * 
      * <p>
-     * As part of the optimization to minimize conditionals, we calculate the child adjacency state
-     * every time in this method, even if the constraint check finds that {@code prefix} directly
-     * satisfies the constraints. While this does avoid branching in the loop, it adds an unnecessary
-     * XOR operation. It may be worth considering an optimization where we check the
-     * {@link #skipConstraintsCheck} flag after performing the early check and execute
-     * {@link #computeIntermediateSubtasksSkipPath(GeneratorContext)} if the flag is set, but this may
-     * add additional method complexity.
+     * If the path is viable, the method proceeds to fork subtasks in a tight loop. For each new
+     * subtask, it incrementally updates the {@link #cachedAdjacencyState} with a single {@code XOR}
+     * operation and passes it down. It also propagates the {@link #skipConstraintsCheck} flag, which
+     * may have been set to {@code true} inside {@code canPotentiallySatisfyConstraints}, allowing all
+     * subsequent children to use the "fast path" from this point forward. To keep the loop free of
+     * conditionals, the adjacency state is calculated even if the check passes and sets the skip flag,
+     * which is a minor trade-off for a more JIT-friendly method body. A similar safeguard for the
+     * {@link ArrayPool} also exists here.
      * </p>
      * 
-     * <p>
-     * In a different vein, we could consider removing the array allocation safeguard and assume that
-     * the {@link ArrayPool} will always return a non-{@code null} array. This would allow us to remove
-     * the {@code null} check and the array allocation in the loop at the cost of having to ensure that
-     * the pool is properly sized at initialization. Since we already do this anyways, it may be worth
-     * exploring to simplify the code and make it smaller for better JIT optimization.
-     * </p>
-     * 
-     * @param ctx the {@link GeneratorContext} containing the current batch and resource pools.
-     * @see #canPotentiallySatisfyConstraints(int)
+     * @param ctx The thread-local {@link GeneratorContext} containing the resource pools.
      * @see #computeIntermediateSubtasksSkipPath(GeneratorContext)
      * @see #ensureTrueCellMasks(short[])
-     * @since 2025.08.04 - Specialized Subtask Paths
+     * @since 2025.08 - Specialized Subtask Paths
      * @performance {@code O(1)} for the early constraint check,
      *              <code>O({@link Grid#NUM_CELLS} - {@link #numClicks} + {@link #prefixLength} -
      *              {@link #prefix}[prefixLength - 1] + 1)</code> for iterating over possible next
      *              clicks.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @optimization Minimizes branching and conditionals, caches loop-invariant values, and uses a
-     *               tight loop with minimal branching to allow for aggressive JIT optimizations.
+     * @memory Does not allocate unless pools are empty; uses pooled resources.
      */
     private void computeIntermediateSubtasksConstraintPath(GeneratorContext ctx) {
         final short start = (short) (prefix[prefixLength - 1] + 1);
@@ -1558,77 +1076,44 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
     
     /**
-     * Checks if the current {@link #prefix} (or the {@code prefix} of a descendant task) could satisfy
-     * the constraints.
+     * Checks if the current {@link #prefix} and its descendants can potentially form a valid solution.
      * 
      * <p>
-     * Though fork-join tasks are designed to be small and fast, too many of them can lead to
-     * performance degradation due to the overhead of task management and scheduling in addition to
-     * extra queue pressure. We want to avoid creating tasks that are guaranteed to fail, and due to the
-     * recursive nature of generation, we want to perform this pruning as early as possible. This method
-     * facilitates that.
+     * This is the primary pruning mechanism in the generation tree. A valid solution must toggle every
+     * initially {@code true} cell. This method uses bitmasks to determine if it's possible for the
+     * current {@code prefix}, combined with any future clicks, to meet this condition. If not, the
+     * entire branch of the search tree is abandoned, saving immense computation.
      * </p>
      * 
-     * <h3>Algorithm Details</h3>
+     * <h3>Algorithm</h3>
      * <p>
-     * To start, we need to understand the constraints of the puzzle. We know that a solution must
-     * toggle all initially {@code true} cells in order to be valid. While it is also a requirement that
-     * those cells are toggled an odd number of times, we can simplify our checks at the moment by
-     * focusing on whether the cells are toggled at all.
+     * The check is performed in two stages, both using {@code O(1)} bitwise operations:
+     * <ol>
+     * <li><b>Direct Check:</b> It computes the {@code needed} bits by XORing the
+     * {@link #cachedAdjacencyState} (which {@code true} cells are toggled by the current prefix) with
+     * the {@link #targetMask} (all {@code true} cells). If {@code needed} is zero, the constraint is
+     * already met. As an optimization, it sets {@link #skipConstraintsCheck} to {@code true}, allowing
+     * all descendants to use a faster, check-free generation path.</li>
+     * <li><b>Potential Check:</b> If the constraint is not yet met, it checks if it's still
+     * <em>possible</em> to meet it. It uses a pre-computed {@link #SUFFIX_OR_MASKS} bitmask, which
+     * represents all the {@code true} cells that <em>could</em> be toggled by any of the remaining
+     * available clicks. If the bitwise {@code AND} of this "available" mask and the {@code needed} mask
+     * equals the {@code needed} mask, it means a solution is still possible, and the path is not
+     * pruned.</li>
+     * </ol>
+     * This allows the method to prune with certainty without needing to iterate through future clicks.
      * </p>
      * 
-     * <p>
-     * Since this check concerns itself with only the initially {@code true} cells, we can simplify the
-     * grid to a {@link #targetMask target bitmask} representing the toggled state of those cells. We
-     * can then XOR {@code targetMask} with {@link #cachedAdjacencyState} to find which bits need to be
-     * flipped to satisfy the constraints. If all of the initially {@code true} cells are toggled, the
-     * XOR result will be zero and we can skip further checks, returning {@code true} and setting the
-     * {@link #skipConstraintsCheck} flag.
-     * </p>
-     * 
-     * <p>
-     * As we're performing these checks very early on, it's possible that the current {@code prefix} may
-     * not be long enough to satisfy the constraints but a descendant task may be able to. To handle
-     * this, we use {@link #SUFFIX_OR_MASKS pre-computed OR masks} to quickly check if any of the
-     * remaining clicks could satisfy the constraints. If this mask ANDed with the needed bits is equal
-     * to the needed bits (the mask contains all bits that need to be flipped), we can assume that at
-     * least one descendant can satisfy the constraints and return true.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method employs several optimizations to ensure that it runs as fast as possible while being
-     * strict. We cache all loop-invariant values at the start of the method to minimize repeated
-     * calculations and array dereferences. The use of bitmasks allows us to perform set operations
-     * quickly and efficiently, reducing the complexity of the checks. The pre-computed suffix OR masks
-     * allow us to avoid {@code O(N)} checks for each {@code prefix}, reducing the complexity to
-     * {@code O(1)}.
-     * </p>
-     * 
-     * <p>
-     * If a prefix is found to directly satisfy the constraints, we set the
-     * {@link #skipConstraintsCheck} flag to true to skip future checks for all descendants. This
-     * optimization is crucial for performance, as it allows us to avoid redundant checks and create an
-     * optimized path for valid {@code prefixes}.
-     * </p>
-     * 
-     * @param startIdx the index of the first possible next click (used for suffix OR checks)
-     * 
-     * @return {@code true} if the current {@link #prefix} or any descendant can satisfy the
-     *         constraints, {@code false} otherwise.
+     * @param startIdx The starting index for the next click, used to look up the correct suffix mask.
+     * @return {@code true} if this path is still viable, {@code false} if it should be pruned.
      * @see #TRUE_CELL_ADJACENCY_MASKS
-     * @see #ensureTrueCellMasks(short[])
-     * @see Grid#findAdjacents(short)
+     * @see Grid#findAdjacents(short, Grid.ValueFormat, Grid.ValueFormat)
      * @see Grid#findTrueCells(Grid.ValueFormat)
-     * @since 2025.07.03 - Splitting the Compute Method Into Paths
-     * @performance {@code O(1)} for the check due to bitmask operations and pre-computed suffix OR
-     *              masks.
+     * @see Grid.ValueFormat#Bitmask
+     * @since 2025.07 - Splitting the Compute Method Into Paths
+     * @performance {@code O(1)} due to the use of pre-computed bitmasks.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation.
-     * @algorithm Uses bitmask operations to determine if the current {@code prefix} or any descendant
-     *            can satisfy the constraints and compares against a pre-computed {@link #targetMask
-     *            target mask} and pre-computed {@link #SUFFIX_OR_MASKS suffix OR masks}.
-     * @optimization Caches loop-invariant values, uses bitmask operations, and employs pre-computed
-     *               suffix OR masks to reduce complexity.
+     * @memory Does not allocate; uses pre-computed {@code static} bitmasks.
      */
     private boolean canPotentiallySatisfyConstraints(int startIdx) {   
         // OPTIMIZATION: Call ensureTrueCellMasks once in the root task to avoid a call here.
@@ -1657,144 +1142,90 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Bitmasks representing the adjacency of each cell to initially {@code true} cells.
+     * An array of bitmasks where each mask represents which of the initially {@code true} cells a given
+     * click is adjacent to.
      * 
      * <p>
-     * Efficiently generating combinations requires the ability to prune invalid paths early, preventing
-     * wasted computation. A key property of the puzzle is that a solution must toggle all initially
-     * {@code true} cells. This gives us a way to prune combinations early, but we still need a way to
-     * quickly determine which {@code true} cells are toggled by a given {@code prefix} of clicks. This
-     * field gives us that ability.
+     * This is a core data structure for {@link #canPotentiallySatisfyConstraints(int) pruning}.
+     * {@code TRUE_CELL_ADJACENCY_MASKS[i]} is a {@code long} where the {@code k}-th bit is {@code 1} if
+     * and only if clicking cell {@code i} toggles the {@code k}-th initially {@code true} cell.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
      * <p>
-     * Bitmasks are used for their efficiency in representing sets of toggled cells; other formats like
-     * arrays or lists would be too slow and memory-intensive. The use of {@code long}s does limit us to
-     * pre-computing up to 64 initially true cells, but all puzzles in this game have initial
-     * {@code true} counts that are below this limit.
+     * This allows for {@code O(1)} updates to the {@link #cachedAdjacencyState} (e.g.,
+     * {@code state ^= TRUE_CELL_ADJACENCY_MASKS[click]}) instead of expensive re-computation. It is
+     * initialized once per puzzle run by {@link #ensureTrueCellMasks(short[])}. The use of a
+     * {@code long} limits this optimization to puzzles with 64 or fewer {@code true} cells.
      * </p>
      * 
-     * @see #ensureTrueCellMasks(short[])
-     * @see #SUFFIX_OR_MASKS
-     * @see Grid#findAdjacents(short)
+     * @see #canPotentiallySatisfyConstraints(int)
+     * @see Grid#findAdjacents(short, Grid.ValueFormat, Grid.ValueFormat)
      * @see Grid#findTrueCells(Grid.ValueFormat)
-     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @since 2025.07 - Bitmasked Adjacency Checks
      * @performance {@code O(1)} for adjacency checks, {@code O(trueCells.length)} for initial
      *              computation.
      * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
-     * @memory One {@code long} per cell, guaranteeing a fixed memory footprint regardless of the number
-     *         of {@code true} cells and avoiding object overhead.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @memory Fixed memory footprint of ~{@code 8 * Grid.NUM_CELLS} bytes as a {@code long} array.
      */
     private static long[] TRUE_CELL_ADJACENCY_MASKS = null;
     /**
-     * Pre-computed suffix OR masks for fast constraint checks.
+     * An array of pre-computed "suffix OR" bitmasks for {@code O(1)} constraint checking.
      * 
      * <p>
-     * There are three cases that can occur when performing a constraint check:
+     * This is a critical optimization for {@link #canPotentiallySatisfyConstraints(int)}. The mask at
+     * index {@code i} is the bitwise {@code OR} of all {@link #TRUE_CELL_ADJACENCY_MASKS} from index
+     * {@code i} to the end of the grid.
      * </p>
-     * <ol>
-     * <li>The current {@link #prefix} already satisfies the constraints, meaning the test is
-     * passed.</li>
-     * <li>The current {@code prefix} doesn't fully satisfy the constraints, but one or more of its
-     * descendants may be able to.</li>
-     * <li>The current {@code prefix} and all of its descendants cannot satisfy the constraints.</li>
-     * </ol>
-     * 
      * <p>
-     * The first case is trivial, but the second and third are more complex. Since combinations have
-     * clicks in an increasing order (and no duplicates), we know that the range of additional clicks
-     * holding this {@code prefix} is constrained to the range of cells that are greater than the last
-     * click in the {@code prefix}. By summing together the {@link #TRUE_CELL_ADJACENCY_MASKS true
-     * adjacency masks} of all clicks after the last click in the {@code prefix}, we can quickly
-     * determine if any of the child combinations can toggle the remaining {@code true} cells.
+     * In effect, {@code SUFFIX_OR_MASKS[i]} represents every {@code true} cell that can possibly be
+     * toggled by <em>any</em> future click from index {@code i} onwards. This allows the constraint
+     * check to determine if a solution is still possible in a single {@code O(1)} bitwise operation,
+     * rather than iterating through all remaining clicks (though the use of a {@code long} limits this
+     * optimization to puzzles with 64 or fewer {@code true} cells). It is initialized once per puzzle
+     * run by {@link #ensureTrueCellMasks(short[])}.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * The mask at index {@code i} contains the OR of all masks from {@code i} to the end of the array.
-     * This allows us to avoid an <code>O({@value Grid#NUM_CELLS} - i)</code> check for each
-     * {@code prefix}, reducing the complexity to {@code O(1)}. Bitmasks are used for their efficiency
-     * in representing sets of toggled cells; other formats like arrays or lists would be too slow and
-     * memory-intensive. The use of {@code long}s does limit us to pre-computing up to 64 initially
-     * {@code true} cells, but all puzzles in this game have initial true counts that are below this
-     * limit.
-     * </p>
-     * 
-     * @see #TRUE_CELL_ADJACENCY_MASKS
-     * @see #canPotentiallySatisfyConstraints(int)
-     * @see #ensureTrueCellMasks(short[])
-     * @see Grid#findAdjacents(short)
-     * @since 2025.07.14 - Suffix OR Masks Introduction
-     * @performance {@code O(1)} for suffix OR checks, <code>O({@value Grid#NUM_CELLS})</code> for
-     *              initial computation.
-     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])}
-     * @memory One {@code long} per cell, guaranteeing a fixed memory footprint regardless of the number
-     *         of {@code true} cells and avoiding object overhead.
-     * @optimization Pre-computed once per puzzle and reused across tasks to avoid recomputation.
+     * @since 2025.07 - Suffix OR Masks Introduction
+     * @performance {@code O(1)} for constraint checks, {@code O(Grid.NUM_CELLS)} for initial
+     *              computation.
+     * @threading Statically initialized once by {@link #ensureTrueCellMasks(short[])} and effectively
+     *            {@code final} thereafter.
+     * @memory Fixed memory footprint of ~{@code 8 * Grid.NUM_CELLS} bytes as a {@code long} array.
      */
     private static long[] SUFFIX_OR_MASKS = null;
     /**
-     * Adjacency matrix representing which cells are adjacent to each other. Used for initializing
-     * {@link #TRUE_CELL_ADJACENCY_MASKS}.
+     * A static adjacency matrix used to initialize {@link #TRUE_CELL_ADJACENCY_MASKS}.
      * 
-     * <h3>Performance Considerations</h3>
      * <p>
-     * This matrix is technically only used for the initialization of
-     * {@link #TRUE_CELL_ADJACENCY_MASKS}, meaning that it could be replaced by direct calls to
-     * {@link Grid#findAdjacents(short, Grid.ValueFormat)} (or the creation of a method to expose the
-     * cache behind {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}), though we've kept it
-     * since this field pre-dates the creation of the bitmasked Grid state.
+     * {@code CLICK_ADJACENCY_MATRIX[i][j]} is {@code true} if clicking cell {@code i} toggles cell
+     * {@code j}. This is a legacy structure used during the {@link #ensureTrueCellMasks(short[])
+     * one-time computation} of the bitmasks. It is less efficient than the bitmask-based checks in
+     * {@link Grid} but is retained for this setup step, since it pre-dates the bitmask optimizations.
      * </p>
      * 
      * @see #initClickAdjacencyMatrix()
-     * @see Grid#findAdjacents(short, Grid.ValueFormat)
-     * @since 2025.07.06 - Bitmasked Adjacency Checks
+     * @since 2025.07 - Bitmasked Adjacency Checks
      * @performance {@code O(1)} for adjacency checks, <code>O({@value Grid#NUM_CELLS}²)</code> for
      *              initial computation.
      * @threading Statically initialized once at class load time.
-     * @memory Fixed-size boolean matrix of size {@value Grid#NUM_CELLS} × {@value Grid#NUM_CELLS}. This
-     *         guarantees a fixed memory footprint and avoids object overhead.
-     * @optimization Pre-computed once at class load time to avoid recomputation, uses {@code boolean}
-     *               matrix for efficient adjacency representation.
+     * @memory Fixed memory footprint of ~<code>{@value Grid#NUM_CELLS}²</code> bytes as a
+     *         {@code boolean} matrix.
      */
     private static final boolean[][] CLICK_ADJACENCY_MATRIX = initClickAdjacencyMatrix();
 
     /**
-     * Initializes the {@link #CLICK_ADJACENCY_MATRIX} representing adjacency relationships between
-     * cells.
+     * Initializes the {@code static} {@link #CLICK_ADJACENCY_MATRIX} upon class loading.
      * 
-     * <h3>Algorithm Details</h3>
      * <p>
-     * The method creates a {@code boolean[][]} where each row corresponds to a cell in the grid and
-     * each column corresponds to whether that cell is adjacent to another cell. It iterates over all
-     * cells in the grid, using {@link Grid#findAdjacents(short, Grid.ValueFormat)} to find the adjacent
-     * cells for each cell. The adjacency relationships are then stored in the matrix.
+     * This method performs a one-time computation, iterating through every cell in the grid and using
+     * {@link Grid#findAdjacents(short, Grid.ValueFormat)} to populate the adjacency matrix. It is
+     * called only once when the class is loaded.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is called once at class initialization, so its performance is not as critical as
-     * other parts of the program. This matrix is technically only used for the initialization of
-     * {@link #TRUE_CELL_ADJACENCY_MASKS}, meaning that it could be replaced by direct calls to
-     * {@link Grid#findAdjacents(short, Grid.ValueFormat)} (or the creation of a method to expose the
-     * cache behind {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}), though we've kept it
-     * since this method pre-dates the creation of the bitmasked adjacency checks.
-     * </p>
-     * 
-     * @return a {@code boolean[][]} where {@code matrix[i][j]} is true if cell {@code i} is adjacent to
-     *         cell {@code j}.
-     * @see #CLICK_ADJACENCY_MATRIX
-     * @see Grid#findAdjacents(short, Grid.ValueFormat)
-     * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @performance <code>O({@value Grid#NUM_CELLS}²)</code>, due to nested iteration over cells and
-     *              their adjacents.
-     * @threading Statically initialized once at class load time.
-     * @memory Allocates a fixed-size boolean matrix of size {@value Grid#NUM_CELLS} ×
-     *         {@value Grid#NUM_CELLS}.
-     * @optimization Pre-computed once at class load time to avoid recomputation, uses {@code boolean}
-     *               matrix for efficient adjacency representation.
+     * @return A {@code boolean[Grid.NUM_CELLS][Grid.NUM_CELLS} matrix representing cell adjacencies.
+     * @since 2025.07 - Bitmasked Adjacency Checks
+     * @performance {@code O(Grid.NUM_CELLS²)}, due to nested iteration over cells and their adjacents.
+     * @threading Thread-safe as it is called once during class loading and creates an immutable result.
+     * @memory Allocates a fixed-size adjacency matrix of {@code Grid.NUM_CELLS²} bytes.
      */
     private static boolean[][] initClickAdjacencyMatrix() {
         boolean[][] matrix = new boolean[Grid.NUM_CELLS][Grid.NUM_CELLS];
@@ -1810,61 +1241,37 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Initializes the {@link #TRUE_CELL_ADJACENCY_MASKS} and {@link #SUFFIX_OR_MASKS} if they are not
-     * already initialized.
+     * Initializes the static {@link #TRUE_CELL_ADJACENCY_MASKS} and {@link #SUFFIX_OR_MASKS} for a
+     * given puzzle.
      * 
      * <p>
-     * Our pruning strategy relies on quickly determining which {@code true} cells are toggled by a
-     * given {@code prefix} of clicks. In order to make these checks efficient (and constant time), we
-     * use pre-computed masks where possible to avoid repeated calculations. Naturally, though, that
-     * means that we need to compute these masks at some point. This method does that, ensuring that the
-     * masks are only computed once per puzzle and reused across tasks.
+     * This method performs the one-time, expensive pre-computation of the bitmasks used for pruning. It
+     * is called by the root task and uses double-checked locking to ensure the computation happens only
+     * once, even if multiple threads somehow invoke it.
      * </p>
      * 
-     * <h3>Algorithm Details</h3>
+     * <h3>Algorithm</h3>
      * <p>
-     * The method first lazily checks if the masks are already initialized before entering a
-     * {@code synchronized} block, ensuring that one thread performs the initialization (but that
-     * multiple threads could call the method). Inside the {@code synchronized} block, it checks again
-     * if the masks are initialized to avoid redundant computation.
+     * The process has two main steps:
+     * <ol>
+     * <li><b>Adjacency Masks:</b> It iterates through every possible click cell ({@code 0} to
+     * {@value Grid#NUM_CELLS}). For each one, it builds a bitmask representing which of the puzzle's
+     * {@code trueCells} it is adjacent to, using the {@link #CLICK_ADJACENCY_MATRIX}. The results are
+     * stored in {@link #TRUE_CELL_ADJACENCY_MASKS}.</li>
+     * <li><b>Suffix OR Masks:</b> It then iterates backwards over the newly created adjacency masks to
+     * compute the {@link #SUFFIX_OR_MASKS}. Each entry {@code SUFFIX_OR_MASKS[i]} is the cumulative
+     * bitwise {@code OR} of all adjacency masks from {@code i} to the end.</li>
+     * </ol>
+     * This pre-computation is what enables subsequent {@code O(1)}
+     * {@link #canPotentiallySatisfyConstraints(int) constraint checks}.
      * </p>
      * 
-     * <p>
-     * For each click cell, it constructs a bitmask of length {@code trueCells.length} where each bit
-     * represents whether the corresponding {@code true} cell is adjacent to the click cell. This is
-     * done by using the {@link #CLICK_ADJACENCY_MATRIX} to check adjacency. The resulting masks are
-     * stored in the {@link #TRUE_CELL_ADJACENCY_MASKS} array.
-     * </p>
-     * 
-     * <p>
-     * After computing the main masks, it computes the {@link #SUFFIX_OR_MASKS} by iterating backwards
-     * over the {@link #TRUE_CELL_ADJACENCY_MASKS} and performing a cumulative OR operation. This allows
-     * us to quickly check if any of the remaining clicks can satisfy the constraints in a constant
-     * timeframe.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is designed to be called once per puzzle, so its performance is not as critical as
-     * other parts of the program. However, we still want to ensure that it runs efficiently and does
-     * not introduce unnecessary overhead. The double-checked locking pattern ensures that the masks
-     * aren't computed multiple times in a multi-threaded environment while minimizing synchronization
-     * overhead.
-     * </p>
-     * 
-     * @param trueCells a {@code short[]} of initially {@code true} cells in the grid in
-     *                  {@link Grid.ValueFormat#Index Index} format.
-     * @see #CLICK_ADJACENCY_MATRIX
-     * @see #SUFFIX_OR_MASKS
-     * @see #TRUE_CELL_ADJACENCY_MASKS
-     * @see #initClickAdjacencyMatrix()
-     * @since 2025.07.06 - Bitmasked Adjacency Checks
-     * @performance <code>O({@link #numClicks} × {@value Grid#NUM_CELLS})</code>.
-     * @threading Thread-safe due to {@code synchronized} block and double-checked locking.
-     * @memory One {@code long} per cell for {@link #TRUE_CELL_ADJACENCY_MASKS} and one {@code long} per
-     *         cell plus one for {@link #SUFFIX_OR_MASKS}.
-     * @optimization Uses double-checked locking to minimize synchronization overhead, pre-computes
-     *               masks once per puzzle to avoid recomputation.
+     * @param trueCells The {@code short[]} of initially {@code true} cell indices for the current
+     *                  puzzle.
+     * @see Grid.ValueFormat#Bitmask
+     * @since 2025.07 - Bitmasked Adjacency Checks
+     * @threading Thread-safe due to a {@code synchronized} block with double-checked locking.
+     * @memory Allocates two fixed-size arrays of ~<code>{@value Grid#NUM_CELLS} * 8</code> bytes each.
      */
     private static void ensureTrueCellMasks(short[] trueCells) {
         if (TRUE_CELL_ADJACENCY_MASKS == null | SUFFIX_OR_MASKS == null)
@@ -1905,76 +1312,48 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Flushes the given {@link WorkBatch batch} to any available {@link CombinationQueue queue},
-     * sleeping briefly if all queues are full.
+     * Flushes a {@link WorkBatch batch} of combinations to an available {@link CombinationQueue queue},
+     * employing a backoff strategy if all queues are temporarily full.
      * 
      * <p>
-     * Our program's architecture relies on an equal number of generators and
-     * {@link TestClickCombination monkeys} to generate and test combinations in parallel. Communication
-     * between these two components is handled through an array of {@link CombinationQueue queues}, but
-     * we need some mechanism to enqueue these batches of work for the monkeys to process while
-     * maintaining backpressure mechanisms to prevent queue overload or busy-waiting. This method aims
-     * to do that.
+     * This method is a critical component of the producer-consumer architecture, ensuring that
+     * generated combinations are efficiently transferred to {@link TestClickCombination monkeys} for
+     * validation. It implements a robust mechanism to handle queue contention and backpressure without
+     * dropping any combinations.
      * </p>
      * 
-     * <h3>Algorithm Details</h3>
+     * <h3>Algorithm</h3>
      * <p>
-     * The method first retrieves all available queues from the {@link CombinationQueueArray} and
-     * selects a random starting index to avoid contention. It then iterates over the queues, attempting
-     * to {@link CombinationQueue#add(WorkBatch) add} the batch to any available queue. If a queue
-     * accepts the batch, the method immediately returns {@code true}. If all queues are full, the
-     * method {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting before
-     * looping once more.
+     * The method attempts to add the {@code WorkBatch} to a {@link ThreadLocalRandom#nextInt(int)
+     * randomly selected queue} from the {@link #queueArray}. To minimize contention, it tries each
+     * queue once in a round-robin fashion. If all queues are full, the thread
+     * {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting, then retries. This
+     * loop continues indefinitely until the batch is successfully enqueued or the thread is
+     * interrupted. This "never drop a combination" rule is fundamental to the solver's correctness.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
+     * <h3>Future Optimizations</h3>
      * <p>
-     * This method is designed to be called frequently by generator tasks, so its performance is
-     * critical. We use {@link ThreadLocalRandom} to select a random starting index to try to balance
-     * the load across queues and minimize contention. The brief sleep when all queues are full provides
-     * a backpressure mechanism to prevent busy-waiting while still allowing for quick retries.
+     * The current backpressure mechanism (sleeping) is simple but can be improved. Potential
+     * enhancements include:
+     * <ul>
+     * <li>Using {@link ForkJoinPool.ManagedBlocker} to allow the pool to compensate for blocked
+     * generator threads by spinning up other workers.</li>
+     * <li>Implementing a more sophisticated blocking strategy (e.g., using a dedicated signal from
+     * consumers) to wake generator threads only when queue space is available, avoiding unnecessary
+     * sleeps. This could, however, increase complexity, potentially requiring a shift to a different
+     * queue structure.</li>
+     * </ul>
      * </p>
      * 
-     * <p>
-     * While it may seem tempting to only make one attempt to enqueue the batch before giving up, this
-     * violates the fundamental rule of our program: No combinations should be dropped before being
-     * properly tested. By looping until successful, we ensure that all generated combinations are
-     * eventually tested, even if it means waiting briefly for an available queue.
-     * </p>
-     * 
-     * <p>
-     * Since this method's progress depends on the state of the queues, we stop making progress if all
-     * queues consistently get filled up. A future optimization could be to implement a more
-     * sophisticated approach that can spin up extra generators to work through non-leaf tasks if the
-     * queues are full (see {@link ForkJoinPool.ManagedBlocker}).
-     * </p>
-     * 
-     * <p>
-     * Another area of potential optimization is to use a backoff strategy that can block the task when
-     * queues are full rather than sleeping. This would be more efficient and reduce the need for
-     * constant awakenings, but this is easier said than done. We would need some type of way to signal
-     * to the generators when a queue has space available and wake them up for this purpose, but
-     * blocking queues block on all operations. Also, how can we ensure that one generator is woken up
-     * when any queue has space (since you can't block on multiple queues at once)? That may require the
-     * need for an SPMC queue structure, which wouldn't be awful but would create complexity. All of
-     * these considerations are left for future work, but are worth noting as areas for great
-     * improvement.
-     * </p>
-     * 
-     * @param batch the {@link WorkBatch} to flush.
+     * @param batch The {@link WorkBatch} containing generated combinations to be flushed.
      * @return {@code true} if the batch was successfully flushed, {@code false} if the thread was
-     *         interrupted.
-     * @see #queueArray
+     *         interrupted before flushing could complete.
      * @see CombinationQueue#add(WorkBatch)
-     * @see CombinationQueueArray#getAllQueues()
-     * @see java.util.concurrent.ThreadLocalRandom
      * @since 2025.06.08 - Fork Join Refactor
-     * @performance <code>O({@link CombinationQueueArray#getAllQueues() queues}.length)</code> per trial, with
-     *              a brief sleep if all queues are full.
-     * @threading Thread-safe due to local queue access and atomic operations in
+     * @performance {@code O(numQueues)} per attempt, with a brief sleep if all queues are full.
+     * @threading Thread-safe due to local queue access and atomic operations within
      *            {@link CombinationQueue#add(WorkBatch)}.
-     * @optimization Uses random starting index to minimize contention, brief sleep to avoid
-     *               busy-waiting.
      */
     private final boolean flushBatchFast(WorkBatch batch) {   
         CombinationQueue[] queues = queueArray.getAllQueues();
@@ -2001,39 +1380,32 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Recycles the resources owned by this task back to the pools in the given
-     * {@link GeneratorContext}.
+     * Recycles the {@link #prefix} and the {@code CombinationGeneratorTask} instance back to their
+     * respective pools within the provided {@link GeneratorContext}.
      * 
      * <p>
-     * Fork-join tasks are designed to be small and fast, but frequent allocations can lead to GC
-     * pressure and degrade performance. We implement resource pooling to mitigate this, allowing tasks
-     * to reuse arrays and task objects rather than constantly allocating and deallocating them, but we
-     * need a way to return these resources to the pools when a task is done. This method does that.
+     * This method is invoked by each {@code CombinationGeneratorTask} upon completion of its
+     * {@link #compute()} method. It is a fundamental part of the object pooling strategy, preventing
+     * excessive heap allocations and subsequent garbage collection overhead during the high-volume
+     * generation process.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
      * <p>
-     * This method is called once per task completion, making it less performance-critical than other
-     * parts of the code, but we still want to ensure that it runs efficiently so generators can quickly
-     * move to the next task. We avoid accessing the {@link ThreadLocal} context here, instead relying
-     * on the passed-in context and its fields. This reduces the overhead of accessing thread-local
-     * storage to once per task and allows the pools to piggyback on the same context used for
-     * {@link WorkBatch batch} management.
+     * By returning objects to pools instead of allowing them to be garbage collected, the solver
+     * maintains a low memory footprint and consistent performance, avoiding "stop-the-world" pauses.
      * </p>
      * 
-     * @param ctx the {@link GeneratorContext} containing the resource pools.
+     * @param ctx The thread-local {@link GeneratorContext} containing the {@link ArrayPool} and
+     *            {@link TaskPool}.
      * @see #context
      * @see ArrayPool
      * @see ArrayPool#put(short[])
-     * @see GeneratorContext
      * @see TaskPool
      * @see TaskPool#put(CombinationGeneratorTask)
-     * @since 2025.07.22 - Task Self-Recycling
-     * @performance {@code O(1)} for returning resources to the pools.
+     * @since 2025.07 - Task Self-Recycling
+     * @performance {@code O(1)} for returning resources.
      * @threading Thread-safe due to {@link java.util.concurrent.ForkJoinTask ForkJoinTask} isolation
-     *            and local context access.
-     * @optimization Avoids {@code ThreadLocal} access by using passed-in context, reuses existing
-     *               pools.
+     *            and thread-local {@code GeneratorContext}.
      */
     private void recycleOwnResources(GeneratorContext ctx) {
         // No ThreadLocal access needed - use passed context
@@ -2046,48 +1418,32 @@ public class CombinationGeneratorTask extends RecursiveAction {
         ctx.taskPool.put(this);
     }
 
-    // TODO: Rework this method so it actually flushes all pending batches, since we currently just handle the batch for one context
     /**
-     * Flushes all pending {@link WorkBatch batches} from all threads to any available queues in the
-     * {@link CombinationQueueArray}. This method currently only flushes the batch for a single thread's
-     * {@link GeneratorContext context}, though we could fix that simply by registering all contexts in
-     * a static list when they are created.
+     * Flushes any remaining pending {@link WorkBatch batches} from a single thread's
+     * {@link GeneratorContext} to the {@link CombinationQueueArray}.
      * 
      * <p>
-     * To amortize the cost of flushing batches, we allow tasks to accumulate work in their
-     * {@code WorkBatch}es until they reach {@link #BATCH_SIZE}, flushing only after they reach this
-     * threshold. However, it is possible (and likely) that all tasks will complete with partially full
-     * batches remaining (leaving a maximum of <code>({@value #BATCH_SIZE} - 1) × numThreads / 2)</code>
-     * combinations left). To ensure that all generated combinations are tested, we need a way for the
-     * main thread to flush these remaining batches after all tasks are done, which is what this method
-     * does.
+     * This method is called once by the main thread after all generator tasks have completed. Its
+     * purpose is to ensure that any partially filled {@code WorkBatch}es, which might not have reached
+     * {@link #BATCH_SIZE} and thus weren't flushed during normal operation, are nonetheless processed.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
      * <p>
-     * This method is called once after all tasks are complete, so its performance is not as critical as
-     * other parts of the program. However, we still want to ensure that it runs efficiently and does
-     * not introduce unnecessary overhead. We use {@link ForkJoinPool#submit(ForkJoinTask)} to create
-     * and offload a custom flushing task to the pool, allowing us to leverage the pool's worker threads
-     * to perform the operation. We also make sure to check if a solution has already been found or if
-     * the pool is shut down before proceeding to avoid a race condition or unnecessary work.
+     * It submits a small task to the {@code ForkJoinPool} to access a {@link ThreadLocal}
+     * {@code GeneratorContext} and
+     * {@link #flushBatchHelper(WorkBatch, CombinationQueueArray, boolean, boolean) flush} its
+     * {@link GeneratorContext#currentBatch}. This approach currently only flushes the batch for the
+     * thread that executes this task. A more comprehensive solution would involve a mechanism to
+     * iterate over and flush all {@code GeneratorContext}s across all threads.
      * </p>
      * 
-     * @param queueArray the {@link CombinationQueueArray} containing the {@link CombinationQueue
-     *                   queues} to flush to.
-     * @param pool       the {@link ForkJoinPool} to submit the flushing task to.
+     * @param queueArray The {@link CombinationQueueArray} to flush batches to.
+     * @param pool       The {@link ForkJoinPool} to submit the flushing task to.
      * @see #context
-     * @see #flushBatchHelper(WorkBatch, CombinationQueueArray, boolean, boolean)
-     * @see CombinationQueueArray
-     * @see GeneratorContext#resetBatch()
-     * @see WorkBatch
-     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
-     * @performance <code>O({@link CombinationQueueArray#getAllQueues() queues}.length)</code>, with a
-     *              brief sleep if all queues are full.
+     * @since 2025.06 - Flush Batches when Full (or on Completion)
+     * @performance {@code O(numQueues)} for the flushing operation.
      * @threading Thread-safe due to local context access and atomic operations in
      *            {@link CombinationQueue#add(WorkBatch)}.
-     * @optimization Uses ForkJoinPool to leverage worker threads, checks for solution found or pool
-     *               shutdown to avoid unnecessary work.
      */
     public static void flushAllPendingBatches(CombinationQueueArray queueArray, ForkJoinPool pool) {
         if (queueArray.solutionFound || pool.isShutdown()) return;
@@ -2109,60 +1465,48 @@ public class CombinationGeneratorTask extends RecursiveAction {
     }
 
     /**
-     * Helper method to flush a single {@link WorkBatch batch} to any available {@link CombinationQueue
-     * queue}, with options to check for cancellation and force flushing.
+     * A helper method for flushing a single {@link WorkBatch batch} to an available
+     * {@link CombinationQueue queue}.
      * 
-     * <h3>Algorithm Details</h3>
      * <p>
-     * The method first retrieves all available queues from the {@link CombinationQueueArray} and
-     * selects a random starting index to avoid contention. It then iterates over the queues, attempting
-     * to {@link CombinationQueue#add(WorkBatch) add} the batch to any available queue. If a queue
-     * accepts the batch, the method immediately returns {@code true}. If all queues are full, the
-     * method either {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting before
-     * looping once more, or returns {@code false} if not forcing a flush.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method was used to consolidate the flushing logic for both regular batch flushing and
-     * {@link #flushAllPendingBatches(CombinationQueueArray, ForkJoinPool) flushing at the end of all
-     * tasks.} However, the {@link #flushBatchFast(WorkBatch) fast flush} method is preferred for
-     * regular batch flushing due to its smaller code size and better performance characteristics,
-     * leaving this method primarily for the final flush operation.
+     * This method encapsulates the core logic for attempting to enqueue a {@code WorkBatch}. It
+     * iterates through available queues, trying to add the batch. It includes options for handling
+     * queue fullness (either returning immediately or spinning with a short delay) and checking for
+     * cancellation signals.
      * </p>
      * 
      * <p>
-     * Since we now only use this method for the final flush operation, we could remove the two boolean
-     * parameters and simplify the logic. In a similar vein, we could remove the
-     * {@code CombinationQueueArray} parameter and use the static {@link #queueArray} field instead. To
-     * fully optimize this method, we could remove all parameters and give it access to an array of all
-     * {@link GeneratorContext contexts} to flush all batches from all threads, though it would make
-     * more sense to remove this method altogether and integrate the logic directly into
-     * {@code flushAllPendingBatches()}.
+     * While originally designed for both continuous and final flushing,
+     * {@link #flushBatchFast(WorkBatch)} is now preferred for its streamlined nature. This helper is
+     * primarily used by {@link #flushAllPendingBatches(CombinationQueueArray, ForkJoinPool)} for its
+     * specific requirements (e.g., forcing a flush of remaining batches).
      * </p>
      * 
-     * @param batch             the {@link WorkBatch} to flush.
-     * @param queueArray        the {@link CombinationQueueArray} containing the {@link CombinationQueue
-     *                          queues} to flush to.
-     * @param checkCancellation On a failed attempt to flush, whether to check if a solution has been
-     *                          found and abort if so. This should be {@code true} when called from a
-     *                          generator task and {@code false} when called from the final flush
-     *                          operation.
-     * @param forceFlush        On a failed attempt to flush, whether to sleep and retry or return
-     *                          {@code false}.
-     * @return {@code true} if the batch was successfully flushed, {@code false} if the thread was
-     *         interrupted or if not forcing a flush and all queues were full.
+     * <h3>Future Optimizations</h3>
+     * <p>
+     * This method could be simplified by removing its boolean parameters and integrating its logic
+     * directly into {@code flushAllPendingBatches()}. A more advanced refactoring would be to give it
+     * access to all {@link GeneratorContext} instances, allowing it to flush all pending batches from
+     * all threads in a single, unified operation.
+     * </p>
+     * 
+     * @param batch             The {@link WorkBatch} to flush.
+     * @param queueArray        The {@link CombinationQueueArray} containing the queues.
+     * @param checkCancellation If {@code true}, the method will check if a solution has been found and
+     *                          abort if so.
+     * @param forceFlush        If {@code true}, the method will repeatedly try to flush the batch,
+     *                          sleeping briefly between attempts if queues are full. If {@code false},
+     *                          it will return immediately if all queues are full after one attempt.
+     * @return {@code true} if the batch was successfully flushed; {@code false} if the thread was
+     *         interrupted or if {@code forceFlush} was {@code false} and all queues were full.
      * @see CombinationQueueArray#getAllQueues()
-     * @see java.util.concurrent.ThreadLocalRandom
-     * @see java.util.concurrent.ThreadLocalRandom#current()
-     * @see java.util.concurrent.ThreadLocalRandom#nextInt(int)
-     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
-     * @performance <code>O({@link CombinationQueueArray#getAllQueues() queues}.length</code>, with a
-     *              brief sleep if all queues are full and {@code forceFlush} is {@code true}.
+     * @see ThreadLocalRandom
+     * @see ThreadLocalRandom#current()
+     * @see ThreadLocalRandom#nextInt(int)
+     * @since 2025.06 - Flush Batches when Full (or on Completion)
+     * @performance {@code O(numQueues)} per attempt.
      * @threading Thread-safe due to local queue access and atomic operations in
      *            {@link CombinationQueue#add(WorkBatch)}.
-     * @optimization Uses random starting index to minimize contention, brief sleep to avoid
-     *               busy-waiting when forcing a flush.
      */
     private static boolean flushBatchHelper(WorkBatch batch, CombinationQueueArray queueArray, boolean checkCancellation, boolean forceFlush) {
         CombinationQueue[] queues = queueArray.getAllQueues();

--- a/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationGeneratorTask.java
@@ -83,8 +83,6 @@ import java.util.concurrent.ThreadLocalRandom;
  * </ul>
  * </p>
  * 
- * <h3>35/36 - ~97.2% of documentation completed (excluding GeneratorContext)</h3>
- * 
  * @since 2025.06.08 - Fork Join Refactor
  * @algorithm Creates a tree of tasks, where each task represents a prefix of clicks. The root task
  *            generates subtasks for each possible first click, and each subtask recursively
@@ -2073,35 +2071,80 @@ public class CombinationGeneratorTask extends RecursiveAction {
         }
     }
 
-    private static boolean flushBatchHelper(WorkBatch batch, CombinationQueueArray queueArray, boolean checkCancellation, boolean forceFlush) 
-    {
+    /**
+     * Helper method to flush a single {@link WorkBatch batch} to any available {@link CombinationQueue
+     * queue}, with options to check for cancellation and force flushing.
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The method first retrieves all available queues from the {@link CombinationQueueArray} and
+     * selects a random starting index to avoid contention. It then iterates over the queues, attempting
+     * to {@link CombinationQueue#add(WorkBatch) add} the batch to any available queue. If a queue
+     * accepts the batch, the method immediately returns <code>true</code>. If all queues are full, the
+     * method either {@link Thread#sleep(long, int) sleeps} briefly (0.5ms) to avoid busy-waiting before
+     * looping once more, or returns <code>false</code> if not forcing a flush.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method was used to consolidate the flushing logic for both regular batch flushing and
+     * {@link #flushAllPendingBatches(CombinationQueueArray, ForkJoinPool) flushing at the end of all
+     * tasks.} However, the {@link #flushBatchFast(WorkBatch) fast flush} method is preferred for
+     * regular batch flushing due to its smaller code size and better performance characteristics,
+     * leaving this method primarily for the final flush operation.
+     * </p>
+     * 
+     * <p>
+     * Since we now only use this method for the final flush operation, we could remove the two boolean
+     * parameters and simplify the logic. In a similar vein, we could remove the
+     * <code>CombinationQueueArray</code> parameter and use the static {@link #queueArray} field
+     * instead. To fully optimize this method, we could remove all parameters and give it access to an
+     * array of all {@link GeneratorContext contexts} to flush all batches from all threads, though it
+     * would make more sense to remove this method altogether and integrate the logic directly into
+     * <code>flushAllPendingBatches()</code>.
+     * </p>
+     * 
+     * @param batch             the {@link WorkBatch} to flush.
+     * @param queueArray        the {@link CombinationQueueArray} containing the {@link CombinationQueue
+     *                          queues} to flush to.
+     * @param checkCancellation On a failed attempt to flush, whether to check if a solution has been
+     *                          found and abort if so. This should be <code>true</code> when called from
+     *                          a generator task and <code>false</code> when called from the final flush
+     *                          operation.
+     * @param forceFlush On a failed attempt to flush, whether to sleep and retry or return <code>false</code>.
+     * @return <code>true</code> if the batch was successfully flushed, <code>false</code> if the thread
+     *         was interrupted or if not forcing a flush and all queues were full.
+     * @since 2025.06.12 - Flush Batches when Full (or on Completion)
+     * @threading Thread-safe due to local queue access and atomic operations in {@link CombinationQueue#add(WorkBatch)}.
+     * @performance O(m) where m is the number of queues in the array, with a brief sleep if all queues are full and forcing a flush.
+     * @optimization Uses random starting index to minimize contention, brief sleep to avoid busy-waiting when forcing a flush.
+     * @see CombinationQueueArray#getAllQueues()
+     * @see java.util.concurrent.ThreadLocalRandom
+     * @see java.util.concurrent.ThreadLocalRandom#current()
+     * @see java.util.concurrent.ThreadLocalRandom#nextInt(int)
+     */
+    private static boolean flushBatchHelper(WorkBatch batch, CombinationQueueArray queueArray, boolean checkCancellation, boolean forceFlush) {
         CombinationQueue[] queues = queueArray.getAllQueues();
         int numQueues = queues.length;
         int startQueue = ThreadLocalRandom.current().nextInt(numQueues);
 
         // Try to offer the entire batch to a queue.
-        while (true) 
-        {   
-            for (int attempt = 0; attempt < numQueues; attempt++) 
-            {
+        while (true) {   
+            for (int attempt = 0; attempt < numQueues; attempt++) {
                 int idx = (startQueue + attempt) % numQueues;
                 CombinationQueue queue = queues[idx];
                 
                 if (queue.add(batch)) return true;
             }
-            if (forceFlush)
-            {
-                try 
-                { 
+            if (forceFlush) {
+                try { 
                     Thread.sleep(1); 
-                } catch (InterruptedException e) 
-                { 
+                } catch (InterruptedException e) { 
                     Thread.currentThread().interrupt();
                     return false; // Exit if interrupted 
                 }
             }
-            else
-            {
+            else {
                 // If not forcing flush, we can break after one attempt
                 return false; // No queue accepted the batch
             }

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * <h2>Initialization Strategy</h2>
  * <p>[How values are computed/determined. Pre-computation rationale.]</p>
  * 
- * <h3>0/11 - 0% of documentation completed</h3>
+ * <h3>1/11 - ~9.09% of documentation completed</h3>
  * 
  * @algorithm [If complex initialization logic is involved]
  * @since [When this configuration was introduced]
@@ -74,18 +74,29 @@ public class CombinationMessage implements Message, StringBuilderFormattable
         }
     }
 
+    /**
+     * Formats the combination into a human-readable string representation onto the provided
+     * {@link java.lang.StringBuilder StringBuilder}. Through the use of a provided buffer,
+     * this method avoids unnecessary memory allocations, making it suitable for high-performance
+     * logging scenarios.
+     * 
+     * @param buffer the {@link java.lang.StringBuilder StringBuilder} to append the formatted message to.
+     * @throws NullPointerException (implicitly) if the provided buffer is null.
+     * @since 2025.05.31 - CombinationMessage Class Introduction
+     * @performance O(n) where n is the number of elements in {@link #list}.
+     * @threading Thread-safe, as the method does not modify shared state.
+     * @memory Does not allocate.
+     * @see org.apache.logging.log4j.util.StringBuilderFormattable
+     * @see org.apache.logging.log4j.util.StringBuilderFormattable#formatTo(StringBuilder)
+     */
     @Override
-    public void formatTo(StringBuilder buffer)
-    {
-        if (format != Grid.ValueFormat.PackedInt)
-        {
+    public void formatTo(StringBuilder buffer) {
+        if (format != Grid.ValueFormat.PackedInt) {
             convertTo(Grid.ValueFormat.PackedInt); // Ensure the format is PackedInt for human-readable output 
         }
         buffer.append('[');
-        for (int i = 0, size = list.length; i < size; i++) 
-        {
-            if (i > 0) 
-            {
+        for (int i = 0, size = list.length; i < size; i++) {
+            if (i > 0) {
                 buffer.append(',');
                 buffer.append(' ');
             }

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -4,7 +4,6 @@ import org.apache.logging.log4j.message.AsynchronouslyFormattable;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
-@AsynchronouslyFormattable
 /**
  * CombinationMessage - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
  * 
@@ -22,6 +21,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * @since [When this configuration was introduced]
  * @see [Related configuration classes]
  */
+@AsynchronouslyFormattable
 public class CombinationMessage implements Message, StringBuilderFormattable 
 {
     private short[] list;

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -83,8 +83,6 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * considering.
  * </p>
  * 
- * <h3>7/11 - ~63.6% of documentation completed</h3>
- * 
  * @since 2025.05.31 - CombinationMessage Introduction
  * @threading Apart from the {@link #convertTo(Grid.ValueFormat)} method, which modifies internal
  *            state and is not thread-safe, the class is designed to be thread-safe for concurrent
@@ -230,9 +228,20 @@ public class CombinationMessage implements Message, StringBuilderFormattable
         buffer.append(']');
     }
 
+    /**
+     * Returns the formatted message as a {@link java.lang.String String}. This method is a fallback for legacy APIs that
+     * require a string representation of the message. Internally, it constructs the string using a {@link java.lang.StringBuilder StringBuilder}
+     * and the {@link #formatTo(StringBuilder)} method to avoid intermediate string allocations, but it must still create a new string for the return value.
+     * 
+     * @return the formatted message as a <code>String</code>.
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @performance O(1) call to {@link #formatTo(StringBuilder)}
+     * @threading Thread-safe, as it delegates to the thread-safe {@link #formatTo(StringBuilder)} method.
+     * @memory Allocates a new string for the return value, but avoids intermediate string allocations.
+     * @see java.lang.StringBuilder#toString()
+     */
     @Override
-    public String getFormattedMessage() 
-    {
+    public String getFormattedMessage() {
         // Fallback for legacy APIs; not GC-free, but rarely used by Log4j2 internals
         StringBuilder sb = new StringBuilder();
         formatTo(sb);
@@ -279,21 +288,48 @@ public class CombinationMessage implements Message, StringBuilderFormattable
         return list; // Return the combination in the requested format
     }
 
+    /**
+     * {@inheritDoc}
+     * 
+     * This method is not used in this implementation and always returns <code>null</code>.
+     * 
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @performance O(1) return of <code>null</code>.
+     * @threading Thread-safe, as it does not modify shared state.
+     * @memory Does not allocate.
+     */
     @Override
-    public String getFormat() 
-    {
+    public String getFormat() {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     * 
+     * This method is not used in this implementation and always returns <code>null</code>.
+     * 
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @performance O(1) return of <code>null</code>.
+     * @threading Thread-safe, as it does not modify shared state.
+     * @memory Does not allocate.
+     */
     @Override
-    public Object[] getParameters() 
-    {
+    public Object[] getParameters() {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     * 
+     * This method is not used in this implementation and always returns <code>null</code>.
+     * 
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @performance O(1) return of <code>null</code>.
+     * @threading Thread-safe, as it does not modify shared state.
+     * @memory Does not allocate.
+     */
     @Override
-    public Throwable getThrowable() 
-    {
+    public Throwable getThrowable() {
         return null;
     }
 }

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * <h2>Initialization Strategy</h2>
  * <p>[How values are computed/determined. Pre-computation rationale.]</p>
  * 
- * <h3>1/11 - ~9.09% of documentation completed</h3>
+ * <h3>6/11 - ~54.5% of documentation completed</h3>
  * 
  * @algorithm [If complex initialization logic is involved]
  * @since [When this configuration was introduced]
@@ -24,46 +24,93 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
 @AsynchronouslyFormattable
 public class CombinationMessage implements Message, StringBuilderFormattable 
 {
+    /**
+     * The combination represented as a <code>short[]</code>. The format of the combination is indicated
+     * by the {@link #format} field.
+     * 
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @see #getCombination(com.github.mrgarbagegamer.Grid.ValueFormat)
+     * @see Grid.ValueFormat
+     */
     private short[] list;
+    /**
+     * The format of the combination stored in {@link #list}. This field indicates how the values in the
+     * combination should be interpreted.
+     * 
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @see #convertTo(com.github.mrgarbagegamer.Grid.ValueFormat)
+     * @see Grid.ValueFormat
+     */
     private Grid.ValueFormat format;
 
-    public CombinationMessage(short[] list, Grid.ValueFormat format) 
-    {
+    /**
+     * Creates a new CombinationMessage with the specified combination list and format.
+     * 
+     * @param list the <code>short[]</code> representing the combination.
+     * @param format the {@link Grid.ValueFormat} indicating the format of the combination.
+     * @throws IllegalArgumentException if the provided format is {@link Grid.ValueFormat#Bitmask}.
+     * @since 2025.05.31 - CombinationMessage Introduction
+     */
+    public CombinationMessage(short[] list, Grid.ValueFormat format) {
         this.list = list;
         this.format = format;
-        if (format == Grid.ValueFormat.Bitmask)
-        {
+        if (format == Grid.ValueFormat.Bitmask) {
             throw new IllegalArgumentException("Cannot create CombinationMessage with Bitmask format at the moment. Use Index or PackedInt instead.");
         }
     }
 
-    public void convertTo(Grid.ValueFormat outputFormat) 
-    {
-        if (format == outputFormat) 
-        {
+    /**
+     * Converts the internal combination list to the specified output {@link Grid.ValueFormat format}.
+     * This method modifies the internal state of the CombinationMessage instance, changing the format
+     * to the desired output format for better readability.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method performs in-place conversion of the combination list, which is efficient in terms of
+     * memory usage, avoiding the need for additional allocations. However, it does iterate through the
+     * entire list, resulting in a time complexity of O(n), where n is the number of elements in the
+     * list. The conversion process involves simple arithmetic operations, which are generally fast,
+     * though the number of <code>switch</code> cases and conversions may introduce some overhead.
+     * </p>
+     * 
+     * <p>
+     * For greater efficiency, one would ideally create specialized methods for each conversion path
+     * (e.g., {@link Grid.ValueFormat#Index} to {@link Grid.ValueFormat#PackedInt} and vice versa). This
+     * would reduce the number of conditional checks during conversion, leading to faster execution
+     * times, at the cost of increased code complexity and maintenance, but with Java, those sacrifices
+     * are often worth it.
+     * </p>
+     * 
+     * @param outputFormat the desired {@link Grid.ValueFormat} to convert the combination to.
+     * @throws IllegalArgumentException if the provided output format is
+     *                                  {@link Grid.ValueFormat#Bitmask}.
+     * @since 2025.07.18 - Cell Format Support
+     * @performance O(n) where n is the number of elements in {@link #list}.
+     * @threading Not thread-safe; should be called in a single-threaded context or synchronized
+     *            externally.
+     * @memory In-place conversion; does not allocate additional memory for the list.
+     * @see Grid#packedToIndex(short)
+     * @see Grid#indexToPacked(short)
+     */
+    public void convertTo(Grid.ValueFormat outputFormat) {
+        if (format == outputFormat) {
             return; // No conversion needed
-        } else if (outputFormat == Grid.ValueFormat.Bitmask) 
-        {
+        } else if (outputFormat == Grid.ValueFormat.Bitmask) {
             throw new IllegalArgumentException("Cannot convert to Bitmask format at the moment.");
         }
 
-        switch (outputFormat) 
-        {
+        switch (outputFormat) {
             case Index:
-                if (format == Grid.ValueFormat.PackedInt) 
-                {
-                    for (int i = 0; i < list.length; i++) 
-                    {
+                if (format == Grid.ValueFormat.PackedInt) {
+                    for (int i = 0; i < list.length; i++) {
                         list[i] = Grid.packedToIndex(list[i]); // Convert packed int to index format
                     }
                     format = Grid.ValueFormat.Index; // Update format to index
                 }
                 break;
             case PackedInt:
-                if (format == Grid.ValueFormat.Index) 
-                {
-                    for (int i = 0; i < list.length; i++) 
-                    {
+                if (format == Grid.ValueFormat.Index) {
+                    for (int i = 0; i < list.length; i++) {
                         list[i] = (short) Grid.indexToPacked(list[i]); // Convert index to packed int format
                     }
                     format = Grid.ValueFormat.PackedInt; // Update format to packed int
@@ -82,7 +129,7 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * 
      * @param buffer the {@link java.lang.StringBuilder StringBuilder} to append the formatted message to.
      * @throws NullPointerException (implicitly) if the provided buffer is null.
-     * @since 2025.05.31 - CombinationMessage Class Introduction
+     * @since 2025.05.31 - CombinationMessage Introduction
      * @performance O(n) where n is the number of elements in {@link #list}.
      * @threading Thread-safe, as the method does not modify shared state.
      * @memory Does not allocate.
@@ -114,14 +161,41 @@ public class CombinationMessage implements Message, StringBuilderFormattable
         return sb.toString();
     }
 
-    public short[] getCombination(Grid.ValueFormat outputFormat)
-    {
-        if (outputFormat == Grid.ValueFormat.Bitmask)
-        {
+    /**
+     * Returns the combination in the specified {@link Grid.ValueFormat format}. If the current format
+     * of the combination does not match the requested output format, it will be converted in-place to
+     * the desired format before being returned.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method may perform an in-place conversion of the combination list if the current format does
+     * not match the requested output format. The conversion process has a time complexity of O(n),
+     * where n is the number of elements in the list, due to the need to iterate through the entire
+     * list. The conversion involves simple arithmetic operations, which are generally fast, but the
+     * number of <code>switch</code> cases and conversions may introduce some overhead.
+     * </p>
+     * 
+     * <p>
+     * For optimal performance, it may be beneficial to create specialized methods for each format to
+     * avoid the overhead of conditional checks during conversion. However, this would increase code
+     * complexity and maintenance efforts. The current design prioritizes simplicity and
+     * maintainability.
+     * </p>
+     * 
+     * @param outputFormat the desired {@link Grid.ValueFormat} for the returned combination.
+     * @return the combination as a <code>short[]</code> in the specified format.
+     * @throws IllegalArgumentException if the provided output format is {@link Grid.ValueFormat#Bitmask}.
+     * @since 2025.05.31 - CombinationMessage Introduction
+     * @performance O(n) where n is the number of elements in {@link #list} if conversion is needed; O(1) if no conversion is needed.
+     * @threading Not thread-safe; should be called in a single-threaded context or synchronized externally.
+     * @memory In-place conversion; does not allocate additional memory for the list.
+     * @see #convertTo(Grid.ValueFormat)
+     */
+    public short[] getCombination(Grid.ValueFormat outputFormat) {
+        if (outputFormat == Grid.ValueFormat.Bitmask) {
             // TODO: Look at making this possible, either by using an array of int bitmasks or making the return type a long[]
             throw new IllegalArgumentException("Cannot convert to Bitmask format.");
-        } else if (outputFormat != format)
-        {
+        } else if (outputFormat != format) {
             convertTo(outputFormat); // Convert to the requested format if needed
         }
         return list; // Return the combination in the requested format

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -5,7 +5,7 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
- * CombinationMessage - A specialized message class for representing and formatting combinations.
+ * A specialized message class for representing and formatting combinations.
  * 
  * <p>
  * Logging is an important part of this application, especially for debugging and monitoring the
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * <h2>Configuration Details</h2>
  * <p>
  * This class fundamentally acts as a wrapper around a combination representation, providing
- * efficient formatting capabilities. We store the combination as a <code>short[]</code> along with
+ * efficient formatting capabilities. We store the combination as a {@code short[]} along with
  * a {@link Grid.ValueFormat format} indicator. This design allows for efficient storage and easy
  * conversion between different formats. For human readability, we always convert to the
  * {@link Grid.ValueFormat#PackedInt PackedInt} format when formatting the message due to its
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * <h2>Initialization Strategy</h2>
  * <p>
  * We don't have complex initialization logic for this class. The constructor simply takes a
- * <code>short[]</code> and a {@link Grid.ValueFormat format} and stores them, performing a basic
+ * {@code short[]} and a {@link Grid.ValueFormat format} and stores them, performing a basic
  * validation to ensure the format is supported by our implementation. We delegate conversion logic
  * to the {@link #convertTo(Grid.ValueFormat)} method to allow for on-demand format conversion.
  * </p>
@@ -101,7 +101,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
 public class CombinationMessage implements Message, StringBuilderFormattable 
 {
     /**
-     * The combination represented as a <code>short[]</code>. The format of the combination is indicated
+     * The combination represented as a {@code short[]}. The format of the combination is indicated
      * by the {@link #format} field.
      * 
      * @see #getCombination(com.github.mrgarbagegamer.Grid.ValueFormat)
@@ -120,9 +120,9 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     private Grid.ValueFormat format;
 
     /**
-     * Creates a new CombinationMessage with the specified combination list and format.
+     * Creates a new {@code CombinationMessage} with the specified combination list and format.
      * 
-     * @param list the <code>short[]</code> representing the combination.
+     * @param list   the {@code short[]} representing the combination.
      * @param format the {@link Grid.ValueFormat} indicating the format of the combination.
      * @throws IllegalArgumentException if the provided format is {@link Grid.ValueFormat#Bitmask}.
      * @since 2025.05.31 - CombinationMessage Introduction
@@ -137,33 +137,33 @@ public class CombinationMessage implements Message, StringBuilderFormattable
 
     /**
      * Converts the internal combination list to the specified output {@link Grid.ValueFormat format}.
-     * This method modifies the internal state of the CombinationMessage instance, changing the format
-     * to the desired output format for better readability.
+     * This method modifies the internal state of the {@code CombinationMessage} instance, changing the
+     * format to the desired output format for better readability.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * This method performs in-place conversion of the combination list, which is efficient in terms of
      * memory usage, avoiding the need for additional allocations. However, it does iterate through the
-     * entire list, resulting in a time complexity of O(n), where n is the number of elements in the
-     * list. The conversion process involves simple arithmetic operations, which are generally fast,
-     * though the number of <code>switch</code> cases and conversions may introduce some overhead.
+     * entire list, resulting in a time complexity of <code>O({@link #list}.length)</code>. The
+     * conversion process involves simple arithmetic operations, which are generally fast, though the
+     * number of {@code switch} cases and conversions may introduce some overhead.
      * </p>
      * 
      * <p>
      * For greater efficiency, one would ideally create specialized methods for each conversion path
-     * (e.g., {@link Grid.ValueFormat#Index} to {@link Grid.ValueFormat#PackedInt} and vice versa). This
-     * would reduce the number of conditional checks during conversion, leading to faster execution
-     * times, at the cost of increased code complexity and maintenance, but with Java, those sacrifices
-     * are often worth it.
+     * (e.g., {@link Grid.ValueFormat#Index Index} to {@link Grid.ValueFormat#PackedInt PackedInt} and
+     * vice versa). This would reduce the number of conditional checks during conversion, leading to
+     * faster execution times, at the cost of increased code complexity and maintenance, but with Java,
+     * those sacrifices are often worth it.
      * </p>
      * 
      * @param outputFormat the desired {@link Grid.ValueFormat} to convert the combination to.
-     * @throws IllegalArgumentException if the provided output format is
-     *                                  {@link Grid.ValueFormat#Bitmask}.
+     * @throws IllegalArgumentException if the provided output format is {@link Grid.ValueFormat#Bitmask
+     *                                  Bitmask}.
      * @see Grid#indexToPacked(short)
      * @see Grid#packedToIndex(short)
      * @since 2025.07.18 - Cell Format Support
-     * @performance O(n) where n is the number of elements in {@link #list}.
+     * @performance <code>O({@link #list}.length)</code>.
      * @threading Not thread-safe; should be called in a single-threaded context or synchronized
      *            externally.
      * @memory In-place conversion; does not allocate additional memory for the list.
@@ -199,16 +199,16 @@ public class CombinationMessage implements Message, StringBuilderFormattable
 
     /**
      * Formats the combination into a human-readable string representation onto the provided
-     * {@link java.lang.StringBuilder StringBuilder}. Through the use of a provided buffer,
-     * this method avoids unnecessary memory allocations, making it suitable for high-performance
-     * logging scenarios.
+     * {@link java.lang.StringBuilder StringBuilder}. Through the use of a provided buffer, this method
+     * avoids unnecessary memory allocations, making it suitable for high-performance logging scenarios.
      * 
-     * @param buffer the {@link java.lang.StringBuilder StringBuilder} to append the formatted message to.
+     * @param buffer the {@link java.lang.StringBuilder StringBuilder} to append the formatted message
+     *               to.
      * @throws NullPointerException (implicitly) if the provided buffer is null.
      * @see org.apache.logging.log4j.util.StringBuilderFormattable
      * @see org.apache.logging.log4j.util.StringBuilderFormattable#formatTo(StringBuilder)
      * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance O(n) where n is the number of elements in {@link #list}.
+     * @performance <code>O({@link #list}.length)</code> due to iteration through the list.
      * @threading Thread-safe, as the method does not modify shared state.
      * @memory Does not allocate.
      */
@@ -229,16 +229,20 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     }
 
     /**
-     * Returns the formatted message as a {@link java.lang.String String}. This method is a fallback for legacy APIs that
-     * require a string representation of the message. Internally, it constructs the string using a {@link java.lang.StringBuilder StringBuilder}
-     * and the {@link #formatTo(StringBuilder)} method to avoid intermediate string allocations, but it must still create a new string for the return value.
+     * Returns the formatted message as a {@link java.lang.String String}. This method is a fallback for
+     * legacy APIs that require a {@code String} representation of the message. Internally, it
+     * constructs the string using a {@link java.lang.StringBuilder StringBuilder} and the
+     * {@link #formatTo(StringBuilder)} method to avoid intermediate {@code String} allocations, but it
+     * must still create a new {@code String} for the return value.
      * 
-     * @return the formatted message as a <code>String</code>.
+     * @return the formatted message as a {@code String}.
      * @see java.lang.StringBuilder#toString()
      * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance O(1) call to {@link #formatTo(StringBuilder)}
-     * @threading Thread-safe, as it delegates to the thread-safe {@link #formatTo(StringBuilder)} method.
-     * @memory Allocates a new string for the return value, but avoids intermediate string allocations.
+     * @performance {@code O(1)} call to {@link #formatTo(StringBuilder)}
+     * @threading Thread-safe, as it delegates to the thread-safe {@link #formatTo(StringBuilder)}
+     *            method.
+     * @memory Allocates a new {@code String} for the return value, but avoids intermediate
+     *         {@code String} allocations.
      */
     @Override
     public String getFormattedMessage() {
@@ -256,10 +260,10 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * <h3>Performance Considerations</h3>
      * <p>
      * This method may perform an in-place conversion of the combination list if the current format does
-     * not match the requested output format. The conversion process has a time complexity of O(n),
-     * where n is the number of elements in the list, due to the need to iterate through the entire
-     * list. The conversion involves simple arithmetic operations, which are generally fast, but the
-     * number of <code>switch</code> cases and conversions may introduce some overhead.
+     * not match the requested output format. The conversion process has a time complexity of
+     * <code>O({@link #list}.length)</code>, due to the need to iterate through the entire {@code list}.
+     * The conversion involves simple arithmetic operations, which are generally fast, but the number of
+     * {@code switch} cases and conversions may introduce some overhead.
      * </p>
      * 
      * <p>
@@ -270,12 +274,15 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * </p>
      * 
      * @param outputFormat the desired {@link Grid.ValueFormat} for the returned combination.
-     * @return the combination as a <code>short[]</code> in the specified format.
-     * @throws IllegalArgumentException if the provided output format is {@link Grid.ValueFormat#Bitmask}.
+     * @return the combination as a {@code short[]} in the specified format.
+     * @throws IllegalArgumentException if the provided output format is
+     *                                  {@link Grid.ValueFormat#Bitmask}.
      * @see #convertTo(Grid.ValueFormat)
      * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance O(n) where n is the number of elements in {@link #list} if conversion is needed; O(1) if no conversion is needed.
-     * @threading Not thread-safe; should be called in a single-threaded context or synchronized externally.
+     * @performance <code>O({@link #list}.length)</code> if conversion is needed; {@code O(1)} if no
+     *              conversion is needed.
+     * @threading Not thread-safe; should be called in a single-threaded context or synchronized
+     *            externally.
      * @memory In-place conversion; does not allocate additional memory for the list.
      */
     public short[] getCombination(Grid.ValueFormat outputFormat) {
@@ -291,10 +298,10 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     /**
      * {@inheritDoc}
      * 
-     * This method is not used in this implementation and always returns <code>null</code>.
+     * This method is not used in this implementation and always returns {@code null}.
      * 
      * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance O(1) return of <code>null</code>.
+     * @performance {@code O(1)} return of {@code null}.
      * @threading Thread-safe, as it does not modify shared state.
      * @memory Does not allocate.
      */
@@ -306,10 +313,10 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     /**
      * {@inheritDoc}
      * 
-     * This method is not used in this implementation and always returns <code>null</code>.
+     * This method is not used in this implementation and always returns {@code null}.
      * 
      * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance O(1) return of <code>null</code>.
+     * @performance {@code O(1)} return of {@code null}.
      * @threading Thread-safe, as it does not modify shared state.
      * @memory Does not allocate.
      */
@@ -321,10 +328,10 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     /**
      * {@inheritDoc}
      * 
-     * This method is not used in this implementation and always returns <code>null</code>.
+     * This method is not used in this implementation and always returns {@code null}.
      * 
      * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance O(1) return of <code>null</code>.
+     * @performance {@code O(1)} return of {@code null}.
      * @threading Thread-safe, as it does not modify shared state.
      * @memory Does not allocate.
      */

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -83,19 +83,19 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
  * considering.
  * </p>
  * 
- * @since 2025.05.31 - CombinationMessage Introduction
- * @threading Apart from the {@link #convertTo(Grid.ValueFormat)} method, which modifies internal
- *            state and is not thread-safe, the class is designed to be thread-safe for concurrent
- *            read operations.
- * @performance Designed to minimize allocations by using a provided {@link java.lang.StringBuilder
- *              StringBuilder} for formatting, avoiding intermediate string creation.
- * @memory Avoids allocations past initialization by using in-place conversion and a reusable buffer
- *         for formatting.
  * @see org.apache.logging.log4j.Logger
  * @see org.apache.logging.log4j.LogManager
  * @see org.apache.logging.log4j.LogManager#getLogger()
  * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous
  *      Logging</a>
+ * @since 2025.05.31 - CombinationMessage Introduction
+ * @performance Designed to minimize allocations by using a provided {@link java.lang.StringBuilder
+ *              StringBuilder} for formatting, avoiding intermediate string creation.
+ * @threading Apart from the {@link #convertTo(Grid.ValueFormat)} method, which modifies internal
+ *            state and is not thread-safe, the class is designed to be thread-safe for concurrent
+ *            read operations.
+ * @memory Avoids allocations past initialization by using in-place conversion and a reusable buffer
+ *         for formatting.
  */
 @AsynchronouslyFormattable
 public class CombinationMessage implements Message, StringBuilderFormattable 
@@ -104,18 +104,18 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * The combination represented as a <code>short[]</code>. The format of the combination is indicated
      * by the {@link #format} field.
      * 
-     * @since 2025.05.31 - CombinationMessage Introduction
      * @see #getCombination(com.github.mrgarbagegamer.Grid.ValueFormat)
      * @see Grid.ValueFormat
+     * @since 2025.05.31 - CombinationMessage Introduction
      */
     private short[] list;
     /**
      * The format of the combination stored in {@link #list}. This field indicates how the values in the
      * combination should be interpreted.
      * 
-     * @since 2025.05.31 - CombinationMessage Introduction
      * @see #convertTo(com.github.mrgarbagegamer.Grid.ValueFormat)
      * @see Grid.ValueFormat
+     * @since 2025.05.31 - CombinationMessage Introduction
      */
     private Grid.ValueFormat format;
 
@@ -160,13 +160,13 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * @param outputFormat the desired {@link Grid.ValueFormat} to convert the combination to.
      * @throws IllegalArgumentException if the provided output format is
      *                                  {@link Grid.ValueFormat#Bitmask}.
+     * @see Grid#indexToPacked(short)
+     * @see Grid#packedToIndex(short)
      * @since 2025.07.18 - Cell Format Support
      * @performance O(n) where n is the number of elements in {@link #list}.
      * @threading Not thread-safe; should be called in a single-threaded context or synchronized
      *            externally.
      * @memory In-place conversion; does not allocate additional memory for the list.
-     * @see Grid#packedToIndex(short)
-     * @see Grid#indexToPacked(short)
      */
     public void convertTo(Grid.ValueFormat outputFormat) {
         if (format == outputFormat) {
@@ -205,12 +205,12 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * 
      * @param buffer the {@link java.lang.StringBuilder StringBuilder} to append the formatted message to.
      * @throws NullPointerException (implicitly) if the provided buffer is null.
+     * @see org.apache.logging.log4j.util.StringBuilderFormattable
+     * @see org.apache.logging.log4j.util.StringBuilderFormattable#formatTo(StringBuilder)
      * @since 2025.05.31 - CombinationMessage Introduction
      * @performance O(n) where n is the number of elements in {@link #list}.
      * @threading Thread-safe, as the method does not modify shared state.
      * @memory Does not allocate.
-     * @see org.apache.logging.log4j.util.StringBuilderFormattable
-     * @see org.apache.logging.log4j.util.StringBuilderFormattable#formatTo(StringBuilder)
      */
     @Override
     public void formatTo(StringBuilder buffer) {
@@ -234,11 +234,11 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * and the {@link #formatTo(StringBuilder)} method to avoid intermediate string allocations, but it must still create a new string for the return value.
      * 
      * @return the formatted message as a <code>String</code>.
+     * @see java.lang.StringBuilder#toString()
      * @since 2025.05.31 - CombinationMessage Introduction
      * @performance O(1) call to {@link #formatTo(StringBuilder)}
      * @threading Thread-safe, as it delegates to the thread-safe {@link #formatTo(StringBuilder)} method.
      * @memory Allocates a new string for the return value, but avoids intermediate string allocations.
-     * @see java.lang.StringBuilder#toString()
      */
     @Override
     public String getFormattedMessage() {
@@ -272,11 +272,11 @@ public class CombinationMessage implements Message, StringBuilderFormattable
      * @param outputFormat the desired {@link Grid.ValueFormat} for the returned combination.
      * @return the combination as a <code>short[]</code> in the specified format.
      * @throws IllegalArgumentException if the provided output format is {@link Grid.ValueFormat#Bitmask}.
+     * @see #convertTo(Grid.ValueFormat)
      * @since 2025.05.31 - CombinationMessage Introduction
      * @performance O(n) where n is the number of elements in {@link #list} if conversion is needed; O(1) if no conversion is needed.
      * @threading Not thread-safe; should be called in a single-threaded context or synchronized externally.
      * @memory In-place conversion; does not allocate additional memory for the list.
-     * @see #convertTo(Grid.ValueFormat)
      */
     public short[] getCombination(Grid.ValueFormat outputFormat) {
         if (outputFormat == Grid.ValueFormat.Bitmask) {

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -5,6 +5,23 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 @AsynchronouslyFormattable
+/**
+ * CombinationMessage - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * 
+ * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * 
+ * <h2>Configuration Details</h2>
+ * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * 
+ * <h2>Initialization Strategy</h2>
+ * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * 
+ * <h3>0/11 - 0% of documentation completed</h3>
+ * 
+ * @algorithm [If complex initialization logic is involved]
+ * @since [When this configuration was introduced]
+ * @see [Related configuration classes]
+ */
 public class CombinationMessage implements Message, StringBuilderFormattable 
 {
     private short[] list;

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -5,21 +5,99 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
- * CombinationMessage - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * CombinationMessage - A specialized message class for representing and formatting combinations.
  * 
- * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * <p>
+ * Logging is an important part of this application, especially for debugging and monitoring the
+ * performance of the brute force solver. However, traditional logging methods can introduce
+ * significant overhead due to memory allocations, string manipulations, and synchronization.
+ * Log4j2's asynchronous logging capabilities help mitigate some of these issues, but custom message
+ * classes can further optimize performance by reducing allocations and improving formatting
+ * efficiency. This class implements Log4j2's {@link org.apache.logging.log4j.message.Message
+ * Message}, {@link org.apache.logging.log4j.util.StringBuilderFormattable
+ * StringBuilderFormattable}, and {@link org.apache.logging.log4j.message.AsynchronouslyFormattable
+ * AsynchronouslyFormattable} interfaces to provide a high-performance logging solution for
+ * combinations that can work asynchronously.
+ * </p>
  * 
  * <h2>Configuration Details</h2>
- * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * <p>
+ * This class fundamentally acts as a wrapper around a combination representation, providing
+ * efficient formatting capabilities. We store the combination as a <code>short[]</code> along with
+ * a {@link Grid.ValueFormat format} indicator. This design allows for efficient storage and easy
+ * conversion between different formats. For human readability, we always convert to the
+ * {@link Grid.ValueFormat#PackedInt PackedInt} format when formatting the message due to its
+ * understandability, though we could also use {@link Grid.ValueFormat#Index Index} format if
+ * desired.
+ * </p>
  * 
  * <h2>Initialization Strategy</h2>
- * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * <p>
+ * We don't have complex initialization logic for this class. The constructor simply takes a
+ * <code>short[]</code> and a {@link Grid.ValueFormat format} and stores them, performing a basic
+ * validation to ensure the format is supported by our implementation. We delegate conversion logic
+ * to the {@link #convertTo(Grid.ValueFormat)} method to allow for on-demand format conversion.
+ * </p>
  * 
- * <h3>6/11 - ~54.5% of documentation completed</h3>
+ * <p>
+ * This, however, could cause issues with concurrent modification, since the conversion modifies the
+ * {@link #list} field in place. To avoid this, we could either make the class immutable (by always
+ * creating a new array on conversion), synchronize access to the conversion method, or perform the
+ * format conversions within a constructor to ensure that the internal state is always consistent
+ * after initialization. The choice depends on the expected usage patterns and performance
+ * considerations.
+ * </p>
  * 
- * @algorithm [If complex initialization logic is involved]
- * @since [When this configuration was introduced]
- * @see [Related configuration classes]
+ * <h2>Limitations and Overhead</h2>
+ * <p>
+ * This implementation does not currently support reuse by Log4j2 reusable message APIs or a message
+ * object pool. As used in the codebase (see {@link TestClickCombination#run()}), a new
+ * CombinationMessage instance is allocated for each logged combination. In high-frequency logging
+ * scenarios this results in substantial object allocation and GC pressure. To mitigate this, we
+ * could implement one or more of the following strategies (ordered from most to least complex):
+ * </p>
+ * <ul>
+ * <li>Implement Log4j2's {@link org.apache.logging.log4j.message.ReusableMessage ReusableMessage}
+ * pattern or a custom {@link org.apache.logging.log4j.message.MessageFactory MessageFactory} so a
+ * message instance can be reused by the logging framework.</li>
+ * <li>Introduce an object pool ({@link java.lang.ThreadLocal ThreadLocal} or shared) for
+ * CombinationMessage objects and reuse the same buffer rather than allocating per log call.</li>
+ * <li>Log only summary information in hot loops and defer full combination dumps to sampling or
+ * debug-only modes.</li>
+ * </ul>
+ * 
+ * <p>
+ * The first strategy is the most optimal in terms of reducing allocations and GC pressure, but also
+ * the most complex to implement correctly. The second strategy is simpler but may still introduce
+ * some contention if a shared pool is used (and can lead to a race condition if not managed
+ * properly). The third strategy is the simplest, but sacrifices detailed logging, which is a
+ * trade-off that may not be acceptable in all scenarios.
+ * </p>
+ * 
+ * <p>
+ * Nevertheless, removing logging from the monkeys altogether could be best if performance is
+ * absolutely critical, opting instead for metrics that can estimate progress through the statistics
+ * of our {@link CombinationGeneratorTask generator} {@link java.util.concurrent.ForkJoinPool
+ * ForkJoinPool}. Logging exists for the purpose of estimating the progress of our solver, and if
+ * that can be achieved through cheaper (and potentially more accurate) means, then that is worth
+ * considering.
+ * </p>
+ * 
+ * <h3>7/11 - ~63.6% of documentation completed</h3>
+ * 
+ * @since 2025.05.31 - CombinationMessage Introduction
+ * @threading Apart from the {@link #convertTo(Grid.ValueFormat)} method, which modifies internal
+ *            state and is not thread-safe, the class is designed to be thread-safe for concurrent
+ *            read operations.
+ * @performance Designed to minimize allocations by using a provided {@link java.lang.StringBuilder
+ *              StringBuilder} for formatting, avoiding intermediate string creation.
+ * @memory Avoids allocations past initialization by using in-place conversion and a reusable buffer
+ *         for formatting.
+ * @see org.apache.logging.log4j.Logger
+ * @see org.apache.logging.log4j.LogManager
+ * @see org.apache.logging.log4j.LogManager#getLogger()
+ * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous
+ *      Logging</a>
  */
 @AsynchronouslyFormattable
 public class CombinationMessage implements Message, StringBuilderFormattable 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationMessage.java
@@ -5,127 +5,103 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
- * A specialized message class for representing and formatting combinations.
- * 
+ * A specialized Log4j2 {@link Message} for logging solution combinations with low overhead.
+ *
  * <p>
- * Logging is an important part of this application, especially for debugging and monitoring the
- * performance of the brute force solver. However, traditional logging methods can introduce
- * significant overhead due to memory allocations, string manipulations, and synchronization.
- * Log4j2's asynchronous logging capabilities help mitigate some of these issues, but custom message
- * classes can further optimize performance by reducing allocations and improving formatting
- * efficiency. This class implements Log4j2's {@link org.apache.logging.log4j.message.Message
- * Message}, {@link org.apache.logging.log4j.util.StringBuilderFormattable
- * StringBuilderFormattable}, and {@link org.apache.logging.log4j.message.AsynchronouslyFormattable
- * AsynchronouslyFormattable} interfaces to provide a high-performance logging solution for
- * combinations that can work asynchronously.
+ * This class serves as a high-performance logging mechanism for {@code short[]} combinations found
+ * by the solver. By implementing the {@link Message} and {@link StringBuilderFormattable}
+ * interfaces, it integrates directly with Log4j2's asynchronous logging architecture. This avoids
+ * the performance penalties of traditional logging, such as intermediate {@link String} creation
+ * and formatting overhead on critical application threads.
  * </p>
- * 
- * <h2>Configuration Details</h2>
+ *
+ * <h2>Performance and Architecture</h2>
  * <p>
- * This class fundamentally acts as a wrapper around a combination representation, providing
- * efficient formatting capabilities. We store the combination as a {@code short[]} along with
- * a {@link Grid.ValueFormat format} indicator. This design allows for efficient storage and easy
- * conversion between different formats. For human readability, we always convert to the
- * {@link Grid.ValueFormat#PackedInt PackedInt} format when formatting the message due to its
- * understandability, though we could also use {@link Grid.ValueFormat#Index Index} format if
- * desired.
+ * The primary goal of this class is to enable "garbage-free" logging. It acts as a wrapper for a
+ * {@code short[]} array, deferring the expensive formatting process to a background I/O thread
+ * managed by Log4j2. The {@link #formatTo(StringBuilder)} method writes the combination data
+ * directly into a reusable {@link StringBuilder}, preventing object allocation in the application's
+ * hot path.
  * </p>
- * 
- * <h2>Initialization Strategy</h2>
+ *
+ * <h2>Limitations and Future Improvements</h2>
  * <p>
- * We don't have complex initialization logic for this class. The constructor simply takes a
- * {@code short[]} and a {@link Grid.ValueFormat format} and stores them, performing a basic
- * validation to ensure the format is supported by our implementation. We delegate conversion logic
- * to the {@link #convertTo(Grid.ValueFormat)} method to allow for on-demand format conversion.
- * </p>
- * 
- * <p>
- * This, however, could cause issues with concurrent modification, since the conversion modifies the
- * {@link #list} field in place. To avoid this, we could either make the class immutable (by always
- * creating a new array on conversion), synchronize access to the conversion method, or perform the
- * format conversions within a constructor to ensure that the internal state is always consistent
- * after initialization. The choice depends on the expected usage patterns and performance
- * considerations.
- * </p>
- * 
- * <h2>Limitations and Overhead</h2>
- * <p>
- * This implementation does not currently support reuse by Log4j2 reusable message APIs or a message
- * object pool. As used in the codebase (see {@link TestClickCombination#run()}), a new
- * CombinationMessage instance is allocated for each logged combination. In high-frequency logging
- * scenarios this results in substantial object allocation and GC pressure. To mitigate this, we
- * could implement one or more of the following strategies (ordered from most to least complex):
+ * While this class avoids formatting overhead on hot threads, it still allocates a new
+ * {@code CombinationMessage} instance for each log event. In high-frequency scenarios, this can
+ * create GC pressure. Several strategies were considered to mitigate this:
  * </p>
  * <ul>
- * <li>Implement Log4j2's {@link org.apache.logging.log4j.message.ReusableMessage ReusableMessage}
- * pattern or a custom {@link org.apache.logging.log4j.message.MessageFactory MessageFactory} so a
- * message instance can be reused by the logging framework.</li>
- * <li>Introduce an object pool ({@link java.lang.ThreadLocal ThreadLocal} or shared) for
- * CombinationMessage objects and reuse the same buffer rather than allocating per log call.</li>
- * <li>Log only summary information in hot loops and defer full combination dumps to sampling or
- * debug-only modes.</li>
+ * <li><b>Reusable Messages:</b> The most robust solution is to implement Log4j2's
+ * {@link org.apache.logging.log4j.message.ReusableMessage ReusableMessage} pattern, which would
+ * allow instances to be recycled by the framework. This is effective but complex to implement
+ * correctly.</li>
+ * <li><b>Object Pooling:</b> A simpler alternative is a custom object pool. However, a shared pool
+ * could introduce contention and potential race conditions if managed improperly.</li>
+ * <li><b>Reduced Logging:</b> The simplest option is to log only summary data, but this sacrifices
+ * valuable, detailed output.</li>
  * </ul>
- * 
  * <p>
- * The first strategy is the most optimal in terms of reducing allocations and GC pressure, but also
- * the most complex to implement correctly. The second strategy is simpler but may still introduce
- * some contention if a shared pool is used (and can lead to a race condition if not managed
- * properly). The third strategy is the simplest, but sacrifices detailed logging, which is a
- * trade-off that may not be acceptable in all scenarios.
+ * An alternative to logging altogether is to rely on statistical metrics from the
+ * {@link CombinationGeneratorTask}, which could provide progress estimates with less performance
+ * impact. Setting this up would be more complex, but is a viable option for future exploration.
  * </p>
- * 
+ *
+ * <h2>Thread Safety</h2>
  * <p>
- * Nevertheless, removing logging from the monkeys altogether could be best if performance is
- * absolutely critical, opting instead for metrics that can estimate progress through the statistics
- * of our {@link CombinationGeneratorTask generator} {@link java.util.concurrent.ForkJoinPool
- * ForkJoinPool}. Logging exists for the purpose of estimating the progress of our solver, and if
- * that can be achieved through cheaper (and potentially more accurate) means, then that is worth
- * considering.
+ * This class is <strong>not</strong> fully thread-safe. The formatting methods are safe for
+ * concurrent use, but methods that modify internal state, such as
+ * {@link #convertTo(Grid.ValueFormat)}, are not. Instances should be confined to a single thread or
+ * properly synchronized if state modifications are required.
  * </p>
- * 
+ *
  * @see org.apache.logging.log4j.Logger
  * @see org.apache.logging.log4j.LogManager
  * @see org.apache.logging.log4j.LogManager#getLogger()
  * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous
  *      Logging</a>
- * @since 2025.05.31 - CombinationMessage Introduction
- * @performance Designed to minimize allocations by using a provided {@link java.lang.StringBuilder
- *              StringBuilder} for formatting, avoiding intermediate string creation.
+ * @since 2025.05 - CombinationMessage Introduction
+ * @performance {@code O(list.length)} for format conversion or string formatting.
  * @threading Apart from the {@link #convertTo(Grid.ValueFormat)} method, which modifies internal
  *            state and is not thread-safe, the class is designed to be thread-safe for concurrent
  *            read operations.
- * @memory Avoids allocations past initialization by using in-place conversion and a reusable buffer
- *         for formatting.
+ * @memory Fixed memory footprint after construction; does not allocate except if
+ *         {@link #getFormattedMessage()} is called.
  */
 @AsynchronouslyFormattable
 public class CombinationMessage implements Message, StringBuilderFormattable 
 {
     /**
-     * The combination represented as a {@code short[]}. The format of the combination is indicated
-     * by the {@link #format} field.
+     * The combination data. The interpretation of this data depends on the {@link #format} field.
      * 
-     * @see #getCombination(com.github.mrgarbagegamer.Grid.ValueFormat)
+     * @see #getCombination(Grid.ValueFormat)
      * @see Grid.ValueFormat
-     * @since 2025.05.31 - CombinationMessage Introduction
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(1)} assignments and retrievals, {@code O(list.length)} for format
+     *              conversion.
+     * @memory Minimal footprint of ~{@code list.length × 2} bytes as a {@code short[]}.
      */
     private short[] list;
     /**
-     * The format of the combination stored in {@link #list}. This field indicates how the values in the
-     * combination should be interpreted.
+     * The {@link Grid.ValueFormat} of the combination stored in {@link #list}.
      * 
-     * @see #convertTo(com.github.mrgarbagegamer.Grid.ValueFormat)
-     * @see Grid.ValueFormat
-     * @since 2025.05.31 - CombinationMessage Introduction
+     * @see #convertTo(Grid.ValueFormat)
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(1)} assignments and retrievals.
+     * @memory Minimal footprint; enum reference.
      */
     private Grid.ValueFormat format;
 
     /**
-     * Creates a new {@code CombinationMessage} with the specified combination list and format.
-     * 
-     * @param list   the {@code short[]} representing the combination.
-     * @param format the {@link Grid.ValueFormat} indicating the format of the combination.
-     * @throws IllegalArgumentException if the provided format is {@link Grid.ValueFormat#Bitmask}.
-     * @since 2025.05.31 - CombinationMessage Introduction
+     * Constructs a new {@code CombinationMessage}.
+     *
+     * @param list   The {@code short[]} representing the combination.
+     * @param format The initial {@link Grid.ValueFormat} of the combination.
+     * @throws IllegalArgumentException if the provided format is {@link Grid.ValueFormat#Bitmask},
+     *                                  which is not supported for logging.
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(1)} assignments.
+     * @memory Does not allocate (except for a new {@code CombinationMessage} instance); reuses the
+     *         passed {@code list}.
      */
     public CombinationMessage(short[] list, Grid.ValueFormat format) {
         this.list = list;
@@ -136,37 +112,23 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     }
 
     /**
-     * Converts the internal combination list to the specified output {@link Grid.ValueFormat format}.
-     * This method modifies the internal state of the {@code CombinationMessage} instance, changing the
-     * format to the desired output format for better readability.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Converts the internal combination list to the specified {@link Grid.ValueFormat}.
+     *
      * <p>
-     * This method performs in-place conversion of the combination list, which is efficient in terms of
-     * memory usage, avoiding the need for additional allocations. However, it does iterate through the
-     * entire list, resulting in a time complexity of <code>O({@link #list}.length)</code>. The
-     * conversion process involves simple arithmetic operations, which are generally fast, though the
-     * number of {@code switch} cases and conversions may introduce some overhead.
+     * This method performs an in-place conversion to avoid memory allocation, giving it an
+     * {@code O(list.length)} time complexity. For greater efficiency, specialized conversion methods
+     * (e.g., a dedicated {@code indexToPackedInt()}) could be created to minimize conditional checks,
+     * though this would increase code complexity.
      * </p>
-     * 
-     * <p>
-     * For greater efficiency, one would ideally create specialized methods for each conversion path
-     * (e.g., {@link Grid.ValueFormat#Index Index} to {@link Grid.ValueFormat#PackedInt PackedInt} and
-     * vice versa). This would reduce the number of conditional checks during conversion, leading to
-     * faster execution times, at the cost of increased code complexity and maintenance, but with Java,
-     * those sacrifices are often worth it.
-     * </p>
-     * 
-     * @param outputFormat the desired {@link Grid.ValueFormat} to convert the combination to.
-     * @throws IllegalArgumentException if the provided output format is {@link Grid.ValueFormat#Bitmask
-     *                                  Bitmask}.
+     *
+     * @param outputFormat The target {@link Grid.ValueFormat} for the conversion.
+     * @throws IllegalArgumentException if conversion to {@link Grid.ValueFormat#Bitmask} is attempted.
      * @see Grid#indexToPacked(short)
      * @see Grid#packedToIndex(short)
-     * @since 2025.07.18 - Cell Format Support
-     * @performance <code>O({@link #list}.length)</code>.
-     * @threading Not thread-safe; should be called in a single-threaded context or synchronized
-     *            externally.
-     * @memory In-place conversion; does not allocate additional memory for the list.
+     * @since 2025.07 - Cell Format Support
+     * @performance {@code O(list.length)} format conversion.
+     * @threading Not thread-safe, as it mutates internal state.
+     * @memory Does not allocate; performs in-place conversion of {@link #list}.
      */
     public void convertTo(Grid.ValueFormat outputFormat) {
         if (format == outputFormat) {
@@ -198,19 +160,21 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     }
 
     /**
-     * Formats the combination into a human-readable string representation onto the provided
-     * {@link java.lang.StringBuilder StringBuilder}. Through the use of a provided buffer, this method
-     * avoids unnecessary memory allocations, making it suitable for high-performance logging scenarios.
-     * 
-     * @param buffer the {@link java.lang.StringBuilder StringBuilder} to append the formatted message
-     *               to.
-     * @throws NullPointerException (implicitly) if the provided buffer is null.
-     * @see org.apache.logging.log4j.util.StringBuilderFormattable
-     * @see org.apache.logging.log4j.util.StringBuilderFormattable#formatTo(StringBuilder)
-     * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance <code>O({@link #list}.length)</code> due to iteration through the list.
-     * @threading Thread-safe, as the method does not modify shared state.
-     * @memory Does not allocate.
+     * Formats the combination as a human-readable string into the provided {@link StringBuilder}.
+     *
+     * <p>
+     * This is the core method for garbage-free logging. It ensures the combination is in a readable
+     * {@link Grid.ValueFormat#PackedInt} format and appends it to the buffer.
+     * </p>
+     *
+     * @param buffer The {@code StringBuilder} to which the formatted message will be appended.
+     * @throws NullPointerException (implicitly) if the provided buffer is {@code null}.
+     * @see StringBuilderFormattable
+     * @see StringBuilderFormattable#formatTo(StringBuilder)
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(list.length)} iteration through the list.
+     * @threading Thread-safe, unless format conversion is triggered.
+     * @memory Does not allocate; appends directly to the provided {@code StringBuilder}.
      */
     @Override
     public void formatTo(StringBuilder buffer) {
@@ -229,18 +193,18 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     }
 
     /**
-     * Returns the formatted message as a {@link java.lang.String String}. This method is a fallback for
-     * legacy APIs that require a {@code String} representation of the message. Internally, it
-     * constructs the string using a {@link java.lang.StringBuilder StringBuilder} and the
-     * {@link #formatTo(StringBuilder)} method to avoid intermediate {@code String} allocations, but it
-     * must still create a new {@code String} for the return value.
-     * 
-     * @return the formatted message as a {@code String}.
+     * Returns the formatted message as a {@link String}.
+     *
+     * <p>
+     * This method serves as a fallback and is not typically called by Log4j2's asynchronous appenders.
+     * It necessarily allocates a new {@link String}, defeating the purpose of a garbage-free message.
+     * </p>
+     *
+     * @return The formatted message as a new {@code String}.
      * @see java.lang.StringBuilder#toString()
-     * @since 2025.05.31 - CombinationMessage Introduction
+     * @since 2025.05 - CombinationMessage Introduction
      * @performance {@code O(1)} call to {@link #formatTo(StringBuilder)}
-     * @threading Thread-safe, as it delegates to the thread-safe {@link #formatTo(StringBuilder)}
-     *            method.
+     * @threading Thread-safe, unless conversion is triggered.
      * @memory Allocates a new {@code String} for the return value, but avoids intermediate
      *         {@code String} allocations.
      */
@@ -253,37 +217,21 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     }
 
     /**
-     * Returns the combination in the specified {@link Grid.ValueFormat format}. If the current format
-     * of the combination does not match the requested output format, it will be converted in-place to
-     * the desired format before being returned.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Returns the raw combination array, {@link #convertTo(Grid.ValueFormat) converting} it to the
+     * specified format if necessary.
+     *
      * <p>
-     * This method may perform an in-place conversion of the combination list if the current format does
-     * not match the requested output format. The conversion process has a time complexity of
-     * <code>O({@link #list}.length)</code>, due to the need to iterate through the entire {@code list}.
-     * The conversion involves simple arithmetic operations, which are generally fast, but the number of
-     * {@code switch} cases and conversions may introduce some overhead.
+     * The current design prioritizes simplicity, but for optimal performance, creating specialized
+     * methods for each format conversion would reduce the overhead of conditional checks.
      * </p>
-     * 
-     * <p>
-     * For optimal performance, it may be beneficial to create specialized methods for each format to
-     * avoid the overhead of conditional checks during conversion. However, this would increase code
-     * complexity and maintenance efforts. The current design prioritizes simplicity and
-     * maintainability.
-     * </p>
-     * 
-     * @param outputFormat the desired {@link Grid.ValueFormat} for the returned combination.
-     * @return the combination as a {@code short[]} in the specified format.
-     * @throws IllegalArgumentException if the provided output format is
-     *                                  {@link Grid.ValueFormat#Bitmask}.
-     * @see #convertTo(Grid.ValueFormat)
-     * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance <code>O({@link #list}.length)</code> if conversion is needed; {@code O(1)} if no
-     *              conversion is needed.
-     * @threading Not thread-safe; should be called in a single-threaded context or synchronized
-     *            externally.
-     * @memory In-place conversion; does not allocate additional memory for the list.
+     *
+     * @param outputFormat The desired {@link Grid.ValueFormat} for the returned array.
+     * @return The {@code short[]} combination in the specified format.
+     * @throws IllegalArgumentException if conversion to {@link Grid.ValueFormat#Bitmask} is attempted.
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(list.length)} if conversion is needed; {@code O(1)} otherwise.
+     * @threading Thread-safe, unless conversion is triggered.
+     * @memory Does not allocate; returns the internal array, converting in-place if needed.
      */
     public short[] getCombination(Grid.ValueFormat outputFormat) {
         if (outputFormat == Grid.ValueFormat.Bitmask) {
@@ -298,11 +246,12 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     /**
      * {@inheritDoc}
      * 
-     * This method is not used in this implementation and always returns {@code null}.
-     * 
-     * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance {@code O(1)} return of {@code null}.
-     * @threading Thread-safe, as it does not modify shared state.
+     * Not used by this message type.
+     *
+     * @return Always {@code null}.
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(1)}.
+     * @threading Thread-safe.
      * @memory Does not allocate.
      */
     @Override
@@ -313,11 +262,12 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     /**
      * {@inheritDoc}
      * 
-     * This method is not used in this implementation and always returns {@code null}.
-     * 
-     * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance {@code O(1)} return of {@code null}.
-     * @threading Thread-safe, as it does not modify shared state.
+     * Not used by this message type.
+     *
+     * @return Always {@code null}.
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(1)}.
+     * @threading Thread-safe.
      * @memory Does not allocate.
      */
     @Override
@@ -328,11 +278,12 @@ public class CombinationMessage implements Message, StringBuilderFormattable
     /**
      * {@inheritDoc}
      * 
-     * This method is not used in this implementation and always returns {@code null}.
-     * 
-     * @since 2025.05.31 - CombinationMessage Introduction
-     * @performance {@code O(1)} return of {@code null}.
-     * @threading Thread-safe, as it does not modify shared state.
+     * Not used by this message type.
+     *
+     * @return Always {@code null}.
+     * @since 2025.05 - CombinationMessage Introduction
+     * @performance {@code O(1)}.
+     * @threading Thread-safe.
      * @memory Does not allocate.
      */
     @Override

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -3,41 +3,87 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MpmcArrayQueue;
 
 /**
- * CombinationQueue - [Primary Purpose in Algorithm]
+ * CombinationQueue - A high-performance, thread-safe queue for managing {@link WorkBatch batches}
+ * of click combinations to be tested by {@link TestClickCombination worker threads (monkeys)}.
  * 
- * <p>[Detailed description of role in the overall puzzle-solving architecture.
- * Explain the "what" and "why" - what problem this class solves and why this 
- * approach was chosen.]</p>
+ * <p>
+ * Parallelism is key to efficiently solving this puzzle, and an efficient way to do that is to
+ * divide the operational roles into {@link CombinationGeneratorTask generators} and
+ * {@link TestClickCombination monkeys}. However, this separation of concerns requires a robust and
+ * efficient way to exchange work between these two roles. This class serves as the conduit for this
+ * exchange, holding batches of click combinations for the monkeys to process.
+ * </p>
+ * 
+ * <p>
+ * This queue is implemented using the {@link org.jctools.queues.MpmcArrayQueue MpmcArrayQueue} from the JCTools library, which is
+ * designed for high-throughput, low-latency concurrent access. The queue is bounded to a fixed size
+ * to prevent unbounded memory growth, and it uses non-blocking operations to minimize contention
+ * between threads. This design choice ensures that both the generators and monkeys can operate
+ * efficiently without being bottlenecked by synchronization overhead.
+ * </p>
  * 
  * <h2>Architecture Role</h2>
- * <p>[How this class fits into the overall system. What classes depend on it,
- * what it depends on, and the data flow.]</p>
+ * <p>
+ * The CombinationQueue acts as a bridge between the {@link CombinationGeneratorTask generators} and
+ * the {@link TestClickCombination monkeys}. Generators produce {@link WorkBatch batches} of work
+ * and enqueue them into a queue, while monkeys dequeue these batches and process them. This
+ * decoupling allows both components to operate independently and at their own pace, improving the
+ * overall throughput and responsiveness of the system.
+ * </p>
  * 
  * <h2>Performance Characteristics</h2>
- * <p>[Key performance properties, bottlenecks, and optimization strategies.
- * Include complexity analysis for critical methods.]</p>
+ * <p>
+ * The CombinationQueue is optimized for high performance in a multi-threaded environment. By using a
+ * bounded, lock-free queue, it minimizes the overhead associated with thread synchronization. The use
+ * of batches instead of individual combinations further reduces the frequency of enqueue and dequeue
+ * operations, amortizing the overhead across multiple combinations. This design is particularly
+ * effective in scenarios with high contention, as it allows multiple threads to operate
+ * concurrently with minimal interference.
+ * </p>
  * 
  * <h2>Thread Safety</h2>
- * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * <p>
+ * The CombinationQueue is inherently thread-safe due to its use of the MpmcArrayQueue, which is
+ * designed for concurrent access by multiple producers and consumers. The non-blocking operations
+ * used for enqueuing and dequeuing ensure that threads can operate without waiting on locks or
+ * other synchronization mechanisms.
+ * </p>
  * 
- * <h3>0/8 - 0% of documentation completed</h3>
+ * <p>
+ * Though the queue itself is thread-safe, it is important to note that the {@link WorkBatch} objects
+ * enqueued in the queue are not. Care should be taken to ensure that these objects are handed off
+ * between threads in a safe manner, preventing a thread from modifying a WorkBatch after it enqueues it.
+ * </p>
  * 
- * @performance [Overall performance characteristics]
- * @threading [Thread safety guarantees]  
- * @algorithm [High-level algorithm description]
- * @since [Version when introduced/major changes]
- * @see [Related classes in the architecture]
+ * <h3>5/8 - 62.5% of documentation completed</h3>
+ * 
+ * @threading Thread-safe via JCTools magic.
+ * @performance O(1) amortized for enqueue/dequeue operations and field accesses.
+ * @algorithm Lock-free MPMC queue using JCTools wizardry.
+ * @since 2025.04.01 - Multi-threaded Architecture Introduction
+ * @see CombinationGeneratorTask
+ * @see TestClickCombination
+ * @see WorkBatch
  */
-public class CombinationQueue 
-{
+public class CombinationQueue {
     // This queue now holds entire batches of work, not individual combinations.
     // A smaller capacity is fine as it represents larger work units.
     // OPTIMIZATION: Drastically reduce queue size to lower memory footprint for pre-allocation.
     private final int QUEUE_SIZE = 16;
     private final MpmcArrayQueue<WorkBatch> queue;
 
-    public CombinationQueue() 
-    {
+    /**
+     * Constructs a new CombinationQueue with a fixed capacity of {@link #QUEUE_SIZE}.
+     * 
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @performance O(1) time complexity.
+     * @optimization Uses a small, fixed-size queue to minimize memory overhead while batching work.
+     * @threading Thread-safe via JCTools magic.
+     * @see #queue
+     * @see org.jctools.queues.MpmcArrayQueue
+     * @see org.jctools.queues.MpmcArrayQueue#MpmcArrayQueue(int)
+     */
+    public CombinationQueue() {
         queue = new MpmcArrayQueue<>(QUEUE_SIZE);
     }
 
@@ -47,26 +93,73 @@ public class CombinationQueue
     }
 
     /**
-     * Adds a full WorkBatch to the queue for a worker to process.
-     * @param workBatch The batch of combinations to add.
-     * @return true if the batch was successfully added.
+     * Offers a {@link WorkBatch} to the queue. Returns <code>true</code> if the batch was added, or
+     * <code>false</code> if the queue is full.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is non-blocking and uses a relaxed offer {@link MpmcArrayQueue#relaxedOffer(Object)
+     * as defined by} the JCTools library. This method trades perfect accuracy for speed, meaning it may
+     * occasionally fail to add an item (and return <code>false</code>) even if the queue is not full.
+     * This is acceptable in our use case, as the {@link CombinationGeneratorTask generator} can simply
+     * try to add the batch to a new queue or retry later.
+     * </p>
+     * 
+     * @param workBatch the {@link WorkBatch} to add to the queue.
+     * @return <code>true</code> if the batch was added successfully, or <code>false</code> if
+     *         unsuccessful (the queue is full or the relaxed offer failed).
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @threading Thread-safe via JCTools magic.
+     * @performance O(1) amortized time complexity.
+     * @optimization Relaxed offer for speed, accepting occasional false negatives. Enqueues batches
+     *               instead of combinations to amortize overhead across more combinations.
+     * @see #getWorkBatch()
+     * @see MpmcArrayQueue#relaxedOffer(Object)
+     * @see WorkBatch
      */
-    public boolean add(WorkBatch workBatch)
-    {
+    public boolean add(WorkBatch workBatch) {
         return queue.relaxedOffer(workBatch);
     }
 
     /**
-     * Retrieves a WorkBatch from the queue.
-     * @return A WorkBatch to be processed, or null if the queue is empty.
+     * Attempts to retrieve a {@link WorkBatch} from the queue.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is non-blocking and uses a relaxed poll {@link MpmcArrayQueue#relaxedPoll() as
+     * defined by} the JCTools library. This method trades perfect accuracy for speed, meaning it may
+     * occasionally return <code>null</code> even if the queue is not empty. This is acceptable in our
+     * use case, as the {@link TestClickCombination monkeys} can try to poll from a new queue or retry
+     * later.
+     * </p>
+     * 
+     * @return the next {@link WorkBatch} from the queue, or <code>null</code> if the queue is empty or
+     *         the relaxed poll failed.
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @threading Thread-safe via JCTools magic.
+     * @performance O(1) amortized time complexity.
+     * @optimization Relaxed poll for speed, accepting occasional false negatives. Polls batches instead
+     *               of combinations to amortize overhead across more combinations.
+     * @see #add(WorkBatch)
+     * @see MpmcArrayQueue#relaxedPoll()
+     * @see WorkBatch
      */
-    public WorkBatch getWorkBatch() 
-    {
+    public WorkBatch getWorkBatch() {
         return queue.relaxedPoll();
     }
 
-    public boolean isEmpty() 
-    {
+    /**
+     * Checks the queue for emptiness. Note that due to the concurrent nature of the queue,
+     * this is only a snapshot in time and may not reflect the state immediately after the call.
+     * 
+     * @return <code>true</code> if the queue is empty at the time of the call, otherwise <code>false</code>.
+     * @since 2025.08.02 - Class Formatting Cleanup
+     * @threading Thread-safe via JCTools magic.
+     * @performance O(1) time complexity.
+     * @optimization Simple check with minimal overhead.
+     * @see org.jctools.queues.MpmcArrayQueue#isEmpty()
+     */
+    public boolean isEmpty() {
         return queue.isEmpty();
     }
 }

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -55,13 +55,13 @@ import org.jctools.queues.MpmcArrayQueue;
  * between threads in a safe manner, preventing a thread from modifying a WorkBatch after it enqueues it.
  * </p>
  * 
- * @threading Thread-safe via JCTools magic.
- * @performance O(1) amortized for enqueue/dequeue operations and field accesses.
- * @algorithm Lock-free MPMC queue using JCTools wizardry.
- * @since 2025.04.01 - Multi-threaded Architecture Introduction
  * @see CombinationGeneratorTask
  * @see TestClickCombination
  * @see WorkBatch
+ * @since 2025.04.01 - Multi-threaded Architecture Introduction
+ * @performance O(1) amortized for enqueue/dequeue operations and field accesses.
+ * @threading Thread-safe via JCTools magic.
+ * @algorithm Lock-free MPMC queue using JCTools wizardry.
  */
 public class CombinationQueue {
     /**
@@ -77,10 +77,10 @@ public class CombinationQueue {
      * monkeys if the generators cannot keep up.
      * </p>
      * 
+     * @see org.jctools.queues.MpmcArrayQueue#capacity()
      * @since 2025.07.07 - Enqueuing WorkBatch Objects
      * @performance O(1) time complexity for capacity access.
      * @optimization Small, fixed-size queue to minimize memory overhead while batching work.
-     * @see org.jctools.queues.MpmcArrayQueue#capacity()
      */
     private final int QUEUE_SIZE = 16;
     /**
@@ -88,26 +88,26 @@ public class CombinationQueue {
      * characteristics. This queue holds {@link WorkBatch} objects, each containing multiple click
      * combinations to be processed by {@link TestClickCombination worker threads (monkeys)}.
      * 
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @threading Thread-safe via JCTools magic.
-     * @performance O(1) amortized time complexity for enqueue/dequeue operations, O(1) capacity access,
-     *              and O(n) size access.
-     * @optimization Uses a bounded, lock-free queue to minimize memory overhead and contention.
      * @see org.jctools.queues.MpmcArrayQueue
      * @see WorkBatch
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @performance O(1) amortized time complexity for enqueue/dequeue operations, O(1) capacity access,
+     *              and O(n) size access.
+     * @threading Thread-safe via JCTools magic.
+     * @optimization Uses a bounded, lock-free queue to minimize memory overhead and contention.
      */
     private final MpmcArrayQueue<WorkBatch> queue;
 
     /**
      * Constructs a new CombinationQueue with a fixed capacity of {@link #QUEUE_SIZE}.
      * 
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) time complexity.
-     * @optimization Uses a small, fixed-size queue to minimize memory overhead while batching work.
-     * @threading Thread-safe via JCTools magic.
      * @see #queue
      * @see org.jctools.queues.MpmcArrayQueue
      * @see org.jctools.queues.MpmcArrayQueue#MpmcArrayQueue(int)
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @performance O(1) time complexity.
+     * @threading Thread-safe via JCTools magic.
+     * @optimization Uses a small, fixed-size queue to minimize memory overhead while batching work.
      */
     public CombinationQueue() {
         queue = new MpmcArrayQueue<>(QUEUE_SIZE);
@@ -117,13 +117,14 @@ public class CombinationQueue {
      * Gets the capacity of the queue.
      * 
      * @return the fixed capacity of the queue.
-     * @since 2025.07.08 - Matching Sized Queues for Generators and Monkeys
-     * @threading Thread-safe, since it only reads a final field.
-     * @performance O(1) time complexity.
-     * @optimization Simple field access with minimal overhead.
+     * @return the fixed capacity of the queue.
      * @see #QUEUE_SIZE
      * @see #CombinationQueue()
      * @see org.jctools.queues.MpmcArrayQueue#capacity()
+     * @since 2025.07.08 - Matching Sized Queues for Generators and Monkeys
+     * @performance O(1) time complexity.
+     * @threading Thread-safe, since it only reads a final field.
+     * @optimization Simple field access with minimal overhead.
      */
     public int getCapacity() {
         return QUEUE_SIZE;
@@ -145,14 +146,14 @@ public class CombinationQueue {
      * @param workBatch the {@link WorkBatch} to add to the queue.
      * @return <code>true</code> if the batch was added successfully, or <code>false</code> if
      *         unsuccessful (the queue is full or the relaxed offer failed).
+     * @see #getWorkBatch()
+     * @see WorkBatch
+     * @see org.jctools.queues.MpmcArrayQueue#relaxedOffer(Object)
      * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @threading Thread-safe via JCTools magic.
      * @performance O(1) amortized time complexity.
+     * @threading Thread-safe via JCTools magic.
      * @optimization Relaxed offer for speed, accepting occasional false negatives. Enqueues batches
      *               instead of combinations to amortize overhead across more combinations.
-     * @see #getWorkBatch()
-     * @see MpmcArrayQueue#relaxedOffer(Object)
-     * @see WorkBatch
      */
     public boolean add(WorkBatch workBatch) {
         return queue.relaxedOffer(workBatch);
@@ -172,14 +173,14 @@ public class CombinationQueue {
      * 
      * @return the next {@link WorkBatch} from the queue, or <code>null</code> if the queue is empty or
      *         the relaxed poll failed.
+     * @see #add(WorkBatch)
+     * @see WorkBatch
+     * @see org.jctools.queues.MpmcArrayQueue#relaxedPoll()
      * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @threading Thread-safe via JCTools magic.
      * @performance O(1) amortized time complexity.
+     * @threading Thread-safe via JCTools magic.
      * @optimization Relaxed poll for speed, accepting occasional false negatives. Polls batches instead
      *               of combinations to amortize overhead across more combinations.
-     * @see #add(WorkBatch)
-     * @see MpmcArrayQueue#relaxedPoll()
-     * @see WorkBatch
      */
     public WorkBatch getWorkBatch() {
         return queue.relaxedPoll();
@@ -190,11 +191,11 @@ public class CombinationQueue {
      * this is only a snapshot in time and may not reflect the state immediately after the call.
      * 
      * @return <code>true</code> if the queue is empty at the time of the call, otherwise <code>false</code>.
-     * @since 2025.08.02 - Class Formatting Cleanup
-     * @threading Thread-safe via JCTools magic.
-     * @performance O(1) time complexity.
-     * @optimization Simple check with minimal overhead.
      * @see org.jctools.queues.MpmcArrayQueue#isEmpty()
+     * @since 2025.08.02 - Class Formatting Cleanup
+     * @performance O(1) time complexity.
+     * @threading Thread-safe via JCTools magic.
+     * @optimization Simple check with minimal overhead.
      */
     public boolean isEmpty() {
         return queue.isEmpty();

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -3,198 +3,162 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MpmcArrayQueue;
 
 /**
- * A high-performance, thread-safe queue for managing {@link WorkBatch batches} of click
- * combinations to be tested by {@link TestClickCombination worker threads (monkeys)}.
- * 
+ * A thin, type-safe wrapper around a JCTools {@link MpmcArrayQueue} designed exclusively for
+ * transferring {@link WorkBatch} objects between producer and consumer threads.
+ *
+ * <h2>Architectural Role</h2>
  * <p>
- * Parallelism is key to efficiently solving this puzzle, and an efficient way to do that is to
- * divide the operational roles into {@link CombinationGeneratorTask generators} and
- * {@link TestClickCombination monkeys}. However, this separation of concerns requires a robust and
- * efficient way to exchange work between these two roles. This class serves as the conduit for this
- * exchange, holding batches of click combinations for the monkeys to process.
- * </p>
- * 
- * <p>
- * This queue is implemented using the {@link org.jctools.queues.MpmcArrayQueue MpmcArrayQueue} from
- * the JCTools library, which is designed for high-throughput, low-latency concurrent access. The
- * queue is bounded to a fixed size to prevent unbounded memory growth, and it uses non-blocking
- * operations to minimize contention between threads. This design choice ensures that both the
- * generators and monkeys can operate efficiently without being bottlenecked by synchronization
+ * This class serves as a high-performance communication channel between
+ * {@link CombinationGeneratorTask} producer threads and {@link TestClickCombination} consumer
+ * threads ("monkeys"). Its sole purpose is to enqueue and dequeue {@link WorkBatch} instances,
+ * which is the cornerstone of the solver's low-contention batching architecture. By batching
+ * thousands of combinations into a single queue operation, it dramatically reduces synchronization
  * overhead.
  * </p>
- * 
- * <h2>Architecture Role</h2>
+ *
+ * <h2>Implementation Details</h2>
  * <p>
- * The {@code CombinationQueue} acts as a bridge between the {@link CombinationGeneratorTask
- * generators} and the {@link TestClickCombination monkeys}. Generators produce {@link WorkBatch
- * batches} of work and enqueue them into a queue, while monkeys dequeue these batches and process
- * them. This decoupling allows both components to operate independently and at their own pace,
- * improving the overall throughput and responsiveness of the system.
+ * It is implemented as a thin wrapper over {@code MpmcArrayQueue} to provide a clear,
+ * domain-specific API. The queue is bounded and operates in a lock-free manner, using relaxed
+ * (non-blocking) offers and polls for maximum throughput.
  * </p>
- * 
- * <h2>Performance Characteristics</h2>
- * <p>
- * {@code CombinationQueue} is optimized for high performance in a multi-threaded environment. By
- * using a bounded, lock-free queue, it minimizes the overhead associated with thread
- * synchronization. The use of batches instead of individual combinations further reduces the
- * frequency of enqueue and dequeue operations, amortizing the overhead across multiple
- * combinations. This design is particularly effective in scenarios with high contention, as it
- * allows multiple threads to operate concurrently with minimal interference.
- * </p>
- * 
+ *
  * <h2>Thread Safety</h2>
  * <p>
- * {@code CombinationQueue} is inherently thread-safe due to its use of the {@code MpmcArrayQueue},
- * which is designed for concurrent access by multiple producers and consumers. The non-blocking
- * operations used for enqueuing and dequeuing ensure that threads can operate without waiting on
- * locks or other synchronization mechanisms.
+ * This class is thread-safe for multiple producers and multiple consumers, as guaranteed by the
+ * underlying JCTools queue. However, the {@link WorkBatch} objects passed through it are
+ * <strong>not</strong> thread-safe. A safe hand-off protocol is required, where producers do not
+ * modify a batch after it has been offered to the queue.
  * </p>
- * 
- * <p>
- * Though the queue itself is thread-safe, it is important to note that the {@link WorkBatch}
- * objects enqueued in the queue are not. Care should be taken to ensure that these objects are
- * handed off between threads in a safe manner, preventing a thread from modifying a
- * {@code WorkBatch} after it enqueues it.
- * </p>
- * 
- * @see CombinationGeneratorTask
- * @see TestClickCombination
- * @see WorkBatch
- * @since 2025.04.01 - Multi-threaded Architecture Introduction
+ *
+ * @see CombinationQueueArray
+ * @since 2025.04 - Multi-threaded Architecture Introduction
  * @performance {@code O(1)} amortized for enqueue/dequeue operations and field accesses.
- * @threading Thread-safe via JCTools magic.
- * @algorithm Lock-free MPMC queue using JCTools wizardry.
+ * @threading Thread-safe via JCTools "magic".
+ * @algorithm Lock-free, bounded MPMC queue with relaxed semantics using JCTools wizardry.
+ * @memory Fixed memory overhead for the queue structure.
  */
 public class CombinationQueue {
     /**
      * The fixed capacity of the queue.
-     * 
-     * <h3>Performance Considerations</h3>
+     *
      * <p>
-     * A smaller queue size is chosen to minimize memory overhead while still allowing effective
-     * batching of work. This size is a balance between memory usage and the need to keep the
-     * {@link TestClickCombination monkeys} fed with work. Higher queue sizes increase the likelihood of
-     * empty spots in the queue for {@link CombinationGeneratorTask generators} to fill, but also
-     * increase memory usage. Lower sizes reduce memory usage, but may lead to starved monkeys if the
-     * generators cannot keep up.
+     * This size represents a trade-off:
+     * <ul>
+     * <li><b>Larger Queue:</b> Reduces the chance of a {@link CombinationGeneratorTask generator}
+     * failing to enqueue a new batch, but increases the solver's overall memory footprint.</li>
+     * <li><b>Smaller Queue:</b> Minimizes memory overhead but increases the risk of
+     * {@link TestClickCombination monkeys} becoming starved for work if generators are temporarily
+     * blocked.</li>
+     * </ul>
+     * A small size is chosen because the queue holds large {@link WorkBatch} objects, making memory a
+     * primary consideration.
      * </p>
      * 
-     * @see org.jctools.queues.MpmcArrayQueue#capacity()
-     * @since 2025.07.07 - Enqueuing {@link WorkBatch} Objects
-     * @performance {@code O(1)} time complexity for capacity access.
-     * @optimization Small, fixed-size queue to minimize memory overhead while batching work.
+     * <p>
+     * Note that, per {@link MpmcArrayQueue#MpmcArrayQueue(int)}, the capacity will be rounded up to the
+     * next power of two if it is not already.
+     * </p>
+     * 
+     * @see MpmcArrayQueue#capacity()
+     * @since 2025.07 - Enqueuing {@link WorkBatch} Objects
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe; immutable field.
+     * @memory Minimal footprint of 4 bytes as an {@code int}.
      */
     private final int QUEUE_SIZE = 16;
     /**
-     * The underlying MPMC queue from the JCTools library, used for its high performance and thread-safe
-     * characteristics. This queue holds {@link WorkBatch} objects, each containing multiple click
-     * combinations to be processed by {@link TestClickCombination worker threads (monkeys)}.
+     * The underlying {@link MpmcArrayQueue JCTools queue} that holds {@link WorkBatch} objects.
      * 
-     * @see org.jctools.queues.MpmcArrayQueue
-     * @see WorkBatch
-     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
-     * @performance {@code O(1)} amortized time complexity for enqueue/dequeue operations, {@code O(1)}
-     *              capacity access, and <code>O({@link #QUEUE_SIZE})</code> size access.
-     * @threading Thread-safe via JCTools magic.
-     * @optimization Uses a bounded, lock-free queue to minimize memory overhead and contention.
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} amortized for enqueue/dequeue operations, {@code O(1)} capacity access,
+     *              and {@code O(QUEUE_SIZE)} size access.
+     * @threading Thread-safe via JCTools "magic".
+     * @memory Fixed memory overhead for the queue structure.
      */
     private final MpmcArrayQueue<WorkBatch> queue;
 
     /**
-     * Constructs a new {@code CombinationQueue} with a fixed capacity of {@link #QUEUE_SIZE}.
+     * Constructs a new {@code CombinationQueue} with a {@link #QUEUE_SIZE fixed capacity}.
      * 
      * @see #queue
-     * @see org.jctools.queues.MpmcArrayQueue
-     * @see org.jctools.queues.MpmcArrayQueue#MpmcArrayQueue(int)
-     * @since 2025.07.07 - Enqueuing {@link WorkBatch} Objects
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe via JCTools magic.
-     * @optimization Uses a small, fixed-size queue to minimize memory overhead while batching work.
+     * @see MpmcArrayQueue
+     * @see MpmcArrayQueue#MpmcArrayQueue(int)
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} creation and assignment.
+     * @threading Thread-safe via JCTools "magic".
+     * @memory Allocates memory for the underlying queue structure.
      */
     public CombinationQueue() {
         queue = new MpmcArrayQueue<>(QUEUE_SIZE);
     }
 
     /**
-     * Gets the capacity of the queue.
-     * 
-     * @return the fixed capacity of the queue.
-     * @see #QUEUE_SIZE
-     * @see #CombinationQueue()
-     * @see org.jctools.queues.MpmcArrayQueue#capacity()
-     * @since 2025.07.08 - Matching Sized Queues for Generators and Monkeys
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe, since it only reads a {@code final} field.
-     * @optimization Simple field access with minimal overhead.
+     * Returns the fixed capacity of the queue.
+     *
+     * @return the queue's capacity.
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} field access.
+     * @threading Thread-safe; returns an immutable field.
+     * @memory Does not allocate.
      */
     public int getCapacity() {
         return QUEUE_SIZE;
     }
 
     /**
-     * Offers a {@link WorkBatch} to the queue. Returns {@code true} if the batch was added, or
-     * {@code false} if the queue is full.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Offers a {@link WorkBatch} to the queue using a non-blocking, relaxed operation.
+     *
      * <p>
-     * This method is non-blocking and uses a relaxed offer {@link MpmcArrayQueue#relaxedOffer(Object)
-     * as defined by} the JCTools library. This method trades perfect accuracy for speed, meaning it may
-     * occasionally fail to add an item (and return {@code false}) even if the queue is not full.
-     * This is acceptable in our use case, as the {@link CombinationGeneratorTask generator} can simply
-     * try to add the batch to a new queue or retry later.
+     * This method may occasionally fail (return {@code false}) even if the queue is not full, which is
+     * an acceptable trade-off for higher throughput.
      * </p>
-     * 
-     * @param workBatch the {@link WorkBatch} to add to the queue.
-     * @return {@code true} if the batch was added successfully, or {@code false} if
-     *         unsuccessful (the queue is full or the relaxed offer failed).
-     * @see #getWorkBatch()
-     * @see org.jctools.queues.MpmcArrayQueue#relaxedOffer(Object)
-     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
-     * @performance {@code O(1)} amortized time complexity.
-     * @threading Thread-safe via JCTools magic.
-     * @optimization Relaxed offer for speed, accepting occasional false negatives. Enqueues batches
-     *               instead of combinations to amortize overhead across more combinations.
+     *
+     * @param workBatch the batch to add.
+     * @return {@code true} if the batch was successfully added, {@code false} otherwise.
+     * @see MpmcArrayQueue#relaxedOffer(Object)
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} amortized enqueue operation.
+     * @threading Thread-safe via JCTools "magic".
+     * @memory Does not allocate; uses pre-allocated queue slots.
      */
     public boolean add(WorkBatch workBatch) {
         return queue.relaxedOffer(workBatch);
     }
 
     /**
-     * Attempts to retrieve a {@link WorkBatch} from the queue.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Retrieves a {@link WorkBatch} from the queue using a non-blocking, relaxed operation.
+     *
      * <p>
-     * This method is non-blocking and uses a relaxed poll {@link MpmcArrayQueue#relaxedPoll() as
-     * defined by} the JCTools library. This method trades perfect accuracy for speed, meaning it may
-     * occasionally return {@code null} even if the queue is not empty. This is acceptable in our use
-     * case, as the {@link TestClickCombination monkeys} can try to poll from a new queue or retry
-     * later.
+     * This method may occasionally fail (return {@code null}) even if the queue is not empty, which is
+     * an acceptable trade-off for higher throughput.
      * </p>
-     * 
-     * @return the next {@link WorkBatch} from the queue, or {@code null} if the queue is empty or the
-     *         relaxed poll failed.
-     * @see #add(WorkBatch)
-     * @see org.jctools.queues.MpmcArrayQueue#relaxedPoll()
-     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
-     * @performance {@code O(1)} amortized time complexity.
-     * @threading Thread-safe via JCTools magic.
-     * @optimization Relaxed poll for speed, accepting occasional false negatives. Polls batches instead
-     *               of combinations to amortize overhead across more combinations.
+     *
+     * @return a {@link WorkBatch} if one was available, or {@code null} otherwise.
+     * @see MpmcArrayQueue#relaxedPoll()
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} amortized dequeue operation.
+     * @threading Thread-safe via JCTools "magic".
+     * @memory Does not allocate; returns references to existing objects.
      */
     public WorkBatch getWorkBatch() {
         return queue.relaxedPoll();
     }
 
     /**
-     * Checks the queue for emptiness. Note that due to the concurrent nature of the queue, this is only
-     * a snapshot in time and may not reflect the state immediately after the call.
-     * 
-     * @return {@code true} if the queue is empty at the time of the call, otherwise {@code false}.
-     * @see org.jctools.queues.MpmcArrayQueue#isEmpty()
-     * @since 2025.08.02 - Class Formatting Cleanup
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe via JCTools magic.
-     * @optimization Simple check with minimal overhead.
+     * Checks if the queue is empty.
+     *
+     * <p>
+     * Note: In a concurrent environment, the result of this call is only a snapshot in time and may be
+     * immediately outdated.
+     * </p>
+     *
+     * @return {@code true} if the queue was empty at the time of the call, {@code false} otherwise.
+     * @see MpmcArrayQueue#isEmpty()
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} call to queue method.
+     * @threading Thread-safe via JCTools "magic". May be stale immediately after return.
+     * @memory Does not allocate.
      */
     public boolean isEmpty() {
         return queue.isEmpty();

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -2,6 +2,32 @@ package com.github.mrgarbagegamer;
 
 import org.jctools.queues.MpmcArrayQueue;
 
+/**
+ * CombinationQueue - [Primary Purpose in Algorithm]
+ * 
+ * <p>[Detailed description of role in the overall puzzle-solving architecture.
+ * Explain the "what" and "why" - what problem this class solves and why this 
+ * approach was chosen.]</p>
+ * 
+ * <h2>Architecture Role</h2>
+ * <p>[How this class fits into the overall system. What classes depend on it,
+ * what it depends on, and the data flow.]</p>
+ * 
+ * <h2>Performance Characteristics</h2>
+ * <p>[Key performance properties, bottlenecks, and optimization strategies.
+ * Include complexity analysis for critical methods.]</p>
+ * 
+ * <h2>Thread Safety</h2>
+ * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * 
+ * <h3>0/8 - 0% of documentation completed</h3>
+ * 
+ * @performance [Overall performance characteristics]
+ * @threading [Thread safety guarantees]  
+ * @algorithm [High-level algorithm description]
+ * @since [Version when introduced/major changes]
+ * @see [Related classes in the architecture]
+ */
 public class CombinationQueue 
 {
     // This queue now holds entire batches of work, not individual combinations.

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -55,8 +55,6 @@ import org.jctools.queues.MpmcArrayQueue;
  * between threads in a safe manner, preventing a thread from modifying a WorkBatch after it enqueues it.
  * </p>
  * 
- * <h3>7/8 - 87.5% of documentation completed</h3>
- * 
  * @threading Thread-safe via JCTools magic.
  * @performance O(1) amortized for enqueue/dequeue operations and field accesses.
  * @algorithm Lock-free MPMC queue using JCTools wizardry.
@@ -115,8 +113,19 @@ public class CombinationQueue {
         queue = new MpmcArrayQueue<>(QUEUE_SIZE);
     }
 
-    public int getCapacity()
-    {
+    /**
+     * Gets the capacity of the queue.
+     * 
+     * @return the fixed capacity of the queue.
+     * @since 2025.07.08 - Matching Sized Queues for Generators and Monkeys
+     * @threading Thread-safe, since it only reads a final field.
+     * @performance O(1) time complexity.
+     * @optimization Simple field access with minimal overhead.
+     * @see #QUEUE_SIZE
+     * @see #CombinationQueue()
+     * @see org.jctools.queues.MpmcArrayQueue#capacity()
+     */
+    public int getCapacity() {
         return QUEUE_SIZE;
     }
 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -55,7 +55,7 @@ import org.jctools.queues.MpmcArrayQueue;
  * between threads in a safe manner, preventing a thread from modifying a WorkBatch after it enqueues it.
  * </p>
  * 
- * <h3>5/8 - 62.5% of documentation completed</h3>
+ * <h3>7/8 - 87.5% of documentation completed</h3>
  * 
  * @threading Thread-safe via JCTools magic.
  * @performance O(1) amortized for enqueue/dequeue operations and field accesses.
@@ -66,10 +66,38 @@ import org.jctools.queues.MpmcArrayQueue;
  * @see WorkBatch
  */
 public class CombinationQueue {
-    // This queue now holds entire batches of work, not individual combinations.
-    // A smaller capacity is fine as it represents larger work units.
-    // OPTIMIZATION: Drastically reduce queue size to lower memory footprint for pre-allocation.
+    /**
+     * The fixed capacity of the queue.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * A smaller queue size is chosen to minimize memory overhead while still allowing
+     * effective batching of work. This size is a balance between memory usage and the need to
+     * keep the {@link TestClickCombination monkeys} fed with work. Higher queue sizes increase
+     * the likelihood of empty spots in the queue for {@link CombinationGeneratorTask generators} to
+     * fill, but also increase memory usage. Lower sizes reduce memory usage, but may lead to starved
+     * monkeys if the generators cannot keep up.
+     * </p>
+     * 
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @performance O(1) time complexity for capacity access.
+     * @optimization Small, fixed-size queue to minimize memory overhead while batching work.
+     * @see org.jctools.queues.MpmcArrayQueue#capacity()
+     */
     private final int QUEUE_SIZE = 16;
+    /**
+     * The underlying MPMC queue from the JCTools library, used for its high performance and thread-safe
+     * characteristics. This queue holds {@link WorkBatch} objects, each containing multiple click
+     * combinations to be processed by {@link TestClickCombination worker threads (monkeys)}.
+     * 
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @threading Thread-safe via JCTools magic.
+     * @performance O(1) amortized time complexity for enqueue/dequeue operations, O(1) capacity access,
+     *              and O(n) size access.
+     * @optimization Uses a bounded, lock-free queue to minimize memory overhead and contention.
+     * @see org.jctools.queues.MpmcArrayQueue
+     * @see WorkBatch
+     */
     private final MpmcArrayQueue<WorkBatch> queue;
 
     /**

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueue.java
@@ -3,8 +3,8 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MpmcArrayQueue;
 
 /**
- * CombinationQueue - A high-performance, thread-safe queue for managing {@link WorkBatch batches}
- * of click combinations to be tested by {@link TestClickCombination worker threads (monkeys)}.
+ * A high-performance, thread-safe queue for managing {@link WorkBatch batches} of click
+ * combinations to be tested by {@link TestClickCombination worker threads (monkeys)}.
  * 
  * <p>
  * Parallelism is key to efficiently solving this puzzle, and an efficient way to do that is to
@@ -15,51 +15,53 @@ import org.jctools.queues.MpmcArrayQueue;
  * </p>
  * 
  * <p>
- * This queue is implemented using the {@link org.jctools.queues.MpmcArrayQueue MpmcArrayQueue} from the JCTools library, which is
- * designed for high-throughput, low-latency concurrent access. The queue is bounded to a fixed size
- * to prevent unbounded memory growth, and it uses non-blocking operations to minimize contention
- * between threads. This design choice ensures that both the generators and monkeys can operate
- * efficiently without being bottlenecked by synchronization overhead.
+ * This queue is implemented using the {@link org.jctools.queues.MpmcArrayQueue MpmcArrayQueue} from
+ * the JCTools library, which is designed for high-throughput, low-latency concurrent access. The
+ * queue is bounded to a fixed size to prevent unbounded memory growth, and it uses non-blocking
+ * operations to minimize contention between threads. This design choice ensures that both the
+ * generators and monkeys can operate efficiently without being bottlenecked by synchronization
+ * overhead.
  * </p>
  * 
  * <h2>Architecture Role</h2>
  * <p>
- * The CombinationQueue acts as a bridge between the {@link CombinationGeneratorTask generators} and
- * the {@link TestClickCombination monkeys}. Generators produce {@link WorkBatch batches} of work
- * and enqueue them into a queue, while monkeys dequeue these batches and process them. This
- * decoupling allows both components to operate independently and at their own pace, improving the
- * overall throughput and responsiveness of the system.
+ * The {@code CombinationQueue} acts as a bridge between the {@link CombinationGeneratorTask
+ * generators} and the {@link TestClickCombination monkeys}. Generators produce {@link WorkBatch
+ * batches} of work and enqueue them into a queue, while monkeys dequeue these batches and process
+ * them. This decoupling allows both components to operate independently and at their own pace,
+ * improving the overall throughput and responsiveness of the system.
  * </p>
  * 
  * <h2>Performance Characteristics</h2>
  * <p>
- * The CombinationQueue is optimized for high performance in a multi-threaded environment. By using a
- * bounded, lock-free queue, it minimizes the overhead associated with thread synchronization. The use
- * of batches instead of individual combinations further reduces the frequency of enqueue and dequeue
- * operations, amortizing the overhead across multiple combinations. This design is particularly
- * effective in scenarios with high contention, as it allows multiple threads to operate
- * concurrently with minimal interference.
+ * {@code CombinationQueue} is optimized for high performance in a multi-threaded environment. By
+ * using a bounded, lock-free queue, it minimizes the overhead associated with thread
+ * synchronization. The use of batches instead of individual combinations further reduces the
+ * frequency of enqueue and dequeue operations, amortizing the overhead across multiple
+ * combinations. This design is particularly effective in scenarios with high contention, as it
+ * allows multiple threads to operate concurrently with minimal interference.
  * </p>
  * 
  * <h2>Thread Safety</h2>
  * <p>
- * The CombinationQueue is inherently thread-safe due to its use of the MpmcArrayQueue, which is
- * designed for concurrent access by multiple producers and consumers. The non-blocking operations
- * used for enqueuing and dequeuing ensure that threads can operate without waiting on locks or
- * other synchronization mechanisms.
+ * {@code CombinationQueue} is inherently thread-safe due to its use of the {@code MpmcArrayQueue},
+ * which is designed for concurrent access by multiple producers and consumers. The non-blocking
+ * operations used for enqueuing and dequeuing ensure that threads can operate without waiting on
+ * locks or other synchronization mechanisms.
  * </p>
  * 
  * <p>
- * Though the queue itself is thread-safe, it is important to note that the {@link WorkBatch} objects
- * enqueued in the queue are not. Care should be taken to ensure that these objects are handed off
- * between threads in a safe manner, preventing a thread from modifying a WorkBatch after it enqueues it.
+ * Though the queue itself is thread-safe, it is important to note that the {@link WorkBatch}
+ * objects enqueued in the queue are not. Care should be taken to ensure that these objects are
+ * handed off between threads in a safe manner, preventing a thread from modifying a
+ * {@code WorkBatch} after it enqueues it.
  * </p>
  * 
  * @see CombinationGeneratorTask
  * @see TestClickCombination
  * @see WorkBatch
  * @since 2025.04.01 - Multi-threaded Architecture Introduction
- * @performance O(1) amortized for enqueue/dequeue operations and field accesses.
+ * @performance {@code O(1)} amortized for enqueue/dequeue operations and field accesses.
  * @threading Thread-safe via JCTools magic.
  * @algorithm Lock-free MPMC queue using JCTools wizardry.
  */
@@ -69,17 +71,17 @@ public class CombinationQueue {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * A smaller queue size is chosen to minimize memory overhead while still allowing
-     * effective batching of work. This size is a balance between memory usage and the need to
-     * keep the {@link TestClickCombination monkeys} fed with work. Higher queue sizes increase
-     * the likelihood of empty spots in the queue for {@link CombinationGeneratorTask generators} to
-     * fill, but also increase memory usage. Lower sizes reduce memory usage, but may lead to starved
-     * monkeys if the generators cannot keep up.
+     * A smaller queue size is chosen to minimize memory overhead while still allowing effective
+     * batching of work. This size is a balance between memory usage and the need to keep the
+     * {@link TestClickCombination monkeys} fed with work. Higher queue sizes increase the likelihood of
+     * empty spots in the queue for {@link CombinationGeneratorTask generators} to fill, but also
+     * increase memory usage. Lower sizes reduce memory usage, but may lead to starved monkeys if the
+     * generators cannot keep up.
      * </p>
      * 
      * @see org.jctools.queues.MpmcArrayQueue#capacity()
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) time complexity for capacity access.
+     * @since 2025.07.07 - Enqueuing {@link WorkBatch} Objects
+     * @performance {@code O(1)} time complexity for capacity access.
      * @optimization Small, fixed-size queue to minimize memory overhead while batching work.
      */
     private final int QUEUE_SIZE = 16;
@@ -90,22 +92,22 @@ public class CombinationQueue {
      * 
      * @see org.jctools.queues.MpmcArrayQueue
      * @see WorkBatch
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) amortized time complexity for enqueue/dequeue operations, O(1) capacity access,
-     *              and O(n) size access.
+     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} amortized time complexity for enqueue/dequeue operations, {@code O(1)}
+     *              capacity access, and <code>O({@link #QUEUE_SIZE})</code> size access.
      * @threading Thread-safe via JCTools magic.
      * @optimization Uses a bounded, lock-free queue to minimize memory overhead and contention.
      */
     private final MpmcArrayQueue<WorkBatch> queue;
 
     /**
-     * Constructs a new CombinationQueue with a fixed capacity of {@link #QUEUE_SIZE}.
+     * Constructs a new {@code CombinationQueue} with a fixed capacity of {@link #QUEUE_SIZE}.
      * 
      * @see #queue
      * @see org.jctools.queues.MpmcArrayQueue
      * @see org.jctools.queues.MpmcArrayQueue#MpmcArrayQueue(int)
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) time complexity.
+     * @since 2025.07.07 - Enqueuing {@link WorkBatch} Objects
+     * @performance {@code O(1)} time complexity.
      * @threading Thread-safe via JCTools magic.
      * @optimization Uses a small, fixed-size queue to minimize memory overhead while batching work.
      */
@@ -117,13 +119,12 @@ public class CombinationQueue {
      * Gets the capacity of the queue.
      * 
      * @return the fixed capacity of the queue.
-     * @return the fixed capacity of the queue.
      * @see #QUEUE_SIZE
      * @see #CombinationQueue()
      * @see org.jctools.queues.MpmcArrayQueue#capacity()
      * @since 2025.07.08 - Matching Sized Queues for Generators and Monkeys
-     * @performance O(1) time complexity.
-     * @threading Thread-safe, since it only reads a final field.
+     * @performance {@code O(1)} time complexity.
+     * @threading Thread-safe, since it only reads a {@code final} field.
      * @optimization Simple field access with minimal overhead.
      */
     public int getCapacity() {
@@ -131,26 +132,25 @@ public class CombinationQueue {
     }
 
     /**
-     * Offers a {@link WorkBatch} to the queue. Returns <code>true</code> if the batch was added, or
-     * <code>false</code> if the queue is full.
+     * Offers a {@link WorkBatch} to the queue. Returns {@code true} if the batch was added, or
+     * {@code false} if the queue is full.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * This method is non-blocking and uses a relaxed offer {@link MpmcArrayQueue#relaxedOffer(Object)
      * as defined by} the JCTools library. This method trades perfect accuracy for speed, meaning it may
-     * occasionally fail to add an item (and return <code>false</code>) even if the queue is not full.
+     * occasionally fail to add an item (and return {@code false}) even if the queue is not full.
      * This is acceptable in our use case, as the {@link CombinationGeneratorTask generator} can simply
      * try to add the batch to a new queue or retry later.
      * </p>
      * 
      * @param workBatch the {@link WorkBatch} to add to the queue.
-     * @return <code>true</code> if the batch was added successfully, or <code>false</code> if
+     * @return {@code true} if the batch was added successfully, or {@code false} if
      *         unsuccessful (the queue is full or the relaxed offer failed).
      * @see #getWorkBatch()
-     * @see WorkBatch
      * @see org.jctools.queues.MpmcArrayQueue#relaxedOffer(Object)
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) amortized time complexity.
+     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} amortized time complexity.
      * @threading Thread-safe via JCTools magic.
      * @optimization Relaxed offer for speed, accepting occasional false negatives. Enqueues batches
      *               instead of combinations to amortize overhead across more combinations.
@@ -166,18 +166,17 @@ public class CombinationQueue {
      * <p>
      * This method is non-blocking and uses a relaxed poll {@link MpmcArrayQueue#relaxedPoll() as
      * defined by} the JCTools library. This method trades perfect accuracy for speed, meaning it may
-     * occasionally return <code>null</code> even if the queue is not empty. This is acceptable in our
-     * use case, as the {@link TestClickCombination monkeys} can try to poll from a new queue or retry
+     * occasionally return {@code null} even if the queue is not empty. This is acceptable in our use
+     * case, as the {@link TestClickCombination monkeys} can try to poll from a new queue or retry
      * later.
      * </p>
      * 
-     * @return the next {@link WorkBatch} from the queue, or <code>null</code> if the queue is empty or
-     *         the relaxed poll failed.
+     * @return the next {@link WorkBatch} from the queue, or {@code null} if the queue is empty or the
+     *         relaxed poll failed.
      * @see #add(WorkBatch)
-     * @see WorkBatch
      * @see org.jctools.queues.MpmcArrayQueue#relaxedPoll()
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) amortized time complexity.
+     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} amortized time complexity.
      * @threading Thread-safe via JCTools magic.
      * @optimization Relaxed poll for speed, accepting occasional false negatives. Polls batches instead
      *               of combinations to amortize overhead across more combinations.
@@ -187,13 +186,13 @@ public class CombinationQueue {
     }
 
     /**
-     * Checks the queue for emptiness. Note that due to the concurrent nature of the queue,
-     * this is only a snapshot in time and may not reflect the state immediately after the call.
+     * Checks the queue for emptiness. Note that due to the concurrent nature of the queue, this is only
+     * a snapshot in time and may not reflect the state immediately after the call.
      * 
-     * @return <code>true</code> if the queue is empty at the time of the call, otherwise <code>false</code>.
+     * @return {@code true} if the queue is empty at the time of the call, otherwise {@code false}.
      * @see org.jctools.queues.MpmcArrayQueue#isEmpty()
      * @since 2025.08.02 - Class Formatting Cleanup
-     * @performance O(1) time complexity.
+     * @performance {@code O(1)} time complexity.
      * @threading Thread-safe via JCTools magic.
      * @optimization Simple check with minimal overhead.
      */

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -4,6 +4,29 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jctools.queues.MpmcArrayQueue;
 
+/**
+ * CombinationQueueArray - [Performance Purpose - e.g., "High-performance memory pool"]
+ * 
+ * <p>[Detailed description of the performance problem this class solves.
+ * Include before/after metrics where applicable.]</p>
+ * 
+ * <h2>Optimization Strategy</h2>
+ * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
+ * Explain trade-offs made for performance gains.]</p>
+ * 
+ * <h2>Usage Patterns</h2>
+ * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * 
+ * <h2>Memory Management</h2>
+ * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * 
+ * <h3>0/16 - 0% of documentation completed</h3>
+ * 
+ * @performance [Specific performance characteristics and measurements]
+ * @memory [Memory usage patterns and optimizations]
+ * @threading [Thread safety model]
+ * @since [When introduced and why]
+ */
 public class CombinationQueueArray 
 {
     private final CombinationQueue[] queues;

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -56,8 +56,6 @@ import org.jctools.queues.MpmcArrayQueue;
  * impact performance.
  * </p>
  * 
- * <h3>14/16 - 87.5% of documentation completed</h3>
- * 
  * @since 2025.05.23 - Multiple CombinationQueues
  * @performance O(1) for most operations, O(n) for iterating through all queues.
  * @threading Uses lock-free structures and volatile flags for safe concurrent access and updates.
@@ -492,21 +490,40 @@ public class CombinationQueueArray {
      * @see #getWinningCombination()
      */
     public void solutionFound(String monkeyName, short[] winningCombination) {
-        if (solutionFound == false) 
-        {
+        if (solutionFound == false) {
             solutionFound = true;
             this.winningMonkey = monkeyName;
             this.winningCombination = winningCombination;
         }
     }
 
-    public String getWinningMonkey() 
-    { 
+    /**
+     * Gets the name of the {@link TestClickCombination monkey} that found the solution.
+     * 
+     * @return the name of the winning monkey, or <code>null</code> if no solution has been found yet.
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to the use of a volatile field for the {@link #winningMonkey} field,
+     *            ensuring visibility across threads.
+     * @performance O(1) time complexity.
+     * @see #getWinningCombination()
+     * @see #solutionFound(String, short[])
+     */
+    public String getWinningMonkey() { 
         return winningMonkey; 
     }
     
-    public short[] getWinningCombination() 
-    { 
+    /**
+     * Gets the combination that solves the puzzle.
+     * 
+     * @return the winning combination, or <code>null</code> if no solution has been found yet.
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to the use of a volatile field for the {@link #winningCombination} field,
+     *            ensuring visibility across threads.
+     * @performance O(1) time complexity.
+     * @see #getWinningMonkey()
+     * @see #solutionFound(String, short[])
+     */
+    public short[] getWinningCombination() { 
         return winningCombination; 
     }
 }

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -20,7 +20,7 @@ import org.jctools.queues.MpmcArrayQueue;
  * <h2>Memory Management</h2>
  * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
  * 
- * <h3>0/16 - 0% of documentation completed</h3>
+ * <h3>4/16 - 25% of documentation completed</h3>
  * 
  * @performance [Specific performance characteristics and measurements]
  * @memory [Memory usage patterns and optimizations]
@@ -29,15 +29,161 @@ import org.jctools.queues.MpmcArrayQueue;
  */
 public class CombinationQueueArray 
 {
+    /**
+     * An array of CombinationQueues, one for each {@link TestClickCombination monkey}.
+     * 
+     * <p>
+     * While using just one queue for all monkeys is the simplest approach and may seem tempting, it
+     * can lead to contention and bottlenecks in performance as threads compete for access to the same
+     * queue (this is the case even with lock-free queues because of CAS operations). Having a separate
+     * queue for each monkey allows them to operate independently from other threads and gives them a
+     * dedicated high-priority path to work with. However, we need a way for the generators to get a
+     * reference to the queues and push WorkBatch objects to them (or for monkeys to steal work from
+     * other queues). This array of CombinationQueues provides that mechanism.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * An array of CombinationQueues allows for efficient access to each queue by its index without adding
+     * extra overhead from custom collections or data structures. Each queue can be accessed in O(1)
+     * time, and the array itself is a contiguous block of memory, which is cache-friendly and reduces
+     * memory fragmentation.
+     * </p>
+     * 
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading The array is immutable after construction, making it thread-safe for read operations.
+     * @performance O(1) for access to a specific queue, O(n) for iterating through all queues.
+     * @memory The array has a fixed memory footprint based on the number of queues and their capacities.
+     * @see CombinationQueue
+     */
     private final CombinationQueue[] queues;
     private final AtomicInteger generatorsRemaining;
     // REPLACED: The int[] pool is gone.
     // NEW: Central pool for recycled WorkBatch objects.
+    /**
+     * The central pool for recycled WorkBatch objects. This pool is used to avoid frequent allocations
+     * and deallocations of WorkBatch instances by providing a backflow for WorkBatch objects that have
+     * been processed.
+     * 
+     * <p>
+     * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
+     * deallocations are expensive operations that can lead to frequent garbage collections, driving up
+     * latency and reducing throughput. Changes could be made to other parts of the codebase to allocate
+     * less, but where there are deallocations, there must be allocations to replace them. This pool
+     * plugs the leak and allows the system to recycle WorkBatch objects.
+     * </p>
+     * 
+     * <p>
+     * The pool is pre-allocated with a fixed number of WorkBatch instances, which matches the total
+     * capacity of all the CombinationQueues. Those instances then get pulled into the
+     * {@link CombinationGeneratorTask generators} by their contexts to store generated combinations
+     * until they have been filled with data. The generators then push the filled WorkBatch objects into
+     * the CombinationQueues, where they are processed by the consumers. Once the consumers have
+     * finished processing a WorkBatch, they return it to the pool for reuse, restarting the cycle.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since pools pre-allocate resources, the size of the pool directly affects the memory footprint of
+     * the application. We choose to allocate the pool to match the capacity of all of the worker queues
+     * to ensure that we never run out of WorkBatch objects, which would lead to allocations. Oversizing
+     * the pool would lead to wasted memory and potentially lead to problems regarding in-flight
+     * batches, so it's crucial that we maintain the proper size.
+     * </p>
+     * 
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @threading The pool is thread-safe and can be accessed by multiple threads concurrently through
+     *            the power of JCTools.
+     * @performance O(1) for offer and poll operations (which should be the only ones used), O(n) for {@link MpmcArrayQueue#size()}.
+     * @memory The queue is bounded and has a fixed memory footprint based on the number of WorkBatch instances it contains.
+     * @see WorkBatch
+     * @see CombinationQueue
+     * @see MpmcArrayQueue
+     */
     private final MpmcArrayQueue<WorkBatch> workBatchPool;
     private volatile String winningMonkey = null;
     private volatile short[] winningCombination = null;
 
+    /**
+     * A flag indicating whether a solution has been found.
+     * 
+     * <p>
+     * The goal of the brute force solver is to find a combination that solves the puzzle. It doesn't
+     * matter which {@link TestClickCombination monkey} finds the solution or what the combination is,
+     * as long as it exists. Therefore, it makes no sense to continue searching for solutions once one
+     * has been found. Monkeys are meant to work independently, but if one finds the solution, we need a
+     * mechanism to stop all other monkeys from continuing their work. This flag serves that purpose.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This flag is a volatile boolean, which allows for safe publication and visibility across threads.
+     * An AtomicBoolean was used previously, but since we only need to set it once and to read it
+     * multiple times, a volatile boolean saves us boxing and unboxing overhead while still providing
+     * thread-visibility guarantees. The flag is checked frequently by the monkeys, so it must be
+     * lightweight to avoid introducing unnecessary contention or performance overhead.
+     * </p>
+     * 
+     * <p>
+     * Previously, this field was also checked explicitly by the generators to determine whether to
+     * continue generating combinations. However, the ForkJoinPool architecture provides a more
+     * efficient way to handle this by facilitating cooperative cancellation through a shutdown. In
+     * theory, something similar could be implemented for the monkeys to eliminate the need for this
+     * flag altogether, but for now, we'll keep this flag for simplicity.
+     * </p>
+     * 
+     * @since 2025.07.02 - Volatile Flag Implementation
+     * @threading This flag is marked as volatile, ensuring that changes made by one thread are
+     *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
+     *            but that is not necessary for this use case.
+     * @performance O(1) for reads and writes.
+     * @memory The flag is a single boolean value, which has a negligible memory footprint.
+     * @see #solutionFound(String, short[])
+     * @see #getWinningMonkey()
+     * @see #getWinningCombination()
+     */
     public volatile boolean solutionFound = false;
+    /**
+     * A flag indicating whether the generation of combinations is complete.
+     * 
+     * <p>
+     * There are two ways that the program can finish (under normal circumstances):
+     * </p>
+     * 
+     * <ol>
+     * <li>A solution is found by one of the {@link TestClickCombination monkeys}, which sets the
+     * {@link #solutionFound} flag to true.</li>
+     * <li>All generators have finished generating combinations and the monkeys finish processing all of
+     * them.</li>
+     * </ol>
+     * 
+     * <p>
+     * The latter circumstance is more difficult to detect, as it requires coordination between two
+     * different types of architecture: the {@link CombinationGeneratorTask generators} and the
+     * {@link TestClickCombination monkeys}. The monkeys need a way to tell the difference between a
+     * momentary emptiness in the queue (which is expected) and a complete end to the generation of
+     * combinations. This flag serves that purpose.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This flag is a volatile boolean, which allows for safe publication and visibility across threads.
+     * An AtomicBoolean was used previously, but since we only need to set it once and to read it
+     * multiple times, a volatile boolean saves us boxing and unboxing overhead while still providing
+     * thread-visibility guarantees. The flag is checked frequently by the monkeys, so it must be
+     * lightweight to avoid introducing unnecessary contention or performance overhead.
+     * </p>
+     * 
+     * @since 2025.07.02 - Volatile Flag Implementation
+     * @threading This flag is marked as volatile, ensuring that changes made by one thread are
+     *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
+     *            but that is not necessary for this use case.
+     * @performance O(1) for reads and writes.
+     * @memory The flag is a single boolean value, which has a negligible memory footprint.
+     * @see #generatorFinished()
+     * @see CombinationGeneratorTask#computeRootSubtasks()
+     * @see TestClickCombination#allQueuesEmpty()
+     */
     public volatile boolean generationComplete = false;
 
     public CombinationQueueArray(int numConsumers, int numGenerators)

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -181,7 +181,7 @@ public class CombinationQueueArray
      * @performance O(1) for reads and writes.
      * @memory The flag is a single boolean value, which has a negligible memory footprint.
      * @see #generatorFinished()
-     * @see CombinationGeneratorTask#computeRootSubtasks()
+     * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask#GeneratorContext)
      * @see TestClickCombination#allQueuesEmpty()
      */
     public volatile boolean generationComplete = false;

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -56,13 +56,13 @@ import org.jctools.queues.MpmcArrayQueue;
  * impact performance.
  * </p>
  * 
+ * @see CombinationQueue
+ * @see WorkBatch
+ * @see org.jctools.queues.MpmcArrayQueue
  * @since 2025.05.23 - Multiple CombinationQueues
  * @performance O(1) for most operations, O(n) for iterating through all queues.
  * @threading Uses lock-free structures and volatile flags for safe concurrent access and updates.
  * @memory Pre-allocates fixed-size structures to minimize fragmentation and GC overhead.
- * @see CombinationQueue
- * @see WorkBatch
- * @see org.jctools.queues.MpmcArrayQueue
  */
 public class CombinationQueueArray {
     /**
@@ -86,11 +86,11 @@ public class CombinationQueueArray {
      * memory fragmentation.
      * </p>
      * 
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading The array is immutable after construction, making it thread-safe for read operations.
-     * @performance O(1) for access to a specific queue, O(n) for iterating through all queues.
-     * @memory The array has a fixed memory footprint based on the number of queues and their capacities.
      * @see CombinationQueue
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @performance O(1) for access to a specific queue, O(n) for iterating through all queues.
+     * @threading The array is immutable after construction, making it thread-safe for read operations.
+     * @memory The array has a fixed memory footprint based on the number of queues and their capacities.
      */
     private final CombinationQueue[] queues;
     /**
@@ -114,11 +114,11 @@ public class CombinationQueueArray {
      * <code>AtomicInteger</code> and simply set the <code>generationComplete</code> flag to <code>true</code>.
      * </p>
      * 
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Thread-safe due to the use of an AtomicInteger, allowing for lock-free updates.
-     * @performance O(1) for increment and decrement operations.
-     * @memory Negligible memory footprint, as it only involves a single integer value.
      * @see #generatorFinished()
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @performance O(1) for increment and decrement operations.
+     * @threading Thread-safe due to the use of an AtomicInteger, allowing for lock-free updates.
+     * @memory Negligible memory footprint, as it only involves a single integer value.
      */
     private final AtomicInteger generatorsRemaining;
     /**
@@ -152,16 +152,16 @@ public class CombinationQueueArray {
      * batches, so it's crucial that we maintain the proper size.
      * </p>
      * 
+     * @see CombinationQueue
+     * @see WorkBatch
+     * @see org.jctools.queues.MpmcArrayQueue
      * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @threading The pool is thread-safe and can be accessed by multiple threads concurrently through
-     *            the power of JCTools.
      * @performance O(1) for offer and poll operations (which should be the only ones used), O(n) for
      *              {@link MpmcArrayQueue#size()}.
+     * @threading The pool is thread-safe and can be accessed by multiple threads concurrently through
+     *            the power of JCTools.
      * @memory The queue is bounded and has a fixed memory footprint based on the number of WorkBatch
      *         instances it contains.
-     * @see WorkBatch
-     * @see CombinationQueue
-     * @see MpmcArrayQueue
      */
     private final MpmcArrayQueue<WorkBatch> workBatchPool;
     /**
@@ -185,8 +185,8 @@ public class CombinationQueueArray {
      * </p>
      * 
      * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Marked as volatile to ensure visibility across threads.
      * @performance O(1) for reads and writes.
+     * @threading Marked as volatile to ensure visibility across threads.
      * @memory Negligible memory footprint, as it only involves a reference to a String object.
      */
     private volatile String winningMonkey = null;
@@ -211,8 +211,8 @@ public class CombinationQueueArray {
      * </p>
      * 
      * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Marked as volatile to ensure visibility across threads.
      * @performance O(1) for reads and writes.
+     * @threading Marked as volatile to ensure visibility across threads.
      * @memory Negligible memory footprint, as it only involves a reference to a short array.
      */
     private volatile short[] winningCombination = null;
@@ -245,15 +245,15 @@ public class CombinationQueueArray {
      * flag altogether, but for now, we'll keep this flag for simplicity.
      * </p>
      * 
+     * @see #getWinningCombination()
+     * @see #getWinningMonkey()
+     * @see #solutionFound(String, short[])
      * @since 2025.07.02 - Volatile Flag Implementation
+     * @performance O(1) for reads and writes.
      * @threading This flag is marked as volatile, ensuring that changes made by one thread are
      *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
      *            but that is not necessary for this use case.
-     * @performance O(1) for reads and writes.
      * @memory The flag is a single boolean value, which has a negligible memory footprint.
-     * @see #solutionFound(String, short[])
-     * @see #getWinningMonkey()
-     * @see #getWinningCombination()
      */
     public volatile boolean solutionFound = false;
     /**
@@ -287,15 +287,15 @@ public class CombinationQueueArray {
      * lightweight to avoid introducing unnecessary contention or performance overhead.
      * </p>
      * 
-     * @since 2025.07.02 - Volatile Flag Implementation
-     * @threading This flag is marked as volatile, ensuring that changes made by one thread are
-     *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
-     *            but that is not necessary for this use case.
-     * @performance O(1) for reads and writes.
-     * @memory The flag is a single boolean value, which has a negligible memory footprint.
      * @see #generatorFinished()
      * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask#GeneratorContext)
      * @see TestClickCombination#allQueuesEmpty()
+     * @since 2025.07.02 - Volatile Flag Implementation
+     * @performance O(1) for reads and writes.
+     * @threading This flag is marked as volatile, ensuring that changes made by one thread are
+     *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
+     *            but that is not necessary for this use case.
+     * @memory The flag is a single boolean value, which has a negligible memory footprint.
      */
     public volatile boolean generationComplete = false;
 
@@ -336,11 +336,11 @@ public class CombinationQueueArray {
      *                      will be producing combinations. Affects the {@link #generatorsRemaining}
      *                      counter.
      * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Thread-safe due to instance isolation (a constructor must create a new object).
      * @performance O(<code>numConsumers</code>) queue initialization + O(1) counter setup +
      *              O(<code>numConsumers</code>) counter initialization + O(<code>numConsumers *
      *              {@link CombinationQueue#QUEUE_SIZE}</code>) pool pre-allocation =
      *              O(<code>numConsumers</code>) time complexity.
+     * @threading Thread-safe due to instance isolation (a constructor must create a new object).
      * @memory Fixed memory footprint based on <code>numConsumers</code>,
      *         {@link CombinationQueue#QUEUE_SIZE}, and {@link CombinationGeneratorTask#BATCH_SIZE}.
      * @optimization Pre-allocates the entire WorkBatch pool to prevent allocations in the hot path.
@@ -378,13 +378,13 @@ public class CombinationQueueArray {
      * reference to it. This getter provides that mechanism.
      * 
      * @return a reference to the pool.
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @threading Thread-safe due to field immutability after construction. The pool itself is also thread-safe through JCTools magic.
-     * @performance O(1) time complexity.
      * @see #workBatchPool
      * @see #CombinationQueueArray(int, int)
      * @see WorkBatch
-     * @see MpmcArrayQueue
+     * @see org.jctools.queues.MpmcArrayQueue
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @performance O(1) time complexity.
+     * @threading Thread-safe due to field immutability after construction. The pool itself is also thread-safe through JCTools magic.
      */
     public MpmcArrayQueue<WorkBatch> getWorkBatchPool() {
         return workBatchPool;
@@ -394,10 +394,10 @@ public class CombinationQueueArray {
      * Gets the {@link CombinationQueue} at the specified index.
      * @param idx the index of the {@link CombinationQueue} to retrieve.
      * @return the {@link CombinationQueue} at the specified index in the {@link #queues} array.
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Thread-safe due to field immutability after construction.
-     * @performance O(1) time complexity.
      * @see #CombinationQueueArray(int, int)
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @performance O(1) time complexity.
+     * @threading Thread-safe due to field immutability after construction.
      */
     public CombinationQueue getQueue(int idx) { 
         return queues[idx]; 
@@ -406,10 +406,10 @@ public class CombinationQueueArray {
     /**
      * Returns all of the {@link CombinationQueue CombinationQueues} in the {@link #queues} array.
      * @return the entire {@link #queues} array.
-     * @since 2025.05.26 - Monkey Work-Stealing Introduction
-     * @threading Thread-safe due to field immutability after construction.
-     * @performance O(1) time complexity.
      * @see #CombinationQueueArray(int, int)
+     * @since 2025.05.26 - Monkey Work-Stealing Introduction
+     * @performance O(1) time complexity.
+     * @threading Thread-safe due to field immutability after construction.
      */
     public CombinationQueue[] getAllQueues() { 
         return queues; 
@@ -442,13 +442,13 @@ public class CombinationQueueArray {
      * <code>generationComplete</code> flag to <code>true</code>.
      * </p>
      * 
+     * @see #generatorsRemaining
      * @since 2025.05.23 - Multiple CombinationQueues
+     * @performance O(1) time complexity.
      * @threading Thread-safe due to the use of an AtomicInteger for the {@link #generatorsRemaining}
      *            counter, allowing for lock-free updates.
-     * @performance O(1) time complexity.
      * @memory Negligible memory footprint, as it only involves updating a single integer and a boolean
      *         flag.
-     * @see #generatorsRemaining
      */
     public void generatorFinished() {
         if (generatorsRemaining.decrementAndGet() == 0) {
@@ -479,15 +479,15 @@ public class CombinationQueueArray {
      * volatile fields.
      * </p>
      * 
+     * @see #solutionFound
+     * @see #getWinningCombination()
+     * @see #getWinningMonkey()
      * @param monkeyName the name of the monkey that found the solution.
      * @param winningCombination the combination that solves the puzzle.
      * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Thread-safe due to the use of a volatile boolean flag for the {@link #solutionFound} field, ensuring visibility across threads.
      * @performance O(1) time complexity.
+     * @threading Thread-safe due to the use of a volatile boolean flag for the {@link #solutionFound} field, ensuring visibility across threads.
      * @memory Negligible memory footprint, as it only involves updating a few fields.
-     * @see #solutionFound
-     * @see #getWinningMonkey()
-     * @see #getWinningCombination()
      */
     public void solutionFound(String monkeyName, short[] winningCombination) {
         if (solutionFound == false) {
@@ -501,12 +501,12 @@ public class CombinationQueueArray {
      * Gets the name of the {@link TestClickCombination monkey} that found the solution.
      * 
      * @return the name of the winning monkey, or <code>null</code> if no solution has been found yet.
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Thread-safe due to the use of a volatile field for the {@link #winningMonkey} field,
-     *            ensuring visibility across threads.
-     * @performance O(1) time complexity.
      * @see #getWinningCombination()
      * @see #solutionFound(String, short[])
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @performance O(1) time complexity.
+     * @threading Thread-safe due to the use of a volatile field for the {@link #winningMonkey} field,
+     *            ensuring visibility across threads.
      */
     public String getWinningMonkey() { 
         return winningMonkey; 
@@ -516,12 +516,12 @@ public class CombinationQueueArray {
      * Gets the combination that solves the puzzle.
      * 
      * @return the winning combination, or <code>null</code> if no solution has been found yet.
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @threading Thread-safe due to the use of a volatile field for the {@link #winningCombination} field,
-     *            ensuring visibility across threads.
-     * @performance O(1) time complexity.
      * @see #getWinningMonkey()
      * @see #solutionFound(String, short[])
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @performance O(1) time complexity.
+     * @threading Thread-safe due to the use of a volatile field for the {@link #winningCombination} field,
+     *            ensuring visibility across threads.
      */
     public short[] getWinningCombination() { 
         return winningCombination; 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -5,30 +5,68 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jctools.queues.MpmcArrayQueue;
 
 /**
- * CombinationQueueArray - [Performance Purpose - e.g., "High-performance memory pool"]
+ * CombinationQueueArray - A shared structure for managing communication and state between
+ * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys}.
  * 
- * <p>[Detailed description of the performance problem this class solves.
- * Include before/after metrics where applicable.]</p>
+ * <p>
+ * In order to facilitate efficient communication between the generators and the monkeys, we need
+ * some type of shared structure that both can access, storing information about the state of the
+ * system. We also need a way to manage the lifecycle of our system - specifically, monkeys need to
+ * know when all generators have finished working (so they can stop waiting for new work) and
+ * generators need to know when a monkey has found a solution (so they can stop generating new
+ * work). This class serves that purpose, providing the necessary fields and methods for state
+ * management and signaling.
+ * </p>
  * 
  * <h2>Optimization Strategy</h2>
- * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
- * Explain trade-offs made for performance gains.]</p>
+ * <p>
+ * We use a combination of lock-free data structures (from JCTools) and volatile flags to manage
+ * state and communication between threads. This approach minimizes contention and maximizes
+ * throughput, allowing for efficient operation even under high load. As the name suggests, the core
+ * field of this class is an array of {@link CombinationQueue CombinationQueues}, one for each
+ * {@link TestClickCombination monkey}. The use of a separate queue for each monkey reduces
+ * contention and allows for more efficient work distribution. We can facilitate work-stealing
+ * between monkeys by providing access to all queues, allowing idle monkeys to take work from busier
+ * ones. Additionally, we use a central pool for recycled {@link WorkBatch} objects to avoid
+ * frequent allocations and deallocations, which can lead to garbage collection overhead.
+ * </p>
  * 
  * <h2>Usage Patterns</h2>
- * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * <p>
+ * This class is intended to be used as a singleton, with one instance shared between all
+ * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys}. The
+ * generators push generated combinations into the appropriate {@link CombinationQueue} based on the
+ * monkey they are targeting, while the monkeys pull combinations from their own queue (and
+ * potentially steal work from others). The {@link #solutionFound} and {@link #generationComplete}
+ * flags are used to signal the end of processing, allowing threads to exit gracefully. The
+ * {@link #generatorFinished()} and {@link #solutionFound(String, short[])} methods are used to
+ * update the state of the system when generators finish their work or when a solution is found,
+ * respectively.
+ * </p>
  * 
  * <h2>Memory Management</h2>
- * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * <p>
+ * This class uses a fixed-size array for the {@link #queues} field, which is allocated
+ * {@link #CombinationQueueArray(int, int) during construction} and remains constant throughout the
+ * lifetime of the instance. Queues themselves are bounded to prevent unbounded memory growth and
+ * providing backpressure to the generators. The {@link #workBatchPool} is also bounded and
+ * pre-allocated to match the total capacity of all queues, ensuring that we never run out of
+ * {@link WorkBatch} objects, which would lead to allocations in the hot path. This approach
+ * minimizes memory fragmentation and reduces the likelihood of garbage collection pauses, which can
+ * impact performance.
+ * </p>
  * 
- * <h3>4/16 - 25% of documentation completed</h3>
+ * <h3>11/16 - ~68.8% of documentation completed</h3>
  * 
- * @performance [Specific performance characteristics and measurements]
- * @memory [Memory usage patterns and optimizations]
- * @threading [Thread safety model]
- * @since [When introduced and why]
+ * @since 2025.05.23 - Multiple CombinationQueues
+ * @performance O(1) for most operations, O(n) for iterating through all queues.
+ * @threading Uses lock-free structures and volatile flags for safe concurrent access and updates.
+ * @memory Pre-allocates fixed-size structures to minimize fragmentation and GC overhead.
+ * @see CombinationQueue
+ * @see WorkBatch
+ * @see org.jctools.queues.MpmcArrayQueue
  */
-public class CombinationQueueArray 
-{
+public class CombinationQueueArray {
     /**
      * An array of CombinationQueues, one for each {@link TestClickCombination monkey}.
      * 
@@ -94,8 +132,10 @@ public class CombinationQueueArray
      * @since 2025.07.07 - Enqueuing WorkBatch Objects
      * @threading The pool is thread-safe and can be accessed by multiple threads concurrently through
      *            the power of JCTools.
-     * @performance O(1) for offer and poll operations (which should be the only ones used), O(n) for {@link MpmcArrayQueue#size()}.
-     * @memory The queue is bounded and has a fixed memory footprint based on the number of WorkBatch instances it contains.
+     * @performance O(1) for offer and poll operations (which should be the only ones used), O(n) for
+     *              {@link MpmcArrayQueue#size()}.
+     * @memory The queue is bounded and has a fixed memory footprint based on the number of WorkBatch
+     *         instances it contains.
      * @see WorkBatch
      * @see CombinationQueue
      * @see MpmcArrayQueue
@@ -186,8 +226,53 @@ public class CombinationQueueArray
      */
     public volatile boolean generationComplete = false;
 
-    public CombinationQueueArray(int numConsumers, int numGenerators)
-    {
+    /**
+     * Constructs a CombinationQueueArray with the specified number of consumers
+     * ({@link TestClickCombination monkeys}) and {@link CombinationGeneratorTask generators.}
+     * 
+     * <p>
+     * Of the two parameters, the number of consumers is the more important one, as it directly affects
+     * the size of the {@link #queues} array and the {@link #workBatchPool} pool. While the number of
+     * generators does affect the {@link #generatorsRemaining} counter, the ForkJoinPool architecture
+     * means that the number of active generator threads can vary dynamically, so completion signaling
+     * is handled by one thread (the one that spawns the generators) rather than all of them. For this
+     * reason, we typically set the number of generators to 1. In the future, we may remove this
+     * parameter entirely and assume it is always 1.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * In the context of our program, we should only need one instance of this class, as it serves as a
+     * central hub for communication and state management. This constructor is therefore not part of the
+     * hot path and does not need to be optimized for performance. However, there are still some tricks
+     * we apply to amortize the cost of allocations and setup.
+     * </p>
+     * 
+     * <p>
+     * First, we pre-allocate the entire {@link #workBatchPool} pool to prevent allocations in the hot
+     * path. The pool is sized to match the total capacity of all the {@link #queues}, ensuring that we
+     * never run out of WorkBatch objects, which would lead to allocations. Second, we use an
+     * {@link AtomicInteger} for the {@link #generatorsRemaining} counter, which allows for lock-free
+     * updates and avoids the need for synchronization.
+     * </p>
+     * 
+     * @param numConsumers  The number of {@link TestClickCombination monkeys} that will be consuming
+     *                      combinations. Affects the size of the {@link #queues} array and the
+     *                      {@link #workBatchPool} pool.
+     * @param numGenerators The (effective) number of {@link CombinationGeneratorTask generators} that
+     *                      will be producing combinations. Affects the {@link #generatorsRemaining}
+     *                      counter.
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to instance isolation (a constructor must create a new object).
+     * @performance O(<code>numConsumers</code>) queue initialization + O(1) counter setup +
+     *              O(<code>numConsumers</code>) counter initialization + O(<code>numConsumers *
+     *              {@link CombinationQueue#QUEUE_SIZE}</code>) pool pre-allocation =
+     *              O(<code>numConsumers</code>) time complexity.
+     * @memory Fixed memory footprint based on <code>numConsumers</code>,
+     *         {@link CombinationQueue#QUEUE_SIZE}, and {@link CombinationGeneratorTask#BATCH_SIZE}.
+     * @optimization Pre-allocates the entire WorkBatch pool to prevent allocations in the hot path.
+     */
+    public CombinationQueueArray(int numConsumers, int numGenerators) {
         this.queues = new CombinationQueue[numConsumers];
         this.generatorsRemaining = new AtomicInteger(numGenerators);
 
@@ -207,36 +292,131 @@ public class CombinationQueueArray
         final int BATCH_SIZE = CombinationGeneratorTask.BATCH_SIZE;
         for (int i = 0; i < totalWorkQueueCapacity; i++)
         {
+            // TODO: Make this offer strict and handle failure (which shouldn't happen) with an exception.
             workBatchPool.relaxedOffer(new WorkBatch(BATCH_SIZE));
         }
     }
 
-    // NEW: Accessors for the WorkBatch pool
-    public MpmcArrayQueue<WorkBatch> getWorkBatchPool()
-    {
+    /**
+     * Gets the {@link #workBatchPool central pool} for recycled {@link WorkBatch} objects. This pool
+     * completes the lifecycle of <code>WorkBatch</code> objects, allowing them to be reused and
+     * preventing frequent allocations and deallocations, but we need a way for the
+     * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys} to get a
+     * reference to it. This getter provides that mechanism.
+     * 
+     * @return a reference to the pool.
+     * @since 2025.07.07 - Enqueuing WorkBatch Objects
+     * @threading Thread-safe due to field immutability after construction. The pool itself is also thread-safe through JCTools magic.
+     * @performance O(1) time complexity.
+     * @see #workBatchPool
+     * @see #CombinationQueueArray(int, int)
+     * @see WorkBatch
+     * @see MpmcArrayQueue
+     */
+    public MpmcArrayQueue<WorkBatch> getWorkBatchPool() {
         return workBatchPool;
     }
 
-    public CombinationQueue getQueue(int idx) 
-    { 
+    /**
+     * Gets the {@link CombinationQueue} at the specified index.
+     * @param idx the index of the {@link CombinationQueue} to retrieve.
+     * @return the {@link CombinationQueue} at the specified index in the {@link #queues} array.
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to field immutability after construction.
+     * @performance O(1) time complexity.
+     * @see #CombinationQueueArray(int, int)
+     */
+    public CombinationQueue getQueue(int idx) { 
         return queues[idx]; 
     }
 
-    public CombinationQueue[] getAllQueues() 
-    { 
+    /**
+     * Returns all of the {@link CombinationQueue CombinationQueues} in the {@link #queues} array.
+     * @return the entire {@link #queues} array.
+     * @since 2025.05.26 - Monkey Work-Stealing Introduction
+     * @threading Thread-safe due to field immutability after construction.
+     * @performance O(1) time complexity.
+     * @see #CombinationQueueArray(int, int)
+     */
+    public CombinationQueue[] getAllQueues() { 
         return queues; 
     }
 
-    public void generatorFinished() 
-    {
-        if (generatorsRemaining.decrementAndGet() == 0) 
-        {
+    /**
+     * Marks that a {@link CombinationGeneratorTask generator} has finished its work. If all generators
+     * have finished, sets the {@link #generationComplete} flag to true, signaling to the
+     * {@link TestClickCombination monkeys} that no more combinations will be generated.
+     * 
+     * <p>
+     * The {@link CombinationGeneratorTask generators} are responsible for producing combinations that
+     * the {@link TestClickCombination monkeys} will test. Our architecture is designed to allow for
+     * mostly independent operation between the two, but when the generators finish their work, we need
+     * to signal to the monkeys that no more combinations will be enqueued so they can stop waiting for
+     * new work and exit when all queues are empty. This method provides the mechanism for that
+     * signaling.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be called only once by each generator when it finishes its work, so it
+     * is not performance-critical. Nevertheless, the use of an
+     * {@link java.util.concurrent.atomic.AtomicInteger} for the {@link #generatorsRemaining} counter
+     * allows for lock-free and thread-safe updates, ensuring that we can accurately track the number of
+     * active generators without introducing contention or performance overhead. However, in our current
+     * architecture, we typically only have one effective generator thread, meaning that the counter
+     * will only ever be decremented once. In the future, we may remove this parameter entirely and
+     * assume it is always 1, letting us get rid of the <code>AtomicInteger</code> and simply set the
+     * <code>generationComplete</code> flag to <code>true</code>.
+     * </p>
+     * 
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to the use of an AtomicInteger for the {@link #generatorsRemaining}
+     *            counter, allowing for lock-free updates.
+     * @performance O(1) time complexity.
+     * @memory Negligible memory footprint, as it only involves updating a single integer and a boolean
+     *         flag.
+     * @see #generatorsRemaining
+     */
+    public void generatorFinished() {
+        if (generatorsRemaining.decrementAndGet() == 0) {
             generationComplete = true;
         }
     }
 
-    public void solutionFound(String monkeyName, short[] winningCombination)
-    {
+    /**
+     * Marks that a solution has been found by a {@link TestClickCombination monkey}.
+     * 
+     * <p>
+     * Since our program concerns itself only with finding a single solution to the puzzle, it doesn't
+     * matter what the solution is or which monkey found it. Once a solution has been found, we need a
+     * way to stop all other monkeys from continuing their work and stop all
+     * {@link CombinationGeneratorTask generators} from producing more combinations. Solution signaling
+     * is therefore a crucial part of our architecture, and this method provides the mechanism for it.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be called only once, by the first monkey that finds a solution. We
+     * don't need to worry about multiple monkeys finding solutions simultaneously, so we can keep the
+     * method simple and worry less about aggressive optimizations. Rather than using an AtomicBoolean,
+     * we use a volatile boolean flag for the {@link #solutionFound} field, which saves us boxing and
+     * unboxing overhead as well as some memory while providing the same effect (safe publication and
+     * visibility across threads). The winning monkey's name and combination could piggyback on the
+     * volatile status of the flag to avoid volatility overhead, but for simplicity, we keep them as
+     * volatile fields.
+     * </p>
+     * 
+     * @param monkeyName the name of the monkey that found the solution.
+     * @param winningCombination the combination that solves the puzzle.
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to the use of a volatile boolean flag for the {@link #solutionFound} field, ensuring visibility across threads.
+     * @performance O(1) time complexity.
+     * @memory Negligible memory footprint, as it only involves updating a few fields.
+     * @see #solutionFound
+     * @see #getWinningMonkey()
+     * @see #getWinningCombination()
+     */
+    public void solutionFound(String monkeyName, short[] winningCombination) {
         if (solutionFound == false) 
         {
             solutionFound = true;

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jctools.queues.MpmcArrayQueue;
 
 /**
- * CombinationQueueArray - A shared structure for managing communication and state between
+ * A shared structure for managing communication and state between
  * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys}.
  * 
  * <p>
@@ -59,46 +59,50 @@ import org.jctools.queues.MpmcArrayQueue;
  * @see CombinationQueue
  * @see WorkBatch
  * @see org.jctools.queues.MpmcArrayQueue
- * @since 2025.05.23 - Multiple CombinationQueues
- * @performance O(1) for most operations, O(n) for iterating through all queues.
- * @threading Uses lock-free structures and volatile flags for safe concurrent access and updates.
+ * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+ * @performance {@code O(1)} for most operations, <code>O({@link #queues}.length)</code> for
+ *              iterating through all queues.
+ * @threading Uses lock-free structures and {@code volatile} flags for safe concurrent access and
+ *            updates.
  * @memory Pre-allocates fixed-size structures to minimize fragmentation and GC overhead.
  */
 public class CombinationQueueArray {
     /**
-     * An array of CombinationQueues, one for each {@link TestClickCombination monkey}.
+     * An array of {@link CombinationQueue}s, one for each {@link TestClickCombination monkey}.
      * 
      * <p>
-     * While using just one queue for all monkeys is the simplest approach and may seem tempting, it
-     * can lead to contention and bottlenecks in performance as threads compete for access to the same
-     * queue (this is the case even with lock-free queues because of CAS operations). Having a separate
-     * queue for each monkey allows them to operate independently from other threads and gives them a
-     * dedicated high-priority path to work with. However, we need a way for the generators to get a
-     * reference to the queues and push WorkBatch objects to them (or for monkeys to steal work from
-     * other queues). This array of CombinationQueues provides that mechanism.
+     * While using just one queue for all monkeys is the simplest approach and may seem tempting, it can
+     * lead to contention and bottlenecks in performance as threads compete for access to the same queue
+     * (this is the case even with lock-free queues because of CAS operations). Having a separate queue
+     * for each monkey allows them to operate independently from other threads and gives them a
+     * dedicated high-priority path to work with. However, we need a way for the
+     * {@link CombinationGeneratorTask generators} to get a reference to the queues and push WorkBatch
+     * objects to them (or for monkeys to steal work from other queues). This array of
+     * {@code CombinationQueue}s provides that mechanism.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * An array of CombinationQueues allows for efficient access to each queue by its index without adding
-     * extra overhead from custom collections or data structures. Each queue can be accessed in O(1)
-     * time, and the array itself is a contiguous block of memory, which is cache-friendly and reduces
-     * memory fragmentation.
+     * An array of {@code CombinationQueue}s allows for efficient access to each queue by its index
+     * without adding extra overhead from custom collections or data structures. Each queue can be
+     * accessed in {@code O(1)} time, and the array itself is a contiguous block of memory, which is
+     * cache-friendly and reduces memory fragmentation.
      * </p>
      * 
-     * @see CombinationQueue
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) for access to a specific queue, O(n) for iterating through all queues.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} for access to a specific queue, {@code O(queues.length)} for iterating
+     *              through all queues.
      * @threading The array is immutable after construction, making it thread-safe for read operations.
-     * @memory The array has a fixed memory footprint based on the number of queues and their capacities.
+     * @memory The array has a fixed memory footprint based on the number of queues and their
+     *         capacities.
      */
     private final CombinationQueue[] queues;
     /**
      * A counter for the number of active {@link CombinationGeneratorTask generators}.
      * 
      * <p>
-     * In order to determine when all generators have finished their work, we need a way to track how many
-     * are still active. This counter serves that purpose, allowing each generator to decrement the
+     * In order to determine when all generators have finished their work, we need a way to track how
+     * many are still active. This counter serves that purpose, allowing each generator to decrement the
      * count when it finishes its work. When the count reaches zero, we know that all generators have
      * finished, and we can set the {@link #generationComplete} flag to true, signaling to the
      * {@link TestClickCombination monkeys} that no more combinations will be generated.
@@ -106,62 +110,64 @@ public class CombinationQueueArray {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The use of an {@link java.util.concurrent.atomic.AtomicInteger} allows for lock-free updates to the
-     * counter, ensuring that we can accurately track the number of active generators without
-     * introducing contention or performance overhead. However, in our current architecture, we typically
-     * only have one effective generator thread, meaning that the counter will only ever be decremented
-     * once. In the future, we may remove this parameter entirely and assume it is always 1, letting us get rid of the
-     * <code>AtomicInteger</code> and simply set the <code>generationComplete</code> flag to <code>true</code>.
+     * The use of an {@link java.util.concurrent.atomic.AtomicInteger} allows for lock-free updates to
+     * the counter, ensuring that we can accurately track the number of active generators without
+     * introducing contention or performance overhead. However, in our current architecture, we
+     * typically only have one effective generator thread, meaning that the counter will only ever be
+     * decremented once. In the future, we may assume it is always 1 until generation has finished,
+     * letting us get rid of the {@code AtomicInteger} and simply set the {@code generationComplete}
+     * flag to {@code true}.
      * </p>
      * 
      * @see #generatorFinished()
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) for increment and decrement operations.
-     * @threading Thread-safe due to the use of an AtomicInteger, allowing for lock-free updates.
-     * @memory Negligible memory footprint, as it only involves a single integer value.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} for increment and decrement operations.
+     * @threading Thread-safe due to the use of an {@link java.util.concurrent.atomic.AtomicInteger
+     *            AtomicInteger}, allowing for lock-free updates.
+     * @memory Negligible memory footprint, as it only involves a single {@code int} value.
      */
     private final AtomicInteger generatorsRemaining;
     /**
-     * The central pool for recycled WorkBatch objects. This pool is used to avoid frequent allocations
-     * and deallocations of WorkBatch instances by providing a backflow for WorkBatch objects that have
-     * been processed.
+     * The central pool for recycled {@link WorkBatch} objects. This pool is used to avoid frequent
+     * allocations and deallocations of {@code WorkBatch} instances by providing a backflow for
+     * {@code WorkBatch} objects that have been processed.
      * 
      * <p>
      * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
      * deallocations are expensive operations that can lead to frequent garbage collections, driving up
      * latency and reducing throughput. Changes could be made to other parts of the codebase to allocate
      * less, but where there are deallocations, there must be allocations to replace them. This pool
-     * plugs the leak and allows the system to recycle WorkBatch objects.
+     * plugs the leak and allows the system to recycle {@code WorkBatch} objects.
      * </p>
      * 
      * <p>
-     * The pool is pre-allocated with a fixed number of WorkBatch instances, which matches the total
-     * capacity of all the CombinationQueues. Those instances then get pulled into the
+     * The pool is pre-allocated with a fixed number of {@code WorkBatch} instances, which matches the
+     * total capacity of all the {@link CombinationQueue}s. Those instances then get pulled into the
      * {@link CombinationGeneratorTask generators} by their contexts to store generated combinations
-     * until they have been filled with data. The generators then push the filled WorkBatch objects into
-     * the CombinationQueues, where they are processed by the consumers. Once the consumers have
-     * finished processing a WorkBatch, they return it to the pool for reuse, restarting the cycle.
+     * until they have been filled with data. The generators then push the filled {@code WorkBatch}
+     * objects into the {@code CombinationQueue}s, where they are processed by the consumers. Once the
+     * consumers have finished processing a {@code WorkBatch}, they return it to the pool for reuse,
+     * restarting the cycle.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Since pools pre-allocate resources, the size of the pool directly affects the memory footprint of
      * the application. We choose to allocate the pool to match the capacity of all of the worker queues
-     * to ensure that we never run out of WorkBatch objects, which would lead to allocations. Oversizing
-     * the pool would lead to wasted memory and potentially lead to problems regarding in-flight
-     * batches, so it's crucial that we maintain the proper size.
+     * to ensure that we never run out of {@code WorkBatch} objects, which would lead to allocations.
+     * Oversizing the pool would lead to wasted memory and potentially lead to problems regarding
+     * in-flight batches, so it's crucial that we maintain the proper size.
      * </p>
      * 
-     * @see CombinationQueue
-     * @see WorkBatch
      * @see org.jctools.queues.MpmcArrayQueue
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) for offer and poll operations (which should be the only ones used), O(n) for
-     *              {@link MpmcArrayQueue#size()}.
+     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} for offer and poll operations (which should be the only ones used),
+     *              <code>O({@link org.jctools.queues.MpmcArrayQueue#capacity() 
+     *              workBatchPool.capacity()})</code> for {@link MpmcArrayQueue#size() size()}.
      * @threading The pool is thread-safe and can be accessed by multiple threads concurrently through
      *            the power of JCTools.
-     * @memory The queue is bounded and has a fixed memory footprint based on the number of WorkBatch
-     *         instances it contains.
+     * @memory The queue is bounded and has a fixed memory footprint based on the number of
+     *         {@code WorkBatch} instances it contains.
      */
     private final MpmcArrayQueue<WorkBatch> workBatchPool;
     /**
@@ -176,18 +182,19 @@ public class CombinationQueueArray {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This field is marked as volatile to ensure visibility across threads. While the winning monkey's
-     * name could piggyback on the volatile status of the {@link #solutionFound} flag to avoid
-     * volatility overhead, for simplicity, we keep it as a separate volatile field. The overhead of
-     * volatility is negligible in this case, as the field is only
+     * This field is marked as {@code volatile} to ensure visibility across threads. While the winning
+     * monkey's name could piggyback on the {@code volatile} status of the {@link #solutionFound} flag
+     * to avoid volatility overhead, for simplicity, we keep it as a separate {@code volatile} field.
+     * The overhead of volatility is negligible in this case, as the field is only
      * {@link #solutionFound(String, short[]) written} once and {@link #getWinningMonkey() read} a few
      * times at the end of the program's lifecycle.
      * </p>
      * 
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) for reads and writes.
-     * @threading Marked as volatile to ensure visibility across threads.
-     * @memory Negligible memory footprint, as it only involves a reference to a String object.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} for reads and writes.
+     * @threading Marked as {@code volatile} to ensure visibility across threads.
+     * @memory Negligible memory footprint, as it only involves a reference to a {@link java.lang.String
+     *         String} object.
      */
     private volatile String winningMonkey = null;
     /**
@@ -202,18 +209,18 @@ public class CombinationQueueArray {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This field is marked as volatile to ensure visibility across threads. While the winning combination
-     * could piggyback on the volatile status of the {@link #solutionFound} flag to avoid
-     * volatility overhead, for simplicity, we keep it as a separate volatile field. The overhead of
-     * volatility is negligible in this case, as the field is only
-     * {@link #solutionFound(String, short[]) written} once and {@link #getWinningCombination() read} a few
-     * times at the end of the program's lifecycle.
+     * This field is marked as {@code volatile} to ensure visibility across threads. While the winning
+     * combination could piggyback on the {@code volatile} status of the {@link #solutionFound} flag to
+     * avoid volatility overhead, for simplicity, we keep it as a separate {@code volatile} field. The
+     * overhead of volatility is negligible in this case, as the field is only
+     * {@link #solutionFound(String, short[]) written} once and {@link #getWinningCombination() read} a
+     * few times at the end of the program's lifecycle.
      * </p>
      * 
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) for reads and writes.
-     * @threading Marked as volatile to ensure visibility across threads.
-     * @memory Negligible memory footprint, as it only involves a reference to a short array.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} for reads and writes.
+     * @threading Marked as {@code volatile} to ensure visibility across threads.
+     * @memory Negligible memory footprint, as it only involves a reference to a {@code short[]}.
      */
     private volatile short[] winningCombination = null;
 
@@ -230,30 +237,32 @@ public class CombinationQueueArray {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This flag is a volatile boolean, which allows for safe publication and visibility across threads.
-     * An AtomicBoolean was used previously, but since we only need to set it once and to read it
-     * multiple times, a volatile boolean saves us boxing and unboxing overhead while still providing
-     * thread-visibility guarantees. The flag is checked frequently by the monkeys, so it must be
-     * lightweight to avoid introducing unnecessary contention or performance overhead.
+     * This flag is a {@code volatile boolean}, which allows for safe publication and visibility across
+     * threads. An {@link java.util.concurrent.atomic.AtomicBoolean AtomicBoolean} was used previously,
+     * but since we only need to set it once and to read it multiple times, a {@code volatile boolean}
+     * saves us boxing and unboxing overhead while still providing thread-visibility guarantees. The
+     * flag is checked frequently by the monkeys, so it must be lightweight to avoid introducing
+     * unnecessary contention or performance overhead.
      * </p>
      * 
      * <p>
      * Previously, this field was also checked explicitly by the generators to determine whether to
-     * continue generating combinations. However, the ForkJoinPool architecture provides a more
-     * efficient way to handle this by facilitating cooperative cancellation through a shutdown. In
-     * theory, something similar could be implemented for the monkeys to eliminate the need for this
-     * flag altogether, but for now, we'll keep this flag for simplicity.
+     * continue generating combinations. However, the {@link java.util.concurrent.ForkJoinPool
+     * ForkJoinPool} architecture provides a more efficient way to handle this by facilitating
+     * cooperative cancellation through a shutdown. In theory, something similar could be implemented
+     * for the monkeys to eliminate the need for this flag altogether, but for now, we'll keep this flag
+     * for simplicity.
      * </p>
      * 
      * @see #getWinningCombination()
      * @see #getWinningMonkey()
      * @see #solutionFound(String, short[])
      * @since 2025.07.02 - Volatile Flag Implementation
-     * @performance O(1) for reads and writes.
-     * @threading This flag is marked as volatile, ensuring that changes made by one thread are
+     * @performance {@code O(1)} for reads and writes.
+     * @threading This flag is marked as {@code volatile}, ensuring that changes made by one thread are
      *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
      *            but that is not necessary for this use case.
-     * @memory The flag is a single boolean value, which has a negligible memory footprint.
+     * @memory The flag is a single {@code boolean} value, which has a negligible memory footprint.
      */
     public volatile boolean solutionFound = false;
     /**
@@ -265,7 +274,7 @@ public class CombinationQueueArray {
      * 
      * <ol>
      * <li>A solution is found by one of the {@link TestClickCombination monkeys}, which sets the
-     * {@link #solutionFound} flag to true.</li>
+     * {@link #solutionFound} flag to {@code true}.</li>
      * <li>All generators have finished generating combinations and the monkeys finish processing all of
      * them.</li>
      * </ol>
@@ -280,37 +289,39 @@ public class CombinationQueueArray {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This flag is a volatile boolean, which allows for safe publication and visibility across threads.
-     * An AtomicBoolean was used previously, but since we only need to set it once and to read it
-     * multiple times, a volatile boolean saves us boxing and unboxing overhead while still providing
-     * thread-visibility guarantees. The flag is checked frequently by the monkeys, so it must be
-     * lightweight to avoid introducing unnecessary contention or performance overhead.
+     * This flag is a {@code volatile boolean}, which allows for safe publication and visibility across
+     * threads. An {@link java.util.concurrent.atomic.AtomicBoolean AtomicBoolean} was used previously,
+     * but since we only need to set it once and to read it multiple times, a {@code volatile boolean}
+     * saves us boxing and unboxing overhead while still providing thread-visibility guarantees. The
+     * flag is checked frequently by the monkeys, so it must be lightweight to avoid introducing
+     * unnecessary contention or performance overhead.
      * </p>
      * 
      * @see #generatorFinished()
      * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask#GeneratorContext)
      * @see TestClickCombination#allQueuesEmpty()
      * @since 2025.07.02 - Volatile Flag Implementation
-     * @performance O(1) for reads and writes.
-     * @threading This flag is marked as volatile, ensuring that changes made by one thread are
+     * @performance {@code O(1)} for reads and writes.
+     * @threading This flag is marked as {@code volatile}, ensuring that changes made by one thread are
      *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
      *            but that is not necessary for this use case.
-     * @memory The flag is a single boolean value, which has a negligible memory footprint.
+     * @memory The flag is a single {@code boolean} value, which has a negligible memory footprint.
      */
     public volatile boolean generationComplete = false;
 
     /**
-     * Constructs a CombinationQueueArray with the specified number of consumers
+     * Constructs a {@code CombinationQueueArray} with the specified number of consumers
      * ({@link TestClickCombination monkeys}) and {@link CombinationGeneratorTask generators.}
      * 
      * <p>
      * Of the two parameters, the number of consumers is the more important one, as it directly affects
      * the size of the {@link #queues} array and the {@link #workBatchPool} pool. While the number of
-     * generators does affect the {@link #generatorsRemaining} counter, the ForkJoinPool architecture
-     * means that the number of active generator threads can vary dynamically, so completion signaling
-     * is handled by one thread (the one that spawns the generators) rather than all of them. For this
-     * reason, we typically set the number of generators to 1. In the future, we may remove this
-     * parameter entirely and assume it is always 1.
+     * generators does affect the {@link #generatorsRemaining} counter, the
+     * {@link java.util.concurrent.ForkJoinPool ForkJoinPool} architecture means that the number of
+     * active generator threads can vary dynamically, so completion signaling is handled by one thread
+     * (the one that spawns the generators) rather than all of them. For this reason, we typically set
+     * the number of generators to 1. In the future, we may remove this parameter entirely and assume it
+     * is always 1.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -324,7 +335,7 @@ public class CombinationQueueArray {
      * <p>
      * First, we pre-allocate the entire {@link #workBatchPool} pool to prevent allocations in the hot
      * path. The pool is sized to match the total capacity of all the {@link #queues}, ensuring that we
-     * never run out of WorkBatch objects, which would lead to allocations. Second, we use an
+     * never run out of {@link WorkBatch} objects, which would lead to allocations. Second, we use an
      * {@link AtomicInteger} for the {@link #generatorsRemaining} counter, which allows for lock-free
      * updates and avoids the need for synchronization.
      * </p>
@@ -335,15 +346,16 @@ public class CombinationQueueArray {
      * @param numGenerators The (effective) number of {@link CombinationGeneratorTask generators} that
      *                      will be producing combinations. Affects the {@link #generatorsRemaining}
      *                      counter.
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(<code>numConsumers</code>) queue initialization + O(1) counter setup +
-     *              O(<code>numConsumers</code>) counter initialization + O(<code>numConsumers *
-     *              {@link CombinationQueue#QUEUE_SIZE}</code>) pool pre-allocation =
-     *              O(<code>numConsumers</code>) time complexity.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(numConsumers)} queue initialization + {@code O(1)} counter setup +
+     *              {@code O(numConsumers)} counter initialization + <code>O(numConsumers *
+     *              {@link CombinationQueue#QUEUE_SIZE})</code> pool pre-allocation =
+     *              {@code O(numConsumers)} time complexity.
      * @threading Thread-safe due to instance isolation (a constructor must create a new object).
-     * @memory Fixed memory footprint based on <code>numConsumers</code>,
+     * @memory Fixed memory footprint based on {@code numConsumers},
      *         {@link CombinationQueue#QUEUE_SIZE}, and {@link CombinationGeneratorTask#BATCH_SIZE}.
-     * @optimization Pre-allocates the entire WorkBatch pool to prevent allocations in the hot path.
+     * @optimization Pre-allocates the entire {@code WorkBatch} pool to prevent allocations in the hot
+     *               path.
      */
     public CombinationQueueArray(int numConsumers, int numGenerators) {
         this.queues = new CombinationQueue[numConsumers];
@@ -372,19 +384,20 @@ public class CombinationQueueArray {
 
     /**
      * Gets the {@link #workBatchPool central pool} for recycled {@link WorkBatch} objects. This pool
-     * completes the lifecycle of <code>WorkBatch</code> objects, allowing them to be reused and
-     * preventing frequent allocations and deallocations, but we need a way for the
-     * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys} to get a
-     * reference to it. This getter provides that mechanism.
+     * completes the lifecycle of {@code WorkBatch} objects, allowing them to be reused and preventing
+     * frequent allocations and deallocations, but we need a way for the {@link CombinationGeneratorTask
+     * generators} and {@link TestClickCombination monkeys} to get a reference to it. This getter
+     * provides that mechanism.
      * 
      * @return a reference to the pool.
      * @see #workBatchPool
      * @see #CombinationQueueArray(int, int)
      * @see WorkBatch
      * @see org.jctools.queues.MpmcArrayQueue
-     * @since 2025.07.07 - Enqueuing WorkBatch Objects
-     * @performance O(1) time complexity.
-     * @threading Thread-safe due to field immutability after construction. The pool itself is also thread-safe through JCTools magic.
+     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} time complexity.
+     * @threading Thread-safe due to field immutability after construction. The pool itself is also
+     *            thread-safe through JCTools magic.
      */
     public MpmcArrayQueue<WorkBatch> getWorkBatchPool() {
         return workBatchPool;
@@ -392,11 +405,12 @@ public class CombinationQueueArray {
 
     /**
      * Gets the {@link CombinationQueue} at the specified index.
+     * 
      * @param idx the index of the {@link CombinationQueue} to retrieve.
      * @return the {@link CombinationQueue} at the specified index in the {@link #queues} array.
      * @see #CombinationQueueArray(int, int)
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) time complexity.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} time complexity.
      * @threading Thread-safe due to field immutability after construction.
      */
     public CombinationQueue getQueue(int idx) { 
@@ -405,10 +419,11 @@ public class CombinationQueueArray {
 
     /**
      * Returns all of the {@link CombinationQueue CombinationQueues} in the {@link #queues} array.
+     * 
      * @return the entire {@link #queues} array.
      * @see #CombinationQueueArray(int, int)
      * @since 2025.05.26 - Monkey Work-Stealing Introduction
-     * @performance O(1) time complexity.
+     * @performance {@code O(1)} time complexity.
      * @threading Thread-safe due to field immutability after construction.
      */
     public CombinationQueue[] getAllQueues() { 
@@ -417,7 +432,7 @@ public class CombinationQueueArray {
 
     /**
      * Marks that a {@link CombinationGeneratorTask generator} has finished its work. If all generators
-     * have finished, sets the {@link #generationComplete} flag to true, signaling to the
+     * have finished, sets the {@link #generationComplete} flag to {@code true}, signaling to the
      * {@link TestClickCombination monkeys} that no more combinations will be generated.
      * 
      * <p>
@@ -433,20 +448,20 @@ public class CombinationQueueArray {
      * <p>
      * This method is designed to be called only once by each generator when it finishes its work, so it
      * is not performance-critical. Nevertheless, the use of an
-     * {@link java.util.concurrent.atomic.AtomicInteger} for the {@link #generatorsRemaining} counter
-     * allows for lock-free and thread-safe updates, ensuring that we can accurately track the number of
-     * active generators without introducing contention or performance overhead. However, in our current
-     * architecture, we typically only have one effective generator thread, meaning that the counter
-     * will only ever be decremented once. In the future, we may remove this parameter entirely and
-     * assume it is always 1, letting us get rid of the <code>AtomicInteger</code> and simply set the
-     * <code>generationComplete</code> flag to <code>true</code>.
+     * {@link java.util.concurrent.atomic.AtomicInteger AtomicInteger} for the
+     * {@link #generatorsRemaining} counter allows for lock-free and thread-safe updates, ensuring that
+     * we can accurately track the number of active generators without introducing contention or
+     * performance overhead. However, in our current architecture, we typically only have one effective
+     * generator thread, meaning that the counter will only ever be decremented once. In the future, we
+     * may remove this parameter entirely and assume it is always 1, letting us get rid of the
+     * {@code AtomicInteger} and simply set the {@code generationComplete} flag to {@code true}.
      * </p>
      * 
      * @see #generatorsRemaining
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) time complexity.
-     * @threading Thread-safe due to the use of an AtomicInteger for the {@link #generatorsRemaining}
-     *            counter, allowing for lock-free updates.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} time complexity.
+     * @threading Thread-safe due to the use of an {@code AtomicInteger} for the
+     *            {@link #generatorsRemaining} counter, allowing for lock-free updates.
      * @memory Negligible memory footprint, as it only involves updating a single integer and a boolean
      *         flag.
      */
@@ -472,21 +487,22 @@ public class CombinationQueueArray {
      * This method is designed to be called only once, by the first monkey that finds a solution. We
      * don't need to worry about multiple monkeys finding solutions simultaneously, so we can keep the
      * method simple and worry less about aggressive optimizations. Rather than using an AtomicBoolean,
-     * we use a volatile boolean flag for the {@link #solutionFound} field, which saves us boxing and
-     * unboxing overhead as well as some memory while providing the same effect (safe publication and
-     * visibility across threads). The winning monkey's name and combination could piggyback on the
-     * volatile status of the flag to avoid volatility overhead, but for simplicity, we keep them as
-     * volatile fields.
+     * we use a {@code volatile boolean} flag for the {@link #solutionFound} field, which saves us
+     * boxing and unboxing overhead as well as some memory while providing the same effect (safe
+     * publication and visibility across threads). The winning monkey's name and combination could
+     * piggyback on the {@code volatile} status of the flag to avoid volatility overhead, but for
+     * simplicity, we keep them as {@code volatile} fields.
      * </p>
      * 
      * @see #solutionFound
      * @see #getWinningCombination()
      * @see #getWinningMonkey()
-     * @param monkeyName the name of the monkey that found the solution.
+     * @param monkeyName         the name of the monkey that found the solution.
      * @param winningCombination the combination that solves the puzzle.
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) time complexity.
-     * @threading Thread-safe due to the use of a volatile boolean flag for the {@link #solutionFound} field, ensuring visibility across threads.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} time complexity.
+     * @threading Thread-safe due to the use of a {@code volatile boolean} flag for the
+     *            {@link #solutionFound} field, ensuring visibility across threads.
      * @memory Negligible memory footprint, as it only involves updating a few fields.
      */
     public void solutionFound(String monkeyName, short[] winningCombination) {
@@ -500,13 +516,13 @@ public class CombinationQueueArray {
     /**
      * Gets the name of the {@link TestClickCombination monkey} that found the solution.
      * 
-     * @return the name of the winning monkey, or <code>null</code> if no solution has been found yet.
+     * @return the name of the winning monkey, or {@code null} if no solution has been found yet.
      * @see #getWinningCombination()
      * @see #solutionFound(String, short[])
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) time complexity.
-     * @threading Thread-safe due to the use of a volatile field for the {@link #winningMonkey} field,
-     *            ensuring visibility across threads.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} time complexity.
+     * @threading Thread-safe due to the use of a {@code volatile} field for the {@link #winningMonkey}
+     *            field, ensuring visibility across threads.
      */
     public String getWinningMonkey() { 
         return winningMonkey; 
@@ -515,13 +531,13 @@ public class CombinationQueueArray {
     /**
      * Gets the combination that solves the puzzle.
      * 
-     * @return the winning combination, or <code>null</code> if no solution has been found yet.
+     * @return the winning combination, or {@code null} if no solution has been found yet.
      * @see #getWinningMonkey()
      * @see #solutionFound(String, short[])
-     * @since 2025.05.23 - Multiple CombinationQueues
-     * @performance O(1) time complexity.
-     * @threading Thread-safe due to the use of a volatile field for the {@link #winningCombination} field,
-     *            ensuring visibility across threads.
+     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} time complexity.
+     * @threading Thread-safe due to the use of a {@code volatile} field for the
+     *            {@link #winningCombination} field, ensuring visibility across threads.
      */
     public short[] getWinningCombination() { 
         return winningCombination; 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -5,357 +5,234 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jctools.queues.MpmcArrayQueue;
 
 /**
- * A shared structure for managing communication and state between
+ * A structure for managing work distribution and shared resources between
  * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys}.
- * 
+ *
  * <p>
- * In order to facilitate efficient communication between the generators and the monkeys, we need
- * some type of shared structure that both can access, storing information about the state of the
- * system. We also need a way to manage the lifecycle of our system - specifically, monkeys need to
- * know when all generators have finished working (so they can stop waiting for new work) and
- * generators need to know when a monkey has found a solution (so they can stop generating new
- * work). This class serves that purpose, providing the necessary fields and methods for state
- * management and signaling.
+ * This class serves as the central coordination point for the solver. It has two primary
+ * responsibilities:
  * </p>
- * 
- * <h2>Optimization Strategy</h2>
+ * <ol>
+ * <li><b>Work Distribution:</b> It holds an array of {@link CombinationQueue} instances, one for
+ * each monkey. This partitions the workload and reduces contention.</li>
+ * <li><b>Centralized Pooling:</b> It manages a global {@link #workBatchPool} for recycling
+ * {@link WorkBatch} objects. This is critical for minimizing garbage collection by allowing
+ * consumers to return processed batches to a central location for reuse by generators.</li>
+ * </ol>
+ *
+ * <h2>Architectural Role</h2>
  * <p>
- * We use a combination of lock-free data structures (from JCTools) and volatile flags to manage
- * state and communication between threads. This approach minimizes contention and maximizes
- * throughput, allowing for efficient operation even under high load. As the name suggests, the core
- * field of this class is an array of {@link CombinationQueue CombinationQueues}, one for each
- * {@link TestClickCombination monkey}. The use of a separate queue for each monkey reduces
- * contention and allows for more efficient work distribution. We can facilitate work-stealing
- * between monkeys by providing access to all queues, allowing idle monkeys to take work from busier
- * ones. Additionally, we use a central pool for recycled {@link WorkBatch} objects to avoid
- * frequent allocations and deallocations, which can lead to garbage collection overhead.
+ * As a singleton instance, this class provides the infrastructure for decoupling generators from
+ * monkeys. Generators acquire empty {@code WorkBatch} objects from the central pool, fill them with
+ * work, and offer them to one of the work queues. Monkeys poll their designated queue, process the
+ * entire batch, and return the now-empty {@code WorkBatch} to the central pool.
  * </p>
- * 
- * <h2>Usage Patterns</h2>
+ *
  * <p>
- * This class is intended to be used as a singleton, with one instance shared between all
- * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys}. The
- * generators push generated combinations into the appropriate {@link CombinationQueue} based on the
- * monkey they are targeting, while the monkeys pull combinations from their own queue (and
- * potentially steal work from others). The {@link #solutionFound} and {@link #generationComplete}
- * flags are used to signal the end of processing, allowing threads to exit gracefully. The
- * {@link #generatorFinished()} and {@link #solutionFound(String, short[])} methods are used to
- * update the state of the system when generators finish their work or when a solution is found,
- * respectively.
+ * It also manages the application's lifecycle by tracking the number of active producers
+ * ({@link #generatorsRemaining}) and signaling termination conditions via the
+ * {@link #solutionFound} and {@link #generationComplete} flags.
  * </p>
- * 
- * <h2>Memory Management</h2>
+ *
+ * <h2>Memory and Performance</h2>
  * <p>
- * This class uses a fixed-size array for the {@link #queues} field, which is allocated
- * {@link #CombinationQueueArray(int, int) during construction} and remains constant throughout the
- * lifetime of the instance. Queues themselves are bounded to prevent unbounded memory growth and
- * providing backpressure to the generators. The {@link #workBatchPool} is also bounded and
- * pre-allocated to match the total capacity of all queues, ensuring that we never run out of
- * {@link WorkBatch} objects, which would lead to allocations in the hot path. This approach
- * minimizes memory fragmentation and reduces the likelihood of garbage collection pauses, which can
- * impact performance.
+ * The entire structure is designed to minimize allocations and synchronization in the hot path. The
+ * {@link #workBatchPool} is pre-allocated at startup to a size that guarantees a recycled batch is
+ * never discarded, eliminating the need for runtime allocations. Communication relies on lock-free
+ * queues from JCTools and {@code volatile} flags, ensuring high throughput.
  * </p>
- * 
- * @see CombinationQueue
- * @see WorkBatch
- * @see org.jctools.queues.MpmcArrayQueue
- * @since 2025.05.23 - Multiple {@code CombinationQueue}s
- * @performance {@code O(1)} for most operations, <code>O({@link #queues}.length)</code> for
- *              iterating through all queues.
- * @threading Uses lock-free structures and {@code volatile} flags for safe concurrent access and
- *            updates.
- * @memory Pre-allocates fixed-size structures to minimize fragmentation and GC overhead.
+ *
+ * @see MpmcArrayQueue
+ * @since 2025.05 - Multiple {@code CombinationQueue}s
+ * @performance {@code O(1)} for most operations, {@code O(queues.length)} for iterating through all
+ *              queues.
+ * @threading Thread-safe; uses lock-free structures and {@code volatile} flags for safe concurrent
+ *            access and updates.
+ * @memory Fixed memory footprint after initialization; no dynamic allocations in the hot path.
  */
 public class CombinationQueueArray {
     /**
-     * An array of {@link CombinationQueue}s, one for each {@link TestClickCombination monkey}.
-     * 
+     * An array of {@link CombinationQueue work queues}, with each queue dedicated to a specific
+     * {@link TestClickCombination monkey}.
+     *
      * <p>
-     * While using just one queue for all monkeys is the simplest approach and may seem tempting, it can
-     * lead to contention and bottlenecks in performance as threads compete for access to the same queue
-     * (this is the case even with lock-free queues because of CAS operations). Having a separate queue
-     * for each monkey allows them to operate independently from other threads and gives them a
-     * dedicated high-priority path to work with. However, we need a way for the
-     * {@link CombinationGeneratorTask generators} to get a reference to the queues and push WorkBatch
-     * objects to them (or for monkeys to steal work from other queues). This array of
-     * {@code CombinationQueue}s provides that mechanism.
+     * This design partitions the workload, significantly reducing contention compared to a single
+     * shared queue. Each monkey primarily polls its own dedicated queue. The array structure also
+     * facilitates work-stealing, allowing an idle monkey to poll other queues for work.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * An array of {@code CombinationQueue}s allows for efficient access to each queue by its index
-     * without adding extra overhead from custom collections or data structures. Each queue can be
-     * accessed in {@code O(1)} time, and the array itself is a contiguous block of memory, which is
-     * cache-friendly and reduces memory fragmentation.
-     * </p>
-     * 
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} for access to a specific queue, {@code O(queues.length)} for iterating
+     *
+     * @see #getQueue(int)
+     * @see #getAllQueues()
+     * @since 2025.05 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} access of an individual queue, {@code O(queues.length)} for iterating
      *              through all queues.
-     * @threading The array is immutable after construction, making it thread-safe for read operations.
-     * @memory The array has a fixed memory footprint based on the number of queues and their
-     *         capacities.
+     * @threading Thread-safe; immutable for read operations after construction.
+     * @memory Minimal overhead of {@code queues.length * 4} bytes as an array of references.
      */
     private final CombinationQueue[] queues;
     /**
      * A counter for the number of active {@link CombinationGeneratorTask generators}.
-     * 
+     *
      * <p>
-     * In order to determine when all generators have finished their work, we need a way to track how
-     * many are still active. This counter serves that purpose, allowing each generator to decrement the
-     * count when it finishes its work. When the count reaches zero, we know that all generators have
-     * finished, and we can set the {@link #generationComplete} flag to true, signaling to the
-     * {@link TestClickCombination monkeys} that no more combinations will be generated.
+     * This {@link AtomicInteger atomic counter} is decremented when a root generator task completes.
+     * When the count reaches zero, the {@link #generationComplete} flag is set, signaling to monkeys
+     * that no new work will be produced.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * The use of an {@link java.util.concurrent.atomic.AtomicInteger} allows for lock-free updates to
-     * the counter, ensuring that we can accurately track the number of active generators without
-     * introducing contention or performance overhead. However, in our current architecture, we
-     * typically only have one effective generator thread, meaning that the counter will only ever be
-     * decremented once. In the future, we may assume it is always 1 until generation has finished,
-     * letting us get rid of the {@code AtomicInteger} and simply set the {@code generationComplete}
-     * flag to {@code true}.
+     * An {@code AtomicInteger} provides lock-free updates, avoiding contention. Currently, only one
+     * main generator task decrements this counter. Future optimizations might replace this with a
+     * simple flag set by that single task, removing the atomic operation overhead entirely.
      * </p>
-     * 
+     *
      * @see #generatorFinished()
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     * @since 2025.05 - Multiple {@code CombinationQueue}s
      * @performance {@code O(1)} for increment and decrement operations.
-     * @threading Thread-safe due to the use of an {@link java.util.concurrent.atomic.AtomicInteger
-     *            AtomicInteger}, allowing for lock-free updates.
-     * @memory Negligible memory footprint, as it only involves a single {@code int} value.
+     * @threading Thread-safe; uses atomic operations for safe concurrent updates.
+     * @memory Fixed memory footprint of 16 bytes for the atomic integer.
      */
     private final AtomicInteger generatorsRemaining;
     /**
-     * The central pool for recycled {@link WorkBatch} objects. This pool is used to avoid frequent
-     * allocations and deallocations of {@code WorkBatch} instances by providing a backflow for
-     * {@code WorkBatch} objects that have been processed.
-     * 
+     * A central, thread-safe pool for recycling {@link WorkBatch} objects.
+     *
      * <p>
-     * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
-     * deallocations are expensive operations that can lead to frequent garbage collections, driving up
-     * latency and reducing throughput. Changes could be made to other parts of the codebase to allocate
-     * less, but where there are deallocations, there must be allocations to replace them. This pool
-     * plugs the leak and allows the system to recycle {@code WorkBatch} objects.
+     * This pool is the cornerstone of the application's memory management strategy. It allows
+     * {@link WorkBatch} instances to be reused, effectively eliminating them as a source of garbage
+     * collection pressure.
      * </p>
-     * 
+     *
      * <p>
-     * The pool is pre-allocated with a fixed number of {@code WorkBatch} instances, which matches the
-     * total capacity of all the {@link CombinationQueue}s. Those instances then get pulled into the
-     * {@link CombinationGeneratorTask generators} by their contexts to store generated combinations
-     * until they have been filled with data. The generators then push the filled {@code WorkBatch}
-     * objects into the {@code CombinationQueue}s, where they are processed by the consumers. Once the
-     * consumers have finished processing a {@code WorkBatch}, they return it to the pool for reuse,
-     * restarting the cycle.
+     * The lifecycle is as follows:
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
+     * <ol>
+     * <li>The pool is pre-filled with empty {@code WorkBatch} instances at startup.</li>
+     * <li>A {@link CombinationGeneratorTask generator} polls a batch from this pool.</li>
+     * <li>The generator fills the batch with work items.</li>
+     * <li>The full batch is offered to a work {@link #queues queue}.</li>
+     * <li>A {@link TestClickCombination monkey} polls the batch, processes its contents, and clears
+     * it.</li>
+     * <li>The monkey returns the empty, cleared batch to this pool.</li>
+     * </ol>
+     *
      * <p>
-     * Since pools pre-allocate resources, the size of the pool directly affects the memory footprint of
-     * the application. We choose to allocate the pool to match the capacity of all of the worker queues
-     * to ensure that we never run out of {@code WorkBatch} objects, which would lead to allocations.
-     * Oversizing the pool would lead to wasted memory and potentially lead to problems regarding
-     * in-flight batches, so it's crucial that we maintain the proper size.
+     * The pool is sized to hold a number of batches equal to the total capacity of all work queues,
+     * guaranteeing that a recycled batch is never discarded.
      * </p>
-     * 
-     * @see org.jctools.queues.MpmcArrayQueue
-     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
-     * @performance {@code O(1)} for offer and poll operations (which should be the only ones used),
-     *              <code>O({@link org.jctools.queues.MpmcArrayQueue#capacity() 
-     *              workBatchPool.capacity()})</code> for {@link MpmcArrayQueue#size() size()}.
-     * @threading The pool is thread-safe and can be accessed by multiple threads concurrently through
-     *            the power of JCTools.
-     * @memory The queue is bounded and has a fixed memory footprint based on the number of
-     *         {@code WorkBatch} instances it contains.
+     *
+     * @see #getWorkBatchPool()
+     * @see MpmcArrayQueue
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} for both offer and poll operations, {@code O(workBatchPool.capacity())}
+     *              for {@link MpmcArrayQueue#size() size()}.
+     * @threading Thread-safe through JCTools wizardry
+     * @memory Fixed memory footprint after initialization
      */
     private final MpmcArrayQueue<WorkBatch> workBatchPool;
     /**
-     * The name of the {@link TestClickCombination monkey} that found the solution.
-     * 
-     * <p>
-     * Since our program concerns itself only with finding a single solution to the puzzle, we can
-     * immediately stop all processing once a solution has been found. While the monkey that finds the
-     * solution may not be important, it is still useful information to have for logging and debugging
-     * purposes. This field stores the name of the monkey that found the solution.
-     * </p>
-     * 
+     * The name of the {@link TestClickCombination monkey} that found the solution. Written once when
+     * {@link #solutionFound} is set.
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This field is marked as {@code volatile} to ensure visibility across threads. While the winning
-     * monkey's name could piggyback on the {@code volatile} status of the {@link #solutionFound} flag
-     * to avoid volatility overhead, for simplicity, we keep it as a separate {@code volatile} field.
-     * The overhead of volatility is negligible in this case, as the field is only
-     * {@link #solutionFound(String, short[]) written} once and {@link #getWinningMonkey() read} a few
-     * times at the end of the program's lifecycle.
+     * This field is {@code volatile} to ensure visibility across threads. It could piggyback on the
+     * {@code volatile} write to {@link #solutionFound} for publication, but is kept as a separate
+     * {@code volatile} field for simplicity. The overhead is negligible as it is written only once.
      * </p>
-     * 
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} for reads and writes.
-     * @threading Marked as {@code volatile} to ensure visibility across threads.
-     * @memory Negligible memory footprint, as it only involves a reference to a {@link java.lang.String
-     *         String} object.
+     *
+     * @see #solutionFound(String, short[])
+     * @see #getWinningMonkey()
      */
     private volatile String winningMonkey = null;
     /**
-     * The combination that solves the puzzle.
-     * 
-     * <p>
-     * Since our program concerns itself only with finding a single solution to the puzzle, we can
-     * immediately stop all processing once a solution has been found. Unlike the {@link #winningMonkey
-     * winning monkey's name}, the actual combination that solves the puzzle is extremely important
-     * information to have. This field stores the winning combination.
-     * </p>
-     * 
+     * The click combination that solves the puzzle. Written once when {@link #solutionFound} is set.
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This field is marked as {@code volatile} to ensure visibility across threads. While the winning
-     * combination could piggyback on the {@code volatile} status of the {@link #solutionFound} flag to
-     * avoid volatility overhead, for simplicity, we keep it as a separate {@code volatile} field. The
-     * overhead of volatility is negligible in this case, as the field is only
-     * {@link #solutionFound(String, short[]) written} once and {@link #getWinningCombination() read} a
-     * few times at the end of the program's lifecycle.
+     * This field is {@code volatile} to ensure visibility across threads. It could piggyback on the
+     * {@code volatile} write to {@link #solutionFound} for publication, but is kept as a separate
+     * {@code volatile} field for simplicity. The overhead is negligible as it is written only once.
      * </p>
-     * 
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} for reads and writes.
-     * @threading Marked as {@code volatile} to ensure visibility across threads.
-     * @memory Negligible memory footprint, as it only involves a reference to a {@code short[]}.
+     *
+     * @see #solutionFound(String, short[])
+     * @see #getWinningCombination()
      */
     private volatile short[] winningCombination = null;
 
     /**
-     * A flag indicating whether a solution has been found.
-     * 
-     * <p>
-     * The goal of the brute force solver is to find a combination that solves the puzzle. It doesn't
-     * matter which {@link TestClickCombination monkey} finds the solution or what the combination is,
-     * as long as it exists. Therefore, it makes no sense to continue searching for solutions once one
-     * has been found. Monkeys are meant to work independently, but if one finds the solution, we need a
-     * mechanism to stop all other monkeys from continuing their work. This flag serves that purpose.
-     * </p>
-     * 
+     * A {@code volatile} flag indicating that a solution has been found.
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This flag is a {@code volatile boolean}, which allows for safe publication and visibility across
-     * threads. An {@link java.util.concurrent.atomic.AtomicBoolean AtomicBoolean} was used previously,
-     * but since we only need to set it once and to read it multiple times, a {@code volatile boolean}
-     * saves us boxing and unboxing overhead while still providing thread-visibility guarantees. The
-     * flag is checked frequently by the monkeys, so it must be lightweight to avoid introducing
-     * unnecessary contention or performance overhead.
+     * A {@code volatile boolean} is used instead of an {@code AtomicBoolean} because it provides the
+     * necessary visibility guarantees for a single-writer/multi-reader scenario with less overhead. It
+     * is read frequently in the hot path.
      * </p>
-     * 
+     *
      * <p>
-     * Previously, this field was also checked explicitly by the generators to determine whether to
-     * continue generating combinations. However, the {@link java.util.concurrent.ForkJoinPool
-     * ForkJoinPool} architecture provides a more efficient way to handle this by facilitating
-     * cooperative cancellation through a shutdown. In theory, something similar could be implemented
-     * for the monkeys to eliminate the need for this flag altogether, but for now, we'll keep this flag
-     * for simplicity.
+     * While generators now rely on the {@link java.util.concurrent.ForkJoinPool ForkJoinPool}'s
+     * cancellation mechanism, the monkeys still poll this flag to terminate work. A future
+     * implementation could potentially unify this under a single cancellation mechanism, but this flag
+     * remains a simple and effective solution.
      * </p>
-     * 
+     *
      * @see #getWinningCombination()
      * @see #getWinningMonkey()
      * @see #solutionFound(String, short[])
-     * @since 2025.07.02 - Volatile Flag Implementation
+     * @since 2025.07 - Volatile Flag Implementation
      * @performance {@code O(1)} for reads and writes.
-     * @threading This flag is marked as {@code volatile}, ensuring that changes made by one thread are
-     *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
-     *            but that is not necessary for this use case.
-     * @memory The flag is a single {@code boolean} value, which has a negligible memory footprint.
+     * @threading Thread-safe; uses {@code volatile} for safe concurrent access.
+     * @memory Fixed memory footprint of 1 byte as a {@code boolean}.
      */
     public volatile boolean solutionFound = false;
     /**
-     * A flag indicating whether the generation of combinations is complete.
-     * 
+     * A volatile flag indicating that all {@link CombinationGeneratorTask producers} have completed.
+     *
      * <p>
-     * There are two ways that the program can finish (under normal circumstances):
+     * This is set to {@code true} when {@link #generatorsRemaining} reaches zero. It signals to
+     * {@link TestClickCombination monkeys} that no new work will be added to the queues. A monkey can
+     * safely terminate when this flag is {@code true} and all work queues are empty.
      * </p>
-     * 
-     * <ol>
-     * <li>A solution is found by one of the {@link TestClickCombination monkeys}, which sets the
-     * {@link #solutionFound} flag to {@code true}.</li>
-     * <li>All generators have finished generating combinations and the monkeys finish processing all of
-     * them.</li>
-     * </ol>
-     * 
-     * <p>
-     * The latter circumstance is more difficult to detect, as it requires coordination between two
-     * different types of architecture: the {@link CombinationGeneratorTask generators} and the
-     * {@link TestClickCombination monkeys}. The monkeys need a way to tell the difference between a
-     * momentary emptiness in the queue (which is expected) and a complete end to the generation of
-     * combinations. This flag serves that purpose.
-     * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This flag is a {@code volatile boolean}, which allows for safe publication and visibility across
-     * threads. An {@link java.util.concurrent.atomic.AtomicBoolean AtomicBoolean} was used previously,
-     * but since we only need to set it once and to read it multiple times, a {@code volatile boolean}
-     * saves us boxing and unboxing overhead while still providing thread-visibility guarantees. The
-     * flag is checked frequently by the monkeys, so it must be lightweight to avoid introducing
-     * unnecessary contention or performance overhead.
+     * A {@code volatile boolean} is used instead of an {@code AtomicBoolean} because it provides the
+     * necessary visibility guarantees for a single-writer/multi-reader scenario with less overhead. It
+     * is read frequently by monkeys to determine when to stop work.
      * </p>
-     * 
+     *
      * @see #generatorFinished()
      * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask#GeneratorContext)
      * @see TestClickCombination#allQueuesEmpty()
-     * @since 2025.07.02 - Volatile Flag Implementation
+     * @since 2025.07 - Volatile Flag Implementation
      * @performance {@code O(1)} for reads and writes.
-     * @threading This flag is marked as {@code volatile}, ensuring that changes made by one thread are
-     *            immediately visible to all other threads. This doesn't ensure atomicity of operations,
-     *            but that is not necessary for this use case.
-     * @memory The flag is a single {@code boolean} value, which has a negligible memory footprint.
+     * @threading Thread-safe; uses {@code volatile} for safe concurrent access.
+     * @memory Fixed memory footprint of 1 byte as a {@code boolean}.
      */
     public volatile boolean generationComplete = false;
 
     /**
-     * Constructs a {@code CombinationQueueArray} with the specified number of consumers
-     * ({@link TestClickCombination monkeys}) and {@link CombinationGeneratorTask generators.}
-     * 
+     * Constructs the shared {@link #queues queue array} and its associated resources.
+     *
      * <p>
-     * Of the two parameters, the number of consumers is the more important one, as it directly affects
-     * the size of the {@link #queues} array and the {@link #workBatchPool} pool. While the number of
-     * generators does affect the {@link #generatorsRemaining} counter, the
-     * {@link java.util.concurrent.ForkJoinPool ForkJoinPool} architecture means that the number of
-     * active generator threads can vary dynamically, so completion signaling is handled by one thread
-     * (the one that spawns the generators) rather than all of them. For this reason, we typically set
-     * the number of generators to 1. In the future, we may remove this parameter entirely and assume it
-     * is always 1.
+     * This constructor initializes the entire communication and resource-sharing infrastructure. It
+     * creates the array of work {@link CombinationQueue queues} and pre-allocates {@link #workBatchPool
+     * the central} {@link WorkBatch} pool. The pool is sized to match the total
+     * {@link CombinationQueue#getCapacity() capacity} of all work queues combined, which is a critical
+     * invariant to ensure the recycling mechanism never fails.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * In the context of our program, we should only need one instance of this class, as it serves as a
-     * central hub for communication and state management. This constructor is therefore not part of the
-     * hot path and does not need to be optimized for performance. However, there are still some tricks
-     * we apply to amortize the cost of allocations and setup.
-     * </p>
-     * 
-     * <p>
-     * First, we pre-allocate the entire {@link #workBatchPool} pool to prevent allocations in the hot
-     * path. The pool is sized to match the total capacity of all the {@link #queues}, ensuring that we
-     * never run out of {@link WorkBatch} objects, which would lead to allocations. Second, we use an
-     * {@link AtomicInteger} for the {@link #generatorsRemaining} counter, which allows for lock-free
-     * updates and avoids the need for synchronization.
-     * </p>
-     * 
-     * @param numConsumers  The number of {@link TestClickCombination monkeys} that will be consuming
-     *                      combinations. Affects the size of the {@link #queues} array and the
-     *                      {@link #workBatchPool} pool.
-     * @param numGenerators The (effective) number of {@link CombinationGeneratorTask generators} that
-     *                      will be producing combinations. Affects the {@link #generatorsRemaining}
-     *                      counter.
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
+     *
+     * @param numConsumers  The number of {@link TestClickCombination monkeys}. This determines the
+     *                      number of work queues to create.
+     * @param numGenerators The (effective) number of {@link CombinationGeneratorTask generators}. This
+     *                      initializes the {@link #generatorsRemaining completion counter}.
+     * @since 2025.05 - Multiple {@code CombinationQueue}s
      * @performance {@code O(numConsumers)} queue initialization + {@code O(1)} counter setup +
-     *              {@code O(numConsumers)} counter initialization + <code>O(numConsumers *
-     *              {@link CombinationQueue#QUEUE_SIZE})</code> pool pre-allocation =
+     *              {@code O(numConsumers)} counter initialization +
+     *              {@code O(numConsumers * CombinationQueue.QUEUE_SIZE)} pool pre-allocation =
      *              {@code O(numConsumers)} time complexity.
-     * @threading Thread-safe due to instance isolation (a constructor must create a new object).
-     * @memory Fixed memory footprint based on {@code numConsumers},
-     *         {@link CombinationQueue#QUEUE_SIZE}, and {@link CombinationGeneratorTask#BATCH_SIZE}.
-     * @optimization Pre-allocates the entire {@code WorkBatch} pool to prevent allocations in the hot
-     *               path.
+     * @threading Thread-safe due to instance isolation
+     * @memory Allocates the array of queues, counters, and flags, and pre-allocates the pool.
      */
     public CombinationQueueArray(int numConsumers, int numGenerators) {
         this.queues = new CombinationQueue[numConsumers];
@@ -383,87 +260,80 @@ public class CombinationQueueArray {
     }
 
     /**
-     * Gets the {@link #workBatchPool central pool} for recycled {@link WorkBatch} objects. This pool
-     * completes the lifecycle of {@code WorkBatch} objects, allowing them to be reused and preventing
-     * frequent allocations and deallocations, but we need a way for the {@link CombinationGeneratorTask
-     * generators} and {@link TestClickCombination monkeys} to get a reference to it. This getter
-     * provides that mechanism.
-     * 
-     * @return a reference to the pool.
+     * Returns the {@link #workBatchPool central pool} for recycled {@link WorkBatch} objects.
+     *
+     * <p>
+     * Both {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys} use
+     * this method to access the pool. Generators poll from it to get empty batches, and monkeys offer
+     * to it to return processed batches.
+     * </p>
+     *
+     * @return The thread-safe, multi-producer/multi-consumer queue used for pooling {@code WorkBatch}
+     *         instances.
      * @see #workBatchPool
      * @see #CombinationQueueArray(int, int)
-     * @see WorkBatch
-     * @see org.jctools.queues.MpmcArrayQueue
-     * @since 2025.07.07 - Enqueuing {@code WorkBatch} Objects
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to field immutability after construction. The pool itself is also
-     *            thread-safe through JCTools magic.
+     * @see MpmcArrayQueue
+     * @since 2025.07 - Enqueuing {@code WorkBatch} Objects
+     * @performance {@code O(1)} retrieval.
+     * @threading Thread-safe; returns a reference to an immutable field.
      */
     public MpmcArrayQueue<WorkBatch> getWorkBatchPool() {
         return workBatchPool;
     }
 
     /**
-     * Gets the {@link CombinationQueue} at the specified index.
-     * 
-     * @param idx the index of the {@link CombinationQueue} to retrieve.
-     * @return the {@link CombinationQueue} at the specified index in the {@link #queues} array.
+     * Returns the {@link CombinationQueue work queue} at the specified index.
+     *
+     * @param idx The index of the queue to retrieve.
+     * @return The {@code CombinationQueue} at the specified index in the {@link #queues} array.
      * @see #CombinationQueueArray(int, int)
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to field immutability after construction.
+     * @since 2025.05 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} access.
+     * @threading Thread-safe; returns a reference to an immutable field.
      */
     public CombinationQueue getQueue(int idx) { 
         return queues[idx]; 
     }
 
     /**
-     * Returns all of the {@link CombinationQueue CombinationQueues} in the {@link #queues} array.
-     * 
-     * @return the entire {@link #queues} array.
+     * Returns the {@link #queues entire array} of work queues.
+     *
+     * <p>
+     * This is primarily used to enable work-stealing, where a {@link TestClickCombination monkey} can
+     * iterate through other queues to find work if its own queue is empty.
+     * </p>
+     *
+     * @return The array of all {@link CombinationQueue}s.
      * @see #CombinationQueueArray(int, int)
-     * @since 2025.05.26 - Monkey Work-Stealing Introduction
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to field immutability after construction.
+     * @since 2025.05 - Monkey Work-Stealing Introduction
+     * @performance {@code O(1)} access.
+     * @threading Thread-safe; returns a reference to an immutable field.
      */
     public CombinationQueue[] getAllQueues() { 
         return queues; 
     }
 
     /**
-     * Marks that a {@link CombinationGeneratorTask generator} has finished its work. If all generators
-     * have finished, sets the {@link #generationComplete} flag to {@code true}, signaling to the
-     * {@link TestClickCombination monkeys} that no more combinations will be generated.
-     * 
+     * Atomically decrements the {@link #generatorsRemaining} counter and sets the
+     * {@link #generationComplete} flag if the counter reaches zero.
+     *
      * <p>
-     * The {@link CombinationGeneratorTask generators} are responsible for producing combinations that
-     * the {@link TestClickCombination monkeys} will test. Our architecture is designed to allow for
-     * mostly independent operation between the two, but when the generators finish their work, we need
-     * to signal to the monkeys that no more combinations will be enqueued so they can stop waiting for
-     * new work and exit when all queues are empty. This method provides the mechanism for that
-     * signaling.
+     * This method is called by a {@link CombinationGeneratorTask generator} after it has finished
+     * computing all of its subtasks to signal to {@link TestClickCombination monkeys} that no new work
+     * will be produced.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be called only once by each generator when it finishes its work, so it
-     * is not performance-critical. Nevertheless, the use of an
-     * {@link java.util.concurrent.atomic.AtomicInteger AtomicInteger} for the
-     * {@link #generatorsRemaining} counter allows for lock-free and thread-safe updates, ensuring that
-     * we can accurately track the number of active generators without introducing contention or
-     * performance overhead. However, in our current architecture, we typically only have one effective
-     * generator thread, meaning that the counter will only ever be decremented once. In the future, we
-     * may remove this parameter entirely and assume it is always 1, letting us get rid of the
-     * {@code AtomicInteger} and simply set the {@code generationComplete} flag to {@code true}.
+     * This method is not in the hot path. It uses an {@code AtomicInteger} for lock-free updates. Since
+     * only one root generator task calls this, a future optimization could be to remove the atomic
+     * operation and have the main thread set the {@code generationComplete} flag directly.
      * </p>
-     * 
-     * @see #generatorsRemaining
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to the use of an {@code AtomicInteger} for the
-     *            {@link #generatorsRemaining} counter, allowing for lock-free updates.
-     * @memory Negligible memory footprint, as it only involves updating a single integer and a boolean
-     *         flag.
+     *
+     * @since 2025.05 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} atomic decrement and check.
+     * @threading Thread-safe; uses atomic operations for safe concurrent updates.
+     * @memory Does not allocate.
      */
     public void generatorFinished() {
         if (generatorsRemaining.decrementAndGet() == 0) {
@@ -472,38 +342,30 @@ public class CombinationQueueArray {
     }
 
     /**
-     * Marks that a solution has been found by a {@link TestClickCombination monkey}.
-     * 
+     * Signals that a solution has been found.
+     *
      * <p>
-     * Since our program concerns itself only with finding a single solution to the puzzle, it doesn't
-     * matter what the solution is or which monkey found it. Once a solution has been found, we need a
-     * way to stop all other monkeys from continuing their work and stop all
-     * {@link CombinationGeneratorTask generators} from producing more combinations. Solution signaling
-     * is therefore a crucial part of our architecture, and this method provides the mechanism for it.
+     * This method sets the {@link #solutionFound} flag to {@code true} and records the winning
+     * combination and the name of the thread that found it. It is designed to be called by any
+     * {@link TestClickCombination monkey}. A check ensures that only the first-found solution is
+     * recorded.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be called only once, by the first monkey that finds a solution. We
-     * don't need to worry about multiple monkeys finding solutions simultaneously, so we can keep the
-     * method simple and worry less about aggressive optimizations. Rather than using an AtomicBoolean,
-     * we use a {@code volatile boolean} flag for the {@link #solutionFound} field, which saves us
-     * boxing and unboxing overhead as well as some memory while providing the same effect (safe
-     * publication and visibility across threads). The winning monkey's name and combination could
-     * piggyback on the {@code volatile} status of the flag to avoid volatility overhead, but for
-     * simplicity, we keep them as {@code volatile} fields.
+     * This method is called only once. A simple check on the {@code solutionFound} flag prevents a race
+     * condition where multiple monkeys find a solution simultaneously. A {@code volatile
+     * boolean} is used for the flag over an {@code AtomicBoolean} to reduce overhead, as the
+     * single-write nature of the event does not require atomic compare-and-set operations. The other
+     * fields could piggyback on this write for visibility.
      * </p>
-     * 
-     * @see #solutionFound
-     * @see #getWinningCombination()
-     * @see #getWinningMonkey()
-     * @param monkeyName         the name of the monkey that found the solution.
-     * @param winningCombination the combination that solves the puzzle.
-     * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to the use of a {@code volatile boolean} flag for the
-     *            {@link #solutionFound} field, ensuring visibility across threads.
-     * @memory Negligible memory footprint, as it only involves updating a few fields.
+     *
+     * @param monkeyName         The name of the monkey that found the solution.
+     * @param winningCombination The combination that solves the puzzle.
+     * @since 2025.05 - Multiple {@code CombinationQueue}s
+     * @performance {@code O(1)} check and set.
+     * @threading Thread-safe; uses {@code volatile} for safe concurrent access.
+     * @memory Does not allocate.
      */
     public void solutionFound(String monkeyName, short[] winningCombination) {
         if (solutionFound == false) {
@@ -514,30 +376,30 @@ public class CombinationQueueArray {
     }
 
     /**
-     * Gets the name of the {@link TestClickCombination monkey} that found the solution.
-     * 
-     * @return the name of the winning monkey, or {@code null} if no solution has been found yet.
+     * Returns the name of the {@link TestClickCombination monkey} that found the solution.
+     *
+     * @return The winning monkey's name, or {@code null} if no solution has been found.
      * @see #getWinningCombination()
      * @see #solutionFound(String, short[])
      * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to the use of a {@code volatile} field for the {@link #winningMonkey}
-     *            field, ensuring visibility across threads.
+     * @performance {@code O(1)} retrieval.
+     * @threading Thread-safe; returns a reference to a {@code volatile} field.
+     * @memory Does not allocate.
      */
     public String getWinningMonkey() { 
         return winningMonkey; 
     }
     
     /**
-     * Gets the combination that solves the puzzle.
-     * 
-     * @return the winning combination, or {@code null} if no solution has been found yet.
+     * Returns the combination that solves the puzzle.
+     *
+     * @return The winning combination array, or {@code null} if no solution has been found.
      * @see #getWinningMonkey()
      * @see #solutionFound(String, short[])
      * @since 2025.05.23 - Multiple {@code CombinationQueue}s
-     * @performance {@code O(1)} time complexity.
-     * @threading Thread-safe due to the use of a {@code volatile} field for the
-     *            {@link #winningCombination} field, ensuring visibility across threads.
+     * @performance {@code O(1)} retrieval.
+     * @threading Thread-safe; returns a reference to a {@code volatile} field.
+     * @memory Does not allocate.
      */
     public short[] getWinningCombination() { 
         return winningCombination; 

--- a/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
+++ b/src/main/java/com/github/mrgarbagegamer/CombinationQueueArray.java
@@ -56,7 +56,7 @@ import org.jctools.queues.MpmcArrayQueue;
  * impact performance.
  * </p>
  * 
- * <h3>11/16 - ~68.8% of documentation completed</h3>
+ * <h3>14/16 - 87.5% of documentation completed</h3>
  * 
  * @since 2025.05.23 - Multiple CombinationQueues
  * @performance O(1) for most operations, O(n) for iterating through all queues.
@@ -95,9 +95,34 @@ public class CombinationQueueArray {
      * @see CombinationQueue
      */
     private final CombinationQueue[] queues;
+    /**
+     * A counter for the number of active {@link CombinationGeneratorTask generators}.
+     * 
+     * <p>
+     * In order to determine when all generators have finished their work, we need a way to track how many
+     * are still active. This counter serves that purpose, allowing each generator to decrement the
+     * count when it finishes its work. When the count reaches zero, we know that all generators have
+     * finished, and we can set the {@link #generationComplete} flag to true, signaling to the
+     * {@link TestClickCombination monkeys} that no more combinations will be generated.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The use of an {@link java.util.concurrent.atomic.AtomicInteger} allows for lock-free updates to the
+     * counter, ensuring that we can accurately track the number of active generators without
+     * introducing contention or performance overhead. However, in our current architecture, we typically
+     * only have one effective generator thread, meaning that the counter will only ever be decremented
+     * once. In the future, we may remove this parameter entirely and assume it is always 1, letting us get rid of the
+     * <code>AtomicInteger</code> and simply set the <code>generationComplete</code> flag to <code>true</code>.
+     * </p>
+     * 
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Thread-safe due to the use of an AtomicInteger, allowing for lock-free updates.
+     * @performance O(1) for increment and decrement operations.
+     * @memory Negligible memory footprint, as it only involves a single integer value.
+     * @see #generatorFinished()
+     */
     private final AtomicInteger generatorsRemaining;
-    // REPLACED: The int[] pool is gone.
-    // NEW: Central pool for recycled WorkBatch objects.
     /**
      * The central pool for recycled WorkBatch objects. This pool is used to avoid frequent allocations
      * and deallocations of WorkBatch instances by providing a backflow for WorkBatch objects that have
@@ -141,7 +166,57 @@ public class CombinationQueueArray {
      * @see MpmcArrayQueue
      */
     private final MpmcArrayQueue<WorkBatch> workBatchPool;
+    /**
+     * The name of the {@link TestClickCombination monkey} that found the solution.
+     * 
+     * <p>
+     * Since our program concerns itself only with finding a single solution to the puzzle, we can
+     * immediately stop all processing once a solution has been found. While the monkey that finds the
+     * solution may not be important, it is still useful information to have for logging and debugging
+     * purposes. This field stores the name of the monkey that found the solution.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This field is marked as volatile to ensure visibility across threads. While the winning monkey's
+     * name could piggyback on the volatile status of the {@link #solutionFound} flag to avoid
+     * volatility overhead, for simplicity, we keep it as a separate volatile field. The overhead of
+     * volatility is negligible in this case, as the field is only
+     * {@link #solutionFound(String, short[]) written} once and {@link #getWinningMonkey() read} a few
+     * times at the end of the program's lifecycle.
+     * </p>
+     * 
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Marked as volatile to ensure visibility across threads.
+     * @performance O(1) for reads and writes.
+     * @memory Negligible memory footprint, as it only involves a reference to a String object.
+     */
     private volatile String winningMonkey = null;
+    /**
+     * The combination that solves the puzzle.
+     * 
+     * <p>
+     * Since our program concerns itself only with finding a single solution to the puzzle, we can
+     * immediately stop all processing once a solution has been found. Unlike the {@link #winningMonkey
+     * winning monkey's name}, the actual combination that solves the puzzle is extremely important
+     * information to have. This field stores the winning combination.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This field is marked as volatile to ensure visibility across threads. While the winning combination
+     * could piggyback on the volatile status of the {@link #solutionFound} flag to avoid
+     * volatility overhead, for simplicity, we keep it as a separate volatile field. The overhead of
+     * volatility is negligible in this case, as the field is only
+     * {@link #solutionFound(String, short[]) written} once and {@link #getWinningCombination() read} a few
+     * times at the end of the program's lifecycle.
+     * </p>
+     * 
+     * @since 2025.05.23 - Multiple CombinationQueues
+     * @threading Marked as volatile to ensure visibility across threads.
+     * @performance O(1) for reads and writes.
+     * @memory Negligible memory footprint, as it only involves a reference to a short array.
+     */
     private volatile short[] winningCombination = null;
 
     /**

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -24,7 +24,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>6/50 - 12% of documentation completed</h3>
+ * <h3>9/50 - 18% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]
@@ -111,8 +111,8 @@ public abstract class Grid
      * cells are adjacent to a given cell. This method provides that functionality.
      * </p>
      * 
-     * <h3>Algorithm Details</h3>
-     * For a given cell n (in packed int format) in an even row, the adjacent cells include:
+     * <h3>Algorithm Details</h3> For a given cell n (in packed int format) in an even row, the adjacent
+     * cells include:
      * <ul>
      * <li>n - 101 (row - 1, col - 1)</li>
      * <li>n - 100 (row - 1, col)</li>
@@ -137,26 +137,28 @@ public abstract class Grid
      * Internal computations are performed in <code>PackedInt</code> format for efficiency, as it allows
      * for straightforward arithmetic operations to determine adjacency. The method has to convert
      * between formats as needed, which adds some overhead, but this is offset by our use of the method
-     * in the static block to pre-compute an {@link #adjacencyArray adjacency table}. Future
-     * calls to find adjacents can then use this pre-computed table for O(1) lookups. 
+     * in the static block to pre-compute an {@link #adjacencyArray adjacency table}. Future calls to
+     * find adjacents can then use this pre-computed table for O(1) lookups.
      * </p>
      * <p>
-     * Since cells in different grid positions can have a different number of valid adjacent cells
-     * (due to edges and corners), we use a dynamic list (<code>ShortList</code>) to store the results,
+     * Since cells in different grid positions can have a different number of valid adjacent cells (due
+     * to edges and corners), we use a dynamic list (<code>ShortList</code>) to store the results,
      * letting the calling method handle conversion to a fixed-size array if needed. Fastutil's
-     * primitive collections are used to avoid boxing overhead and allow for efficient storage
-     * and retrieval of short values.
+     * primitive collections are used to avoid boxing overhead and allow for efficient storage and
+     * retrieval of short values.
      * </p>
      * 
      * @param cell         A short representing the cell in the grid, expected to be in the same format
      *                     as inputFormat.
-     * @param inputFormat  The ValueFormat of the input cell, which can either be Index or PackedInt.
-     * @param outputFormat The ValueFormat of the output cell, which can either be Index or PackedInt.
-     * @return affectedPieces A ShortList of adjacent cells in the specified output format, containing
+     * @param inputFormat  The {@link ValueFormat} of the input cell, which can either be
+     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
+     * @param outputFormat The {@link ValueFormat} of the output cell, which can either be
+     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
+     * @return affectedPieces A <code>ShortList</code> of adjacent cells in the specified output format, containing
      *         up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
-     * @since 2025.05.15 - Static Adjacency Computations
+     * @since 2025.07.16 - Format Support
      * @performance If outputFormat is <code>PackedInt</code>, O(1) input conversion (if necessary) + 6
      *              * O(1) adjacency computation + O(6) output filtering = O(1) complexity.
      * @performance If outputFormat is <code>Index</code>, O(1) input conversion (if necessary) + 6 *
@@ -173,8 +175,7 @@ public abstract class Grid
      * @see #findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
      * @see ShortList
      */
-    public static ShortList computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
-    {
+    public static ShortList computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         ShortList affectedPieces = new ShortArrayList(6);
 
         // We need to handle different formats for adjacency 
@@ -403,8 +404,7 @@ public abstract class Grid
      * @see #getBit(int index)
      * @see #setBit(int index)
      **/
-    protected void clearBit(int index)
-    {
+    protected void clearBit(int index) {
         int longIndex = index / 64;
         int bitPosition = index % 64;
         if ((gridState[longIndex] & (1L << bitPosition)) != 0)
@@ -449,13 +449,66 @@ public abstract class Grid
     }
 
     /**
-     * Returns the true cells in the requested format.
-     * Internally, true cells are stored as bit indices (0-108).
+     * Scans the {@link #gridState grid bitmask} and returns an array of all true cells. Converts the
+     * result to the requested format ({@link ValueFormat#Index} or {@link ValueFormat#PackedInt}).
+     * 
+     * <p>
+     * For {@link CombinationGeneratorTask generator} and {@link TestClickCombination monkey}
+     * efficiency, we perform several checks to prune combinations early. Many of these checks involve
+     * the initial state of the grid, so we need a way to conveniently extract the true bits from the
+     * bitmask and return them in a format that can be used for processing. This method provides that
+     * functionality, allowing for the efficient scanning of the grid state.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * We use the {@link #getBit(int index)} method to check each bit in the grid state, iterating
+     * across the values in the range 0-108 (inclusive). For each bit that is set, we add its index to
+     * an array that is pre-sized to the number of true cells in the grid. To avoid scanning the entire
+     * grid after finding the requisite number of true cells, we use a counter to track the index in the
+     * array and exit the for loop early when the array is full.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method isn't expected to be called frequently, as it is primarily used for obtaining the
+     * initial grid state. For this reason, we avoid {@link #recalculationNeeded checking for
+     * recalculation} or {@link #getTrueCount() recalculating the true cells count}, assuming the true
+     * count is correctly maintained by the {@link #setBit(int index)} and {@link #clearBit(int index)}
+     * methods. This avoids overhead, though it does allow for the possibility of an incorrectly sized
+     * array or missing true cells. A future update could target this.
+     * </p>
+     * 
+     * <p>
+     * Another area for potential optimization is in the extraction of true cells. We could create two
+     * temporary longs to store the grid state, use the {@link Long#numberOfTrailingZeros(long)} method
+     * to find the first 1 in our bitmask, add the index to the array and turn off the bit (by ANDing
+     * with 0) and repeat until we have found all true cells. This would allow us to avoid the overhead
+     * of iterating over the entire grid state, but it would require additional complexity in the code
+     * that is unneeded at the moment.
+     * </p>
+     * 
      * @param format The desired output format (Index or PackedInt).
-     * @return An array of true cells in the requested format.
+     * @return An array of true cells in the specified format.
+     * @throws IllegalArgumentException if the format is Bitmask, (since that would just be the Grid
+     *                                  itself). Use {@link #getGridState()} instead to fulfill that
+     *                                  purpose.
+     * @since 2025.07.16 - Format Support
+     * @performance If format is {@link ValueFormat#Index}, O(n) loop through the grid state (where n is
+     *              the index of the last true cell, up to 108) + O(1) lookup via {@link #getBit(int)}
+     *              per iteration + O(1) array insertion for every true cell found = O(n) complexity.
+     * @performance If format is {@link ValueFormat#PackedInt}, O(n) loop through the grid state (where
+     *              n is the index of the last true cell, up to 108) + O(1) lookup via
+     *              {@link #getBit(int)} per iteration + O(1) array insertion for every true cell found
+     *              + O(n) conversion to packed int format = O(n) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @optimization Uses a pre-sized array to avoid resizing during insertion, and exits the for loop
+     *               when all true cells are found.
+     * @see #findTrueCells()
+     * @see #findFirstTrueCell(ValueFormat format)
      */
-    public short[] findTrueCells(ValueFormat format) 
-    {
+    public short[] findTrueCells(ValueFormat format) {
         short[] trueCellsArray = new short[trueCellsCount];
         int idx = 0;
         
@@ -487,12 +540,29 @@ public abstract class Grid
     }
 
     /**
-     * Returns the true cells in the default (Index) format.
-     * This is a final method to encourage inlining.
-     * @return An array of true cells in Index format.
+     * Scans the {@link #gridState grid bitmask} and returns an array of all true cells in
+     * {@link ValueFormat#Index} format (0-108).
+     * 
+     * <p>
+     * This method is a convenience overload of {@link #findTrueCells(ValueFormat format)} that defaults
+     * to the Index format, allowing for better inlining and performance if this method is on the hot
+     * path.
+     * </p>
+     * 
+     * @param format The desired output format (Index or PackedInt).
+     * @return An array of true cells in the specified format.
+     * @since 2025.04.08 - Adjacency Optimizations
+     * @performance O(n) loop through the grid state (where n is the index of the last true cell, up to
+     *              108) + O(1) lookup via {@link #getBit(int)} per iteration + O(1) array insertion for
+     *              every true cell found = O(n) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @optimization Uses a pre-sized array to avoid resizing during insertion, and exits the for loop
+     *               when all true cells are found.
+     * @see #findTrueCells(ValueFormat format)
+     * @see #findFirstTrueCell(ValueFormat format)
      */
-    public final short[] findTrueCells() 
-    {
+    public final short[] findTrueCells() {
         short[] trueCellsArray = new short[trueCellsCount];
         int idx = 0;
         
@@ -506,13 +576,62 @@ public abstract class Grid
     }
 
     /**
-     * Returns the first true cell in the requested format.
-     * Internally, firstTrueCell is stored as a bit index (0-108).
-     * @param format The desired output format (Index or PackedInt).
-     * @return The first true cell, or -1 if none found.
+     * Scans the {@link #gridState grid} and returns the first true cell. Converts the result to the
+     * requested format ({@link ValueFormat#Index} or {@link ValueFormat#PackedInt}). If no true cell is
+     * found, returns -1.
+     * 
+     * <p>
+     * Since <code>click</code>s are limited in scope to the adjacents of one cell, we can derive an
+     * important property of the solution: It must toggle the first true cell in the initial grid state.
+     * We can therefore optimize the search for the solution by pruning combinations that violate this
+     * condition, making it important to have a fast way to find the first true cell in the grid. While
+     * one could use the <code>findTrueCells()</code> method to find the first true cell, this method is
+     * optimized for that purpose.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * Java contains a built-in method for finding the first set bit in a long, called
+     * {@link Long#numberOfTrailingZeros(long)}. We can use this method to grab the first true cell and
+     * update the {@link #firstTrueCell} field. We also update {@link #trueCellsCount} field with
+     * another method, {@link Long#bitCount(long)}, which counts the number of set bits in a long.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * If no changes have been made to the grid state since the last call to this method, we'd want to
+     * save on recalculating the value of the first true cell and the count of true cells. We can do
+     * this by checking the {@link #recalculationNeeded recalculationNeeded} flag and updating the
+     * values if it is true. In the case where the flag is false and the count of true cells is 0, we
+     * can short-circuit the method to avoid unnecessary calculations, returning -1 immediately.
+     * </p>
+     * 
+     * <p>
+     * The methods used to find the first true cell and count the number of true cells are O(1) due to
+     * some clever programming on the Java developers' part. Reinventing the wheel would be a waste of
+     * time (and likely less efficient), so we avoid that effort.
+     * </p>
+     * 
+     * @param format The desired output format ({@link ValueFormat#Index Index} or
+     *               {@link ValueFormat#PackedInt PackedInt}).
+     * @return The first true cell in the specified format, or -1 if no true cell is found.
+     * @throws IllegalArgumentException if the format is Bitmask (since bitmasks aren't supported for
+     *                                  single values).
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) lookup time for the flag and true cells count + O(1) bitwise check to find the
+     *              first true cell + 2 * O(1) bitcounts on the bitmask + O(1) conversion to the
+     *              requested format = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @algorithm Uses Java's built-in methods for finding the first set bit and counting the number of set bits
+     *            in a long, which are highly optimized.
+     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
+     * @see #findFirstTrueCell()
+     * @see #click(short, ValueFormat)
+     * @see #click(short[])
+     * @see #findTrueCells(ValueFormat format)
      */
-    public short findFirstTrueCell(ValueFormat format) 
-    {
+    public short findFirstTrueCell(ValueFormat format) {
         if (!recalculationNeeded && trueCellsCount == 0) 
         {
             return -1;
@@ -556,12 +675,30 @@ public abstract class Grid
     }
 
     /**
-     * Returns the first true cell in the default (Index) format.
-     * This is a final method to encourage inlining.
-     * @return The first true cell in Index format, or -1 if none found.
+     * Scans the {@link #gridState grid} and returns the first true cell in {@link ValueFormat#Index}
+     * format (0-108). If no true cell is found, returns -1.
+     * 
+     * <p>
+     * This method is a convenience overload of {@link #findFirstTrueCell(ValueFormat format)} that
+     * defaults to the Index format, allowing for better inlining and performance if this method is on
+     * the hot path.
+     * </p>
+     * 
+     * @return The first true cell in Index format, or -1 if no true cell is found.
+     * @since 2025.04.08 - Adjacency Optimizations
+     * @performance O(1) lookup time for the flag and true cells count + O(1) bitwise check to find the
+     *              first true cell + 2 * O(1) bitcounts on the bitmask = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *           or with proper synchronization.
+     * @algorithm Uses Java's built-in methods for finding the first set bit and counting the number of set bits
+     *           in a long, which are highly optimized.
+     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
+     * @see #findFirstTrueCell(ValueFormat format)
+     * @see #click(short, ValueFormat)
+     * @see #click(short[])
+     * @see #findTrueCells()
      */
-    public final short findFirstTrueCell() 
-    {
+    public final short findFirstTrueCell() {
         if (!recalculationNeeded && trueCellsCount == 0) 
         {
             return -1;

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -6,6 +6,32 @@ import org.apache.logging.log4j.Logger;
 import it.unimi.dsi.fastutil.shorts.ShortArrayList;
 import it.unimi.dsi.fastutil.shorts.ShortIterator;
 import it.unimi.dsi.fastutil.shorts.ShortList;
+/**
+ * Grid - Abstract class representing our hexagonal Lights Out grid.
+ * 
+ * <p>[Detailed description of role in the overall puzzle-solving architecture.
+ * Explain the "what" and "why" - what problem this class solves and why this
+ * approach was chosen.] </p>
+ * 
+ * <h2>Architecture Role</h2>
+ * <p>[How this class fits into the overall system. What classes depend on it,
+ * what it depends on, and the data flow.]</p>
+ * 
+ * <h2>Performance Characteristics</h2>
+ * <p>[Key performance properties, bottlenecks, and optimization strategies.
+ * Include complexity analysis for critical methods.]</p>
+ * 
+ * <h2>Thread Safety</h2>
+ * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * 
+ * <h3>0/50 - 0% of documentation completed</h3>
+ * 
+ * @performance [Overall performance characteristics]
+ * @threading [Thread safety guarantees]
+ * @algorithm [High-level algorithm description]
+ * @since [Version when introduced/major changes]
+ * @see [Related classes in the architecture]
+ */
 public abstract class Grid
 {
     public enum ValueFormat

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -6,34 +6,108 @@ import org.apache.logging.log4j.Logger;
 import it.unimi.dsi.fastutil.shorts.ShortArrayList;
 import it.unimi.dsi.fastutil.shorts.ShortIterator;
 import it.unimi.dsi.fastutil.shorts.ShortList;
+
 /**
  * Grid - Abstract class representing our hexagonal Lights Out grid.
  * 
- * <p>[Detailed description of role in the overall puzzle-solving architecture.
- * Explain the "what" and "why" - what problem this class solves and why this
- * approach was chosen.] </p>
+ * <p>
+ * Our puzzle is a hexagonal grid of lights, where each light can be either on or off. Clicking a
+ * cell flips the state of that cell and its adjacent cells, with the goal of the puzzle being to
+ * turn off all the lights. Building a high-performance solver for this puzzle requires an efficient
+ * representation of the grid and fast operations for clicking cells and checking the grid state.
+ * This class aims to provide that functionality.
+ * </p>
+ * 
+ * <h2>Static Initialization</h2>
+ * <p>
+ * A key component to the performance of this class and its methods is the static initialization
+ * block, which pre-computes adjacency masks and arrays for each cell in the grid, allowing for O(1)
+ * lookups during runtime. This block is executed once when the class is loaded, allowing each
+ * instance of the Grid to share the benefits without incurring the cost repeatedly.
+ * </p>
+ * 
+ * <p>
+ * The static block consists of a for loop that iterates across each cell in the grid (0-108 in
+ * {@link ValueFormat#Index Index} format). For each cell, it
+ * {@link #computeAdjacents(short, ValueFormat, ValueFormat) computes the adjacent cells} as a
+ * {@link ShortList}, which then gets converted to a short array and stored in the
+ * {@link #adjacencyArray adjacency array} for use in the
+ * {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
+ * {@link #ADJACENCY_CACHE A 2D table} is created from this data, allowing for easy adjacency checks
+ * between two values. We also build a bitmask that provides another form of adjacency
+ * representation, storing it in the {@link #ADJACENCY_MASKS adjacency masks} array for use in the
+ * {@link #click(short, ValueFormat) click()} method. Finally, we populate
+ * {@link #PACKED_TO_INDEX_CACHE a cache} for {@link ValueFormat#PackedInt PackedInt} to
+ * {@link ValueFormat#Index Index} conversions. All of these structures are then statically assigned
+ * as the block moves to the next cell.
+ * </p>
  * 
  * <h2>Architecture Role</h2>
- * <p>[How this class fits into the overall system. What classes depend on it,
- * what it depends on, and the data flow.]</p>
+ * <p>
+ * The Grid class serves as the foundational representation of the puzzle's state and operations,
+ * providing the infrastructure for efficient manipulation and querying of the grid. It is designed
+ * to be extended by concrete implementations that define specific {@link #gridState initial states}
+ * and {@link #initialize() initialization procedures} for each puzzle (e.x. Q13, Q22, and Q35).
+ * </p>
+ * 
+ * <p>
+ * {@link TestClickCombination Monkeys} utilize this class to test various click combinations, with
+ * each receiving its own instance of a Grid to operate on. However, re-initializing the grid state
+ * can be costly, so it is recommended to prune combinations before testing against the grid.
+ * {@link CombinationGeneratorTask Generators} are designed to produce combinations efficiently and
+ * thus perform light checks before passing them to the monkeys, limiting the interactions they have
+ * with this class. This separation of concerns allows for a more focused codebase and clarifies
+ * areas of bottlenecks; optimizing this class will primarily benefit the monkeys rather than the
+ * generators.
+ * </p>
  * 
  * <h2>Performance Characteristics</h2>
- * <p>[Key performance properties, bottlenecks, and optimization strategies.
- * Include complexity analysis for critical methods.]</p>
+ * <p>
+ * We aim for O(1) complexity for core operations like {@link #click(short, ValueFormat) clicking a
+ * cell} and {@link #isSolved() checking for the solved state}, with most of the complexity hidden
+ * in the static initialization block. Due to the nature of objects in Java (which allocate on the
+ * heap rather than the stack), primitive types and arrays are used wherever possible to minimize
+ * overhead, with bitmasks allowing for compact storage and fast operations. Sadly, Java lacks a
+ * native 128-bit primitive type, making every operation on our 109-cell grid require 2
+ * modifications or polls rather than 1. The Vector API seemed promising, but it allocates terribly
+ * (4 allocations per lanewise operation), incurring massive overhead. {@link java.util.BitSet
+ * BitSets} were considered, but they incur unnecessary overhead in terms of object headers, making
+ * them less efficient than our custom bitmask approach.
+ * </p>
+ * 
+ * <p>
+ * Future optimizations could include exploring off-heap storage options or finding ways to densely
+ * pack the grid state into a single primitive type, but these would require some heavy ingenuity.
+ * Unless Project Valhalla magically gets released soon, we are likely nearing the limits of what
+ * Java can do, potentially forcing us to look at other languages to push performance further.
+ * </p>
  * 
  * <h2>Thread Safety</h2>
- * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * <p>
+ * This class is <b>not</b> thread-safe. Each instance of a Grid should only be accessed from a
+ * single thread or with proper synchronization. The static members are immutable after
+ * initialization and are thus safe to share across threads, but instance members like
+ * {@link #click(long[])} and {@link #gridState} could have weird side effects if accessed
+ * concurrently. We trade off thread-safety and potentially lower memory usage for performance, as
+ * avoiding synchronization and locks allows for faster operations in the hot path.
+ * </p>
  * 
- * <h3>16/50 - 32% of documentation completed</h3>
+ * <h3>31/52 - ~59.6% of documentation completed</h3>
  * 
- * @performance [Overall performance characteristics]
- * @threading [Thread safety guarantees]
- * @algorithm [High-level algorithm description]
- * @since [Version when introduced/major changes]
- * @see [Related classes in the architecture]
+ * @since 2025.03.20 - Initial creation
+ * @performance Core operations like clicking a cell and checking for the solved state are designed
+ *              to be O(1), with most of the complexity hidden in the static initialization block.
+ *              Some other methods may have O(n) complexity or worse, but these are designed to be
+ *              called infrequently.
+ * @threading This class is <b>not</b> thread-safe. Each instance should only be accessed from a
+ *            single thread or with proper synchronization.
+ * @algorithm Iterates across each cell in the grid during static initialization, pre-computing
+ *            adjacency masks and arrays for O(1) lookups during runtime. Use bitmasks and bitwise
+ *            operations to efficiently represent and manipulate the grid state.
+ * @see #gridState
+ * @see TestClickCombination
  */
-public abstract class Grid
-{
+public abstract class Grid {
     public enum ValueFormat
     {
         PackedInt, // row * 100 + col [Technically, we use shorts, but let's ignore that]
@@ -220,8 +294,53 @@ public abstract class Grid
      * @see #clearBit(int index)
      */
     protected final long[] gridState = new long[2];
+    /**
+     * Cached value of the number of cells that are currently true (on) in the grid. Used for quick
+     * {@link #isSolved() solution checks} and to optimize certain operations. Updated whenever
+     * {@link #getTrueCount()} is called and {@link #recalculationNeeded} is <code>true</code>.
+     * 
+     * @since 2025.07.13 - Bitmasked Grid state
+     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) access time when up to date (and O(1) updates, since
+     *              {@link java.lang.Long#bitCount(long) Long.bitCount()} is O(1))
+     * @optimization Caches the count of true cells to avoid recalculating it on every check, improving
+     *               performance for operations that frequently check the solved state.
+     * @see #getTrueCount()
+     * @see #isSolved()
+     */
     protected int trueCellsCount = 0;
-    protected short firstTrueCell = -1; // The first true cell is in index format (0-108)
+    /**
+     * A cached index of the first cell that is currently true (on) in the grid. Stored in
+     * {@link ValueFormat#Index Index} format and used to optimize constraint satisfaction checks and
+     * certain operations. Updated whenever {@link #findFirstTrueCell(ValueFormat)} is called and
+     * {@link #recalculationNeeded} is <code>true</code>.
+     * 
+     * @since 2025.07.16 - First True Cell Caching
+     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) access time when up to date, and O(n) updates in the worst case (where n is the
+     *              {@link #NUM_CELLS number of cells in the grid}).
+     * @optimization Caches the index of the first true cell to avoid scanning the entire grid on every
+     *               check, improving performance for operations that frequently need this information.
+     * @see #findFirstTrueCell()
+     */
+    protected short firstTrueCell = -1;
+    /**
+     * A flag indicating whether a recalculation of {@link #trueCellsCount} and/or
+     * {@link #firstTrueCell} is needed. Set to <code>true</code> whenever the grid state is modified
+     * (e.g., via a click operation) and reset to <code>false</code> after the next call to
+     * {@link #getTrueCount()} or {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()}.
+     * 
+     * @since 2025.07.13 - Bitmasked Grid state
+     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) access and update time, as it is a simple boolean flag.
+     * @optimization Uses a boolean flag to track whether recalculation is needed, avoiding unnecessary
+     *               recalculations.
+     * @see #firstTrueCell
+     * @see #trueCellsCount
+     */
     protected boolean recalculationNeeded = false;
 
     /**
@@ -258,25 +377,68 @@ public abstract class Grid
     private static final long[][] ADJACENCY_MASKS = new long[NUM_CELLS][2];
     
     // Legacy support for existing code that expects adjacency arrays
+    /**
+     * Adjacency array for each cell in the grid. Each entry contains a <code>short[]</code> of the
+     * indices of adjacent cells. These are filled in during the static block of Grid's initialization,
+     * and are used to quickly retrieve results with the
+     * {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Pre-computing these arrays allows for O(1) lookups when determining the adjacent cells for a
+     * given cell, avoiding the need to compute adjacencies on-the-fly. Previously, we used this array
+     * in the {@link #click(short, ValueFormat) click()} method, but we have since moved to using the
+     * {@link #ADJACENCY_MASKS adjacency masks} for better performance. The array is retained for use in
+     * the {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
+     * </p>
+     * 
+     * @since 2025.05.29 - HashSet -> Array for Adjacency Storage
+     * @threading This array is initialized in a static block and is immutable after that point.
+     * @performance O(1) lookup time for adjacency arrays, as they are pre-computed and stored in a
+     *              static array.
+     * @optimization Uses a static array to avoid the overhead of runtime calculations. Standardized to
+     *               use the {@link ValueFormat#Index Index} format for consistency.
+     * @see #NUM_CELLS
+     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     */
     private static final short[][] adjacencyArray = new short[NUM_CELLS][]; // Index format
+    /**
+     * A 2D boolean array representing adjacency between cells in the grid. This is a legacy structure,
+     * primarily used for quick adjacency checks between two cells in
+     * {@link #areAdjacent(short, short, ValueFormat) areAdjacent()}. It is filled in during the static
+     * block of Grid's initialization and is not used in performance-critical paths.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This structure allows for O(1) adjacency checks between two cells, which is useful for certain
+     * operations. However, it is not used in the hot path of the application, as most operations use
+     * the {@link #ADJACENCY_MASKS adjacency masks} or the {@link #adjacencyArray adjacency array} for
+     * better performance. The 2D array is retained for legacy support and for use in specialized
+     * operations.
+     * </p>
+     * 
+     * @since 2025.06.25 - O(1) areAdjacent() checks
+     * @threading This array is initialized in a static block and is immutable after that point.
+     * @performance O(1) lookup time for adjacency checks, as it is a pre-computed 2D array.
+     * @optimization Uses a static 2D array to avoid the overhead of runtime calculations. Standardized to
+     *               use the {@link ValueFormat#Index Index} format for consistency.
+     * @see #NUM_CELLS
+     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     */
     private static final boolean[][] ADJACENCY_CACHE = new boolean[NUM_CELLS][NUM_CELLS]; // Index format
     private static final short[] PACKED_TO_INDEX_CACHE = new short[(NUM_ROWS - 1) * 100 + EVEN_NUM_COLS]; // Cache for packed to index conversion
 
     // We don't necessarily need to worry too much about how optimized this block
     // is, since it's only run once at startup.
-    static 
-    {
-        // Our goal is to replicate the above static block while iterating on bit indices
-        for (short cell = 0; cell < NUM_CELLS; cell++)
-        {
+    static {
+        for (short cell = 0; cell < NUM_CELLS; cell++) {
             ShortList adjSet = computeAdjacents(cell, ValueFormat.Index, ValueFormat.Index);
             short[] adjArr = new short[adjSet.size()];
             int idx = 0;
 
             // Initialize bitmask for this cell
             long[] mask = new long[2];
-            for (ShortIterator it = adjSet.iterator(); it.hasNext();) 
-            {
+            for (ShortIterator it = adjSet.iterator(); it.hasNext();) {
                 short adjacent = it.nextShort();
                 adjArr[idx++] = adjacent;
 
@@ -443,9 +605,58 @@ public abstract class Grid
         return computeAdjacents(cell, ValueFormat.Index);
     }
 
-    // Finds the adjacent cells for a given cell in the grid, returning them in the requested format (with the array storing in index format).
-    public static short[] findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
-    {
+    /**
+     * Finds the hexagonally adjacent cells for a given cell in the grid, parsing inputs and outputting
+     * in the requested formats.
+     * 
+     * <p>
+     * Since our grid is hexagonal, each cell can have up to 6 adjacent cells, depending on the cell's
+     * position and the grid's boundaries. This method provides a way to retrieve those adjacent cells
+     * in various formats, making it versatile for different use cases.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * While this method does pull from a {@link #adjacencyArray pre-computed adjacency array} for O(1)
+     * lookups, it is forced to convert each of the results to the requested output format, which adds
+     * some overhead and makes the method O(n) in complexity (where n is the number of adjacent cells,
+     * which is at most 6). In addition, the large switch statements for format handling limit this
+     * method's ability to be inlined by the JVM.
+     * </p>
+     * 
+     * <p>
+     * A potential area for optimization would be to pre-compute adjacency arrays for each format
+     * combination, but this method is designed to be called infrequently (if at all) during the
+     * lifetime of the program, so the added complexity and memory usage may not be worth it.
+     * </p>
+     * 
+     * @param cell         A <code>short</code> representing the cell in the grid, expected to be in the
+     *                     same format as <code>inputFormat</code>.
+     * @param inputFormat  The {@link ValueFormat} of the input cell, which can either be
+     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
+     * @param outputFormat The {@link ValueFormat} of the output cell, which can either be
+     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
+     * @return A <code>short[]</code> of adjacent cells in the specified output format, containing up to
+     *         6 items.
+     * @throws IllegalArgumentException       if the input or output format is
+     *                                        {@link ValueFormat#Bitmask Bitmask}, since we cannot
+     *                                        represent a single cell in that format.
+     * @throws ArrayIndexOutOfBoundsException if the input cell is out of bounds for the specified input
+     *                                        format (implicitly checked by array accesses).
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) input conversion (if necessary) + O(1) adjacency lookup {+ O(n) output
+     *              conversion (where n is fixed as 6 or less)} = O(1) for simplest case, O(n) worst
+     *              case complexity.
+     * @threading This method is thread-safe, since it only reads from static, immutable data.
+     * @memory Uses a fixed-size array to store the results, avoiding dynamic memory allocation and
+     *         temporary object creation.
+     * @optimization Uses a pre-computed adjacency array for fast lookups and minimizes memory usage by
+     *               using fixed-size arrays.
+     * @see #adjacencyArray
+     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see ValueFormat
+     */
+    public static short[] findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] result;
         switch (inputFormat)
         {
@@ -501,8 +712,24 @@ public abstract class Grid
         return (short) (ROW_OFFSETS[row] + col);
     }
 
-    public final static short packedToIndex(short packed) 
-    {
+    /**
+     * Converts a cell from {@link ValueFormat#PackedInt PackedInt} format to
+     * {@link ValueFormat#Index Index} format. This method uses a cache to speed up conversions for
+     * commonly used values, and {@link #computePackedToIndex(short) calculates} new values as needed.
+     * 
+     * @param packed A <code>short</code> representing the cell in {@link ValueFormat#PackedInt PackedInt} format.
+     * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
+     * @throws IllegalArgumentException if the input packed value is out of bounds (less than 0 or greater than 615).
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) lookup time in the cache + O(1) computation time for uncached values = O(1) complexity.
+     * @threading This method is thread-safe, as it reads from an immutable static cache and writes to it in a
+     *            thread-safe manner.
+     * @memory Pulls from a static cache to minimize memory usage, preventing the need for dynamic allocations.
+     * @optimization Uses a cache to speed up conversions for commonly used values, reducing the need for repeated calculations.
+     * @see #PACKED_TO_INDEX_CACHE
+     * @see #computePackedToIndex(short)
+     */
+    public final static short packedToIndex(short packed) {
         if (packed >= 0 && packed < PACKED_TO_INDEX_CACHE.length) 
         {
             if (PACKED_TO_INDEX_CACHE[packed] == 0 && packed != 0) 
@@ -515,8 +742,41 @@ public abstract class Grid
         throw new IllegalArgumentException("Invalid packed int: " + packed);
     }
 
-    public final static short indexToPacked(short index) 
-    {
+    /**
+     * Converts a cell from {@link ValueFormat#Index Index} format to {@link ValueFormat#PackedInt
+     * PackedInt} format. This method uses a series of conditional checks to determine the correct row
+     * and column for the given index.
+     * 
+     * <p>
+     * Note that this method does not explicitly check if the input index is greater than 0 for
+     * performance. Negative indices may return a value, but they are not valid packed int values.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be efficient, using a series of conditional checks to quickly
+     * determine the correct row and column for the given index. If extra performance is needed, we
+     * could cache the results of this method (a similar approach is taken for
+     * {@link #packedToIndex(short)}), but since this method is not frequently called in
+     * performance-critical paths, the added complexity and memory usage may not be worth it.
+     * </p>
+     * 
+     * @param index A <code>short</code> representing the cell in {@link ValueFormat#Index Index}
+     *              format.
+     * @return A <code>short</code> representing the cell in {@link ValueFormat#PackedInt PackedInt}
+     *         format.
+     * @throws IllegalArgumentException if the input index is out of bounds (less than 0 or greater than
+     *                                  108).
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) complexity due to a fixed number of conditional checks.
+     * @threading This method is thread-safe, as it does not modify any shared state and only uses local
+     *            variables.
+     * @memory Uses only local variables, minimizing memory usage and avoiding dynamic allocations.
+     * @optimization Uses a series of conditional checks to quickly determine the correct row and column
+     *               for the given index, avoiding the need for complex calculations or data structures.
+     * @see #packedToIndex(short)
+     */
+    public final static short indexToPacked(short index) {
         if (index < 16) return  (short) (0 * 100 + index);
         if (index < 31) return  (short) (1 * 100 + (index - 16));
         if (index < 47) return  (short) (2 * 100 + (index - 31));
@@ -822,9 +1082,10 @@ public abstract class Grid
      *              requested format = O(1) complexity.
      * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
      *            or with proper synchronization.
-     * @algorithm Uses Java's built-in methods for finding the first set bit and counting the number of set bits
-     *            in a long, which are highly optimized.
-     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
+     * @algorithm Uses Java's built-in methods for finding the first set bit and counting the number of
+     *            set bits in a long, which are highly optimized.
+     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded
+     *               recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
      * @see #findFirstTrueCell()
      * @see #click(short, ValueFormat)
      * @see #click(short[])
@@ -925,9 +1186,52 @@ public abstract class Grid
         return firstTrueCell;
     }
 
-    // Ultra-fast click operation using pre-computed bitmasks. This method uses pre-computed adjacency masks that are of the index format.
-    public void click(short cell, ValueFormat format) 
-    {
+    /**
+     * Simulates a click on the <code>Grid</code> at the specified cell, which can be in any of the
+     * supported {@link ValueFormat formats} ({@link ValueFormat#Index Index} or
+     * {@link ValueFormat#PackedInt PackedInt}).
+     * 
+     * <p>
+     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
+     * simply by XORing the {@link #gridState grid state} with a pre-computed {@link #ADJACENCY_MASKS
+     * adjacency mask.}
+     * </p>
+     * 
+     * <p>
+     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to <code>true</code> ensures
+     * that the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will
+     * recalculate the {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of
+     * true cells}. This avoids unnecessary recalculations on every click, which is crucial for
+     * performance in high-frequency scenarios.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit <code>long</code>
+     * for the grid state, meaning that we have to use two <code>long</code>s, and thus two adjacency
+     * masks per cell. Though we could strategically use a single long as a bitmask if the adjacent
+     * cells are localized to the same long, we choose to use two longs for simplicity and to avoid
+     * branching.
+     * </p>
+     * 
+     * @param cell   the cell to click, in the specified format.
+     * @param format the format of the cell (<code>Index</code> or <code>PackedInt</code>).
+     * @throws IllegalArgumentException       if the format is {@link ValueFormat#Bitmask Bitmask}
+     *                                        (since bitmasks aren't supported for single values) or
+     *                                        another unsupported format.
+     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
+     *                                        array accesses).
+     * @since 2025.07.16 - Format Support
+     * @performance If format is {@link ValueFormat#Index Index}, 2 * O(1) click operations using
+     *              pre-computed adjacency bitmasks = O(1) complexity. Otherwise, an additional O(1)
+     *              conversion is necessary (resulting in O(1) complexity overall).
+     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
+     *            instances of Grid or synchronize access to this method.
+     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
+     * @see #click(short cell)
+     * @see #click(short[] cells)
+     */
+    public void click(short cell, ValueFormat format) {
         switch (format) 
         {
             case Bitmask:
@@ -977,8 +1281,8 @@ public abstract class Grid
      * </p>
      * 
      * @param cell The cell to click, in Index format (0-108).
-     * @throws IllegalArgumentException if the cell is out of bounds (implicitly checked by the array
-     *                                  accesses).
+     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
+     *                                        array accesses).
      * @since 2025.07.19 - Inlining Improvements
      * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
      *            instances of Grid or synchronize access to this method.
@@ -1002,12 +1306,24 @@ public abstract class Grid
     }
 
     /**
-     * Specialized click method for PackedInt format. Made final to encourage inlining.
+     * Specialized click method for the {@link ValueFormat#PackedInt PackedInt} format. Made final to
+     * encourage inlining.
+     * 
      * @param row The row of the cell to click.
      * @param col The column of the cell to click.
+     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
+     *                                        array accesses).
+     * @since 2025.03.20 - Initial Commit
+     * @performance O(1) conversion from packed int to index + 2 * O(1) click operations using
+     *              pre-computed adjacency bitmasks = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
+     *            instances of Grid or synchronize access to this method.
+     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
+     *               Declared as final to encourage JIT inlining. Assumes the cell is in
+     *               <code>PackedInt</code> format (row and column) to avoid format checks.
+     * @see #click(short cell, ValueFormat format)
      */
-    public final void click(short row, short col) 
-    {
+    public final void click(short row, short col) {
         // Convert packed int to index format first
         short cell = packedToIndex((short) (row * 100 + col));
 
@@ -1122,14 +1438,67 @@ public abstract class Grid
     }
 
     /**
-     * Returns the adjacents of the first true cell after a given cell, in the requested formats.
-     * @param cell The cell after which to search (format specified by inputFormat).
-     * @param inputFormat The format of the input cell.
-     * @param outputFormat The desired output format.
-     * @return An array of adjacent cells after the given cell, or null if none found.
+     * Returns an array of adjacents of the {@link #findFirstTrueCell() first true cell} that come after
+     * the specified cell, in the requested {@link ValueFormat format}. If no true cell exists, or if no
+     * true adjacents after the specified cell exist, returns <code>null</code>.
+     * 
+     * <p>
+     * Since clicks are limited in scope to the adjacents of one cell (excluding itself), we can derive
+     * an important property of the solution: It must contain at least one click on the adjacents of the
+     * first true cell in the initial grid state. This may seem obvious, but it allows us to establish
+     * bounds for generation, limiting the maximum cell that needs to be considered for the first click
+     * to the last adjacent of the first true cell. This method gives us an easy way to extract and test
+     * those adjacents.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * We first {@link #findFirstTrueAdjacents(ValueFormat) find the adjacents of the first true cell}
+     * in the specified input format. If no true cell exists, we return <code>null</code>. We then
+     * convert the input cell to {@link ValueFormat#Index index} format if necessary, using the
+     * {@link #packedToIndex(short)} method for {@link ValueFormat#PackedInt packed int} format. We then
+     * perform a binary search on the array of adjacents to find the first adjacent cell that is greater
+     * than the specified cell. If no such adjacent exists, we return <code>null</code>. If we find such
+     * an adjacent, we create a new array containing all adjacents from that point onward. Finally, we
+     * convert the result to the desired output format if necessary and return it.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be efficient, performing a logarithmic search on a small array of
+     * adjacents and linear copying the resulting subarray. For greater efficiency, we could consider
+     * caching the result of the operation or figuring out some way to avoid an array copy, but given
+     * the small size of the adjacency list (up to 6 elements) and the infrequent nature of this
+     * operation, the current implementation is sufficient.
+     * </p>
+     * 
+     * @param cell         the cell after which to find adjacents, in the specified input format.
+     * @param inputFormat  the {@link ValueFormat format} of the input cell ({@link ValueFormat#Index
+     *                     Index} or {@link ValueFormat#PackedInt PackedInt}).
+     * @param outputFormat the {@link ValueFormat format} of the output array ({@link ValueFormat#Index
+     *                     Index} or {@link ValueFormat#PackedInt PackedInt}).
+     * @return An array of adjacent cells after the specified cell, in the requested output format, or
+     *         <code>null</code> if no true cell exists or if no adjacents after the specified cell
+     *         exist.
+     * @throws IllegalArgumentException if either format is {@link ValueFormat#Bitmask Bitmask} (since
+     *                                  bitmasks aren't supported for single values) or anything else.
+     * @since 2025.07.16 - Format Support
+     * @performance O(log n) binary search on the adjacency array (where n is up to 6) + O(m) array copy
+     *              (where m is up to 6) + O(m) conversion to packed int format if necessary = O(n)
+     *              complexity overall.
+     * @threading This method is <b>not</b> thread-safe. Each thread should have its own instance of
+     *            Grid or synchronize access to this method.
+     * @algorithm Uses binary search to efficiently find the first adjacent cell greater than the
+     *            specified cell.
+     * @optimization Avoids unnecessary recalculations by leveraging the existing
+     *               {@link #findFirstTrueAdjacents(ValueFormat) findFirstTrueAdjacents()} method and
+     *               reusing its result. Uses binary search for efficient searching in the small
+     *               adjacency array.
+     * @see #findAdjacents(short)
+     * @see #findFirstTrueAdjacents(ValueFormat)
+     * @see #findFirstTrueCell()
      */
-    public short[] findFirstTrueAdjacentsAfter(short cell, ValueFormat inputFormat, ValueFormat outputFormat) 
-    {
+    public short[] findFirstTrueAdjacentsAfter(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] firstTrueAdjacents = findFirstTrueAdjacents(inputFormat);
         if (firstTrueAdjacents == null) return null;
 
@@ -1226,14 +1595,45 @@ public abstract class Grid
     }
 
     /**
-     * Returns true if the click could possibly affect or create a new first true cell.
-     * - If there are no true cells, any click can create one.
-     * - If the first true cell is the top-left cell (0,0), only its adjacents can affect it.
-     * - If the click is before or equal to the first true cell (by packed int order), it can create a new one.
-     * - If the click is adjacent to the first true cell, it can affect it.
+     * Determines if a click on a specified cell can affect or create a new first true cell in the grid.
+     * 
+     * <p>
+     * Since the solution must toggle the first true cell in the initial grid state, we can optimize our
+     * search for the solution by pruning combinations whose first click cannot affect or create a new
+     * first true cell. This method provides the logic to determine that.
+     * </p>
+     * 
+     * <p>
+     * There are several scenarios that this program considers:
+     * <ul>
+     * <li>If there are no true cells, any click can create one. In the context of our solver, we
+     * shouldn't see this case happen too often, but it's included for short-circuiting purposes.</li>
+     * <li>If the first true cell is the top-left cell (0,0), only its adjacents can affect it.</li>
+     * <li>If the click is before or equal to the first true cell, it can create a new one.</li>
+     * <li>If the click is adjacent to the first true cell, it can affect it.</li>
+     * </ul>
+     * If none of these conditions are met, the click cannot affect or create a new first true cell.
+     * </p>
+     * 
+     * @param firstTrueCell the first true cell in the specified format.
+     * @param clickCell     the cell to be clicked, in the specified format.
+     * @param format        the {@link ValueFormat format} of both cells ({@link ValueFormat#Index
+     *                      Index} or {@link ValueFormat#PackedInt PackedInt}).
+     * @return <code>true</code> if the click can affect or create a new first true cell,
+     *         <code>false</code> otherwise.
+     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask} (since
+     *                                  bitmasks aren't supported for single values) or another
+     *                                  unsupported format.
+     * @since 2025.07.16 - Format Support and Adjacency Optimizations
+     * @performance O(1) checks for edge cases + O(1) conversion to index format if necessary + O(1)
+     *              binary search on a small, fixed-size array of adjacents = O(1) complexity.
+     * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
+     * @optimization Short-circuits for edge cases and uses binary search for adjacency checks.
+     * @see #areAdjacent(short cellA, short cellB, ValueFormat format)
+     * @see #findAdjacents(short cell, ValueFormat format)
+     * @see #findFirstTrueCell(ValueFormat format)
      */
-    public static boolean canAffectFirstTrueCell(short firstTrueCell, short clickCell, ValueFormat format) 
-    {
+    public static boolean canAffectFirstTrueCell(short firstTrueCell, short clickCell, ValueFormat format) {
         if (firstTrueCell == -1) return true; // No true cells, any click can create one
         if (clickCell <= firstTrueCell) return true; // packed int order: row * 100 + col
 
@@ -1300,8 +1700,48 @@ public abstract class Grid
         return false; // Click cell is not adjacent to the first true cell
     }
 
-    public static boolean areAdjacent(short cellA, short cellB, ValueFormat format) 
-    {
+    /**
+     * Determines if two cells are adjacent to each other in the grid. Leverages the pre-computed
+     * {@link #ADJACENCY_CACHE adjacency cache} for O(1) lookups.
+     * 
+     * <p>
+     * Two cells are considered adjacent if they share a common edge or vertex. In a hexagonal grid,
+     * each cell can have up to 6 adjacent cells, depending on its position in the grid. Since clicks
+     * only affect adjacent cells, we rely on adjacency calculations to optimize our search for the
+     * solution to a state, factoring these calculations into much of our logic. Therefore, we need a
+     * public facing method to quickly determine adjacency between any two cells. This method fills that
+     * role.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method performs O(1) lookups in a pre-computed adjacency cache, making it extremely fast.
+     * The overhead of converting between formats is likely larger than the lookup itself, so this
+     * method should be used judiciously in performance-critical paths compared to something like
+     * {@link #areAdjacent(short, short)}.
+     * </p>
+     * 
+     * @param cellA  the first cell to check, in the specified format.
+     * @param cellB  the second cell to check, in the specified format.
+     * @param format the {@link ValueFormat format} of both cells ({@link ValueFormat#Index Index} or
+     *               {@link ValueFormat#PackedInt PackedInt}).
+     * @return <code>true</code> if the cells are adjacent, <code>false</code> otherwise.
+     * @throws IllegalArgumentException       if the format is {@link ValueFormat#Bitmask Bitmask}
+     *                                        (since bitmasks aren't supported for single values) or
+     *                                        another unsupported format.
+     * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
+     *                                        array access).
+     * @since 2025.07.16 - Format Support and Adjacency Optimizations
+     * @performance O(1) conversion to index format if necessary + O(1) lookup in the adjacency cache =
+     *              O(1) complexity.
+     * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
+     * @optimization Uses a pre-computed adjacency cache for fast lookups. Short-circuits for
+     *               unsupported formats.
+     * @see #ADJACENCY_CACHE
+     * @see #areAdjacent(short, short)
+     * @see #canAffectFirstTrueCell(short, short, ValueFormat)
+     */
+    public static boolean areAdjacent(short cellA, short cellB, ValueFormat format) {
         // Convert both cells to index format if necessary
         switch (format)
         {

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -44,7 +44,7 @@ public abstract class Grid
     /**
      * The number of rows in the grid. This is a constant value of 7, as the grid is defined to have 7 rows.
      * 
-     * <h2>Performance Characteristics</h2>
+     * <h3>Performance Characteristics</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -66,7 +66,7 @@ public abstract class Grid
      * The number of columns in odd-indexed rows of the grid. This is a constant value of 15, as defined
      * by the grid's structure.
      * 
-     * <h2>Performance Characteristics</h2>
+     * <h3>Performance Characteristics</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -88,7 +88,7 @@ public abstract class Grid
      * The number of columns in even-indexed rows of the grid. This is a constant value of 16, as
      * defined by the grid's structure.
      * 
-     * <h2>Performance Characteristics</h2>
+     * <h3>Performance Characteristics</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -117,7 +117,7 @@ public abstract class Grid
      * between these two formats, allowing us to convert between them without losing information.
      * </p>
      * 
-     * <h2>Performance Characteristics</h2>
+     * <h3>Performance Characteristics</h3>
      * <p>
      * Lookup time for the offsets is O(1) since they are stored in a static array. Testing has shown
      * that using a static array is more efficient than calculating the offsets at runtime, at least for
@@ -145,7 +145,7 @@ public abstract class Grid
      * 109 cells.
      * </p>
      * 
-     * <h2>Performance Characteristics</h2>
+     * <h3>Performance Characteristics</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -24,7 +24,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>2/50 - 4% of documentation completed</h3>
+ * <h3>5/50 - 10% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]
@@ -258,17 +258,77 @@ public abstract class Grid
     abstract void initialize();
 
     // Core bitmask operations
-    protected void setBit(int index)
-    {
+
+    /**
+     * Sets the bit at the specified index in the {@link #gridState grid state}. We assume that the
+     * index is in {@link ValueFormat#Index Index} format (0-108) to save time on format checks.
+     * 
+     * <p>
+     * While this method can be used to toggle a cell in the grid, we pre-compute {@link #ADJACENCY_MASKS 
+     * adjacency masks} for each cell to perform clicks more efficiently. As such, this method is not 
+     * used in any method of the codebase.
+     * </p>
+     * 
+     * <h2>Performance Considerations</h2>
+     * <p>
+     * For performance reasons, this method does not perform bounds checking on the index. It is the
+     * caller's responsibility to ensure that the index is within the valid range (0-108).
+     * </p>
+     * <p>
+     * This method checks internally if the bit is already set before setting it, but this move is not
+     * necessary for performance. Removing the check would be more efficient, but we don't utilize this
+     * method for any performance-critical paths.
+     * </p>
+     * 
+     * @param index The index of the bit to set (0-108).
+     * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
+     * @since 2025.07.13 - Bitmasked Grid state
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) lookup time in the gridState array + O(1) bitwise operation to set the bit =
+     *              O(1) complexity.
+     * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
+     * @see {@link #getBit(int index)} - Method to get a bit from the grid state, the "getter".
+     * @see {@link #clearBit(int index)} - Method to clear a bit in the grid state, the opposite of this
+     *      method.
+     */
+    protected void setBit(int index) {
         int longIndex = index / 64;
         int bitPosition = index % 64;
-        if ((gridState[longIndex] & (1L << bitPosition)) == 0)
-        {
+        if ((gridState[longIndex] & (1L << bitPosition)) == 0) {
             gridState[longIndex] |= (1L << bitPosition);
             trueCellsCount++;
         }
     }
 
+    /**
+     * Clears the bit at the specified index in the {@link #gridState grid state}. We assume that the
+     * index is in {@link ValueFormat#Index Index} format (0-108) to save time on format checks.
+     * 
+     * <p>
+     * While this method can be used to clear a cell in the grid, we pre-compute {@link #ADJACENCY_MASKS
+     * adjacency masks} for each cell to perform clicks more efficiently. As such, this method is not
+     * used in any method of the codebase.
+     * </p>
+     * 
+     * <h2>Performance Considerations</h2>
+     * <p>
+     * For performance reasons, this method does not perform bounds checking on the index. It is the
+     * caller's responsibility to ensure that the index is within the valid range (0-108).
+     * </p>
+     * 
+     * @param index The index of the bit to clear (0-108).
+     * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
+     * @since 2025.07.13 - Bitmasked Grid state
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) lookup time in the gridState array + O(1) bitwise operation to clear the bit =
+     *              O(1) complexity.
+     * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
+     * @see {@link #getBit(int index)} - Method to get a bit from the grid state, the "getter".
+     * @see {@link #setBit(int index)} - Method to set a bit in the grid state, the opposite of this
+     *      method.
+     **/
     protected void clearBit(int index)
     {
         int longIndex = index / 64;
@@ -280,8 +340,35 @@ public abstract class Grid
         }
     }
 
-    protected boolean getBit(int index)
-    {
+    /**
+     * Extracts the bit at the specified index from the {@link #gridState grid state}. We assume that
+     * the index is in {@link ValueFormat#Index Index} format (0-108) to save time on format checks.
+     * 
+     * <p>
+     * This method is used to check if a specific cell in the grid is "true" (active) or "false"
+     * (inactive). We internally use this method for finding true cells in the grid, which is crucial
+     * for {@link #findTrueCells() outputting a list of true cells} or {@link #printGrid() printing the
+     * grid state.}
+     * </p>
+     * 
+     * <h2>Performance Considerations</h2>
+     * <p>
+     * For performance reasons, this method does not perform bounds checking on the index. It is the
+     * caller's responsibility to ensure that the index is within the valid range (0-108).
+     * </p>
+     * 
+     * @param index The index of the bit to check (0-108).
+     * @return true if the bit is set, false otherwise.
+     * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
+     * @since 2025.07.13 - Bitmasked Grid state
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) lookup time for the proper <code>long</code> in the gridState array.
+     * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
+     * @see {@link #setBit(int index)} - Method to set a bit in the grid state, the "setter".
+     * @see {@link #clearBit(int index)} - Method to clear a bit in the grid state, the "clearer".
+     */
+    protected boolean getBit(int index) {
         int longIndex = index / 64;
         int bitPosition = index % 64;
         return (gridState[longIndex] & (1L << bitPosition)) != 0;
@@ -480,7 +567,9 @@ public abstract class Grid
      * </p>
      * 
      * @param cell The cell to click, in Index format (0-108).
-     * @throws IllegalArgumentException if the cell is out of bounds (implicitly checked by the array accesses.
+     * @throws IllegalArgumentException if the cell is out of bounds (implicitly checked by the array
+     *                                  accesses).
+     * @since 2025.07.19 - Inlining Improvements
      * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
      *            instances of Grid or synchronize access to this method.
      * @performance Two O(1) click operations using pre-computed adjacency bitmasks = O(1) complexity.
@@ -491,8 +580,8 @@ public abstract class Grid
      * @see {@link #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)} -
      *      Computes the adjacent cells for a given cell, overloaded for different input and output
      *      formats. Used internally to generate the masks used in this method.
-     * @see {@link #areAdjacent(short cellA, short cellB, ValueFormat format)} - Checks if two cells are adjacent in the
-     *      grid.
+     * @see {@link #areAdjacent(short cellA, short cellB, ValueFormat format)} - Checks if two cells are
+     *      adjacent in the grid.
      * @deprecated As of 2025.07.28, replaced by {@link #click(short[] cells)} for bulk operations on
      *             combinations in {@link TestClickCombination monkeys}.
      */
@@ -576,6 +665,8 @@ public abstract class Grid
      *                                  accesses).
      * @throws NullPointerException     if the cells array is null (implicitly thrown by the for-each
      *                                  loop).
+     * @since 2025.07.28 - Bulk Clicks
+     * 
      * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
      *            instances of Grid or synchronize access to this method.
      * @performance O(n) loop * (2 O(1) bitwise operations per cell) = O(n) complexity, where n is the

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -454,7 +454,7 @@ public abstract class Grid
 
     /**
      * Simulates a click on the <code>Grid</code> at the specified cell. We assume that the cell is in
-     * {@link #ValueFormat.Index <code>Index</code>} format (0-108) to save time on format checks.
+     * {@link ValueFormat#Index <code>Index</code>} format (0-108) to save time on format checks.
      * 
      * <p>
      * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
@@ -538,7 +538,7 @@ public abstract class Grid
 
     /**
      * Simulates a click on multiple cells in the <code>Grid</code>. We assume that the cells are in the
-     * {@link #ValueFormat.Index <code>Index</code>} format (0-108) and the array is non-null to save on
+     * {@link ValueFormat#Index <code>Index</code>} format (0-108) and the array is non-null to save on
      * format checks.
      * 
      * <p>

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -8,102 +8,98 @@ import it.unimi.dsi.fastutil.shorts.ShortIterator;
 import it.unimi.dsi.fastutil.shorts.ShortList;
 
 /**
- * Grid - Abstract class representing our hexagonal Lights Out grid.
- * 
+ * Represents the core hexagonal grid for a "Lights Out" style puzzle.
+ *
  * <p>
- * Our puzzle is a hexagonal grid of lights, where each light can be either on or off. Clicking a
- * cell flips the state of that cell and its adjacent cells, with the goal of the puzzle being to
- * turn off all the lights. Building a high-performance solver for this puzzle requires an efficient
- * representation of the grid and fast operations for clicking cells and checking the grid state.
- * This class aims to provide that functionality.
+ * This abstract class provides a high-performance, bitmask-based representation of a 109-cell
+ * hexagonal grid. It is designed for a specific variant of the puzzle where clicking a cell toggles
+ * the state of its <strong>adjacent cells only</strong>, not the cell itself. The primary goal is to turn
+ * off all the lights on the grid.
  * </p>
- * 
- * <h2>Static Initialization</h2>
- * <p>
- * A key component to the performance of this class and its methods is the static initialization
- * block, which pre-computes adjacency masks and arrays for each cell in the grid, allowing for O(1)
- * lookups during runtime. This block is executed once when the class is loaded, allowing each
- * instance of the Grid to share the benefits without incurring the cost repeatedly.
- * </p>
- * 
- * <p>
- * The static block consists of a for loop that iterates across each cell in the grid (0-108 in
- * {@link ValueFormat#Index Index} format). For each cell, it
- * {@link #computeAdjacents(short, ValueFormat, ValueFormat) computes the adjacent cells} as a
- * {@link ShortList}, which then gets converted to a short array and stored in the
- * {@link #adjacencyArray adjacency array} for use in the
- * {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
- * {@link #ADJACENCY_CACHE A 2D table} is created from this data, allowing for easy adjacency checks
- * between two values. We also build a bitmask that provides another form of adjacency
- * representation, storing it in the {@link #ADJACENCY_MASKS adjacency masks} array for use in the
- * {@link #click(short, ValueFormat) click()} method. Finally, we populate
- * {@link #PACKED_TO_INDEX_CACHE a cache} for {@link ValueFormat#PackedInt PackedInt} to
- * {@link ValueFormat#Index Index} conversions. All of these structures are then statically assigned
- * as the block moves to the next cell.
- * </p>
- * 
+ *
  * <h2>Architecture Role</h2>
  * <p>
- * The Grid class serves as the foundational representation of the puzzle's state and operations,
- * providing the infrastructure for efficient manipulation and querying of the grid. It is designed
- * to be extended by concrete implementations that define specific {@link #gridState initial states}
- * and {@link #initialize() initialization procedures} for each puzzle (e.x. Q13, Q22, and Q35).
+ * As the foundational data structure, {@code Grid} defines the puzzle's state and core
+ * operations. It is extended by concrete implementations such as {@link Grid13}, {@link Grid22},
+ * and {@link Grid35}, which provide specific initial puzzle configurations.
  * </p>
- * 
+ *
  * <p>
- * {@link TestClickCombination Monkeys} utilize this class to test various click combinations, with
- * each receiving its own instance of a Grid to operate on. However, re-initializing the grid state
- * can be costly, so it is recommended to prune combinations before testing against the grid.
- * {@link CombinationGeneratorTask Generators} are designed to produce combinations efficiently and
- * thus perform light checks before passing them to the monkeys, limiting the interactions they have
- * with this class. This separation of concerns allows for a more focused codebase and clarifies
- * areas of bottlenecks; optimizing this class will primarily benefit the monkeys rather than the
- * generators.
+ * {@link TestClickCombination Worker threads ("monkeys")} interact with cloned instances of this
+ * class to test solutions. In contrast, {@link CombinationGeneratorTask generators} perform lighter,
+ * more frequent checks and have limited direct interaction with this class. This separation ensures
+ * that optimizations to this class primarily benefit the state-intensive work of the monkeys.
  * </p>
- * 
+ *
  * <h2>Performance Characteristics</h2>
  * <p>
- * We aim for O(1) complexity for core operations like {@link #click(short, ValueFormat) clicking a
- * cell} and {@link #isSolved() checking for the solved state}, with most of the complexity hidden
- * in the static initialization block. Due to the nature of objects in Java (which allocate on the
- * heap rather than the stack), primitive types and arrays are used wherever possible to minimize
- * overhead, with bitmasks allowing for compact storage and fast operations. Sadly, Java lacks a
- * native 128-bit primitive type, making every operation on our 109-cell grid require 2
- * modifications or polls rather than 1. The Vector API seemed promising, but it allocates terribly
- * (4 allocations per lanewise operation), incurring massive overhead. {@link java.util.BitSet
- * BitSets} were considered, but they incur unnecessary overhead in terms of object headers, making
- * them less efficient than our custom bitmask approach.
+ * The grid state is stored in a {@code long[2]} array, treated as a 128-bit bitmask to represent
+ * the 109 cells. This approach minimizes memory footprint and allows for extremely fast state
+ * manipulation using bitwise operations. Adjacency information is pre-computed into
+ * {@link #ADJACENCY_MASKS}, enabling {@code O(1)} complexity for the critical {@code click}
+ * operation.
  * </p>
- * 
+ *
  * <p>
- * Future optimizations could include exploring off-heap storage options or finding ways to densely
- * pack the grid state into a single primitive type, but these would require some heavy ingenuity.
- * Unless Project Valhalla magically gets released soon, we are likely nearing the limits of what
- * Java can do, potentially forcing us to look at other languages to push performance further.
+ * Several alternatives were evaluated:
  * </p>
- * 
+ * <ul>
+ *   <li><b>{@link java.util.BitSet}:</b> Incurs unacceptable overhead from object headers and indirect
+ *       memory access compared to a primitive array.</li>
+ *   <li><b>Panama/Vector API:</b> Showed promise for 128-bit operations but suffered from excessive
+ *       memory allocation (4+ allocations per lanewise operation in tested JDK versions), making it
+ *       unsuitable for the hot path.</li>
+ * </ul>
+ * The primitive {@code long[]} array was ultimately chosen as the most performant solution on the
+ * modern JVM, despite the complexity of managing two separate {@code long}s.
+ *
+ * <h2>Future Optimizations</h2>
+ * <p>
+ * Further performance gains are likely limited by the JVM itself. Potential avenues for
+ * exploration include off-heap memory storage or the availability of true 128-bit primitives
+ * in a future Java version (e.g., via Project Valhalla), which would simplify the bitmask logic to a
+ * single {@code long}.
+ * </p>
+ *
+ * <h2>Static Initialization</h2>
+ * <p>
+ * A key performance feature is the extensive use of a {@code static} initializer block. This block
+ * runs only once when the class is loaded and pre-computes several critical data structures:
+ * </p>
+ * <ul>
+ *   <li>{@link #ADJACENCY_MASKS}: Bitmasks for every cell, allowing a {@code click} to be a simple
+ *       XOR operation.</li>
+ *   <li>{@link #adjacencyArray}: A legacy structure providing adjacent cell indices for algorithms
+ *       that require iteration.</li>
+ *   <li>{@link #ADJACENCY_CACHE}: A boolean matrix for {@code O(1)} adjacency checks between any two
+ *       cells.</li>
+ *   <li>{@link #PACKED_TO_INDEX_CACHE}: A lookup table for fast conversion from human-readable
+ *       {@link ValueFormat#PackedInt} to the internal {@link ValueFormat#Index}.</li>
+ * </ul>
+ * This pre-computation offloads complex calculations from the performance-critical runtime paths.
+ *
  * <h2>Thread Safety</h2>
  * <p>
- * This class is <b>not</b> thread-safe. Each instance of a Grid should only be accessed from a
- * single thread or with proper synchronization. The static members are immutable after
- * initialization and are thus safe to share across threads, but instance members like
- * {@link #click(long[])} and {@link #gridState} could have weird side effects if accessed
- * concurrently. We trade off thread-safety and potentially lower memory usage for performance, as
- * avoiding synchronization and locks allows for faster operations in the hot path.
+ * This class is <strong>not</strong> thread-safe. Each instance is designed to be used by a single
+ * thread. State-modifying methods like {@link #click(short)} are unsynchronized to maximize
+ * performance. Static members are effectively immutable after initialization and are safe to be
+ * shared across threads.
  * </p>
- * 
- * @since 2025.03.20 - Initial creation
- * @performance Core operations like clicking a cell and checking for the solved state are designed
- *              to be O(1), with most of the complexity hidden in the static initialization block.
- *              Some other methods may have O(n) complexity or worse, but these are designed to be
- *              called infrequently.
- * @threading This class is <b>not</b> thread-safe. Each instance should only be accessed from a
- *            single thread or with proper synchronization.
- * @algorithm Iterates across each cell in the grid during static initialization, pre-computing
- *            adjacency masks and arrays for O(1) lookups during runtime. Use bitmasks and bitwise
- *            operations to efficiently represent and manipulate the grid state.
- * @see #gridState
+ *
+ * @see CombinationGeneratorTask
+ * @see Grid13
+ * @see Grid22
+ * @see Grid35
  * @see TestClickCombination
+ * @since 2025.03 - Initial Creation
+ * @performance Critical operations like {@link #click(short)} and state checks are {@code O(1)} due to
+ *              extensive pre-computation. The majority of computational complexity is handled once in
+ *              a static initializer.
+ * @threading Not thread-safe. Instances of {@code Grid} must not be shared between threads without
+ *            external synchronization.
+ * @algorithm Uses a bitmask ({@code long[2]}) to represent the grid state. Clicks are performed
+ *            using pre-computed adjacency masks and bitwise XOR operations. Adjacency lookups and
+ *            format conversions are accelerated by statically initialized caches.
  */
 public abstract class Grid {
     /**
@@ -126,10 +122,11 @@ public abstract class Grid {
      * relevant methods accordingly, improving maintainability.
      * </p>
      * 
-     * @since 2025.07.16 - ValueFormat Enum Introduction
-     * @threading This enum is immutable and safe to use across threads.
-     * @performance O(1) access time, as enum values are constants.
-     * @optimization Using an enum to avoid magic numbers and improve code clarity and maintainability.
+     * @since 2025.07 - ValueFormat Enum Introduction
+     * @performance {@code O(1)} access time.
+     * @threading This enum is immutable and therefore thread-safe.
+     * @optimization Using an enum improves code clarity and maintainability by avoiding "magic numbers" for
+     *               format types.
      */
     public enum ValueFormat {
         /**
@@ -165,13 +162,14 @@ public abstract class Grid {
          * However, we avoid using it in performance-critical paths where efficiency is paramount.
          * </p>
          * 
-         * @since 2025.07.16 - ValueFormat Enum Introduction
-         * @threading This enum value is immutable and safe to use across threads.
-         * @performance O(1) access time, as enum values are constants.
-         * @optimization The codebase adopts this format for human-readable outputs and clarity in certain
-         *               operations, while avoiding it in performance-critical paths.
-         * @see #packedToIndex(short)
          * @see #indexToPacked(short)
+         * @see #packedToIndex(short)
+         * @since 2025.07 - ValueFormat Enum Introduction
+         * @performance {@code O(1)} access time.
+         * @threading This enum value is an immutable constant and is thread-safe.
+         * @optimization This format is used for human-readable output and for clarity in adjacency
+         *               calculations. It is avoided in performance-critical paths, which prefer the
+         *               {@link #Index} format.
          */
         PackedInt,
         /**
@@ -195,13 +193,13 @@ public abstract class Grid {
          * Bitmask} format instead, as it can allow for operations in parallel.
          * </p>
          * 
-         * @since 2025.07.16 - ValueFormat Enum Introduction
-         * @threading This enum value is immutable and safe to use across threads.
-         * @performance O(1) access time, as enum values are constants.
-         * @optimization The codebase adopts this format for memory efficiency and ease of use in
-         *               generators, while avoiding it in operations that benefit from parallelism.
-         * @see #packedToIndex(short)
          * @see #indexToPacked(short)
+         * @see #packedToIndex(short)
+         * @since 2025.07 - ValueFormat Enum Introduction
+         * @performance {@code O(1)} access time.
+         * @threading This enum value is an immutable constant and is thread-safe.
+         * @optimization This format provides a compact, efficient representation for iterating through cells,
+         *               making it ideal for generator tasks.
          */
         Index,
         /**
@@ -234,17 +232,17 @@ public abstract class Grid {
          * very long click combinations.
          * </p>
          * 
-         * @since 2025.07.16 - Bitmask Enum Introduction
-         * @threading This enum value is immutable and safe to use across threads.
-         * @performance O(1) access time, as enum values are constants.
-         * @optimization The codebase avoids using this format frequently due to its complexity and the lack
-         *               of a native 128-bit primitive type in Java, which would be ideal for our grid
-         *               representation.
          * @see #gridState
+         * @see #clearBit(int)
          * @see #click(long[])
          * @see #getBit(int)
          * @see #setBit(int)
-         * @see #clearBit(int)
+         * @since 2025.07 - ValueFormat Enum Introduction
+         * @performance {@code O(1)} access time.
+         * @threading This enum value is an immutable constant and is thread-safe.
+         * @optimization This format is primarily for internal grid state representation and is not exposed in
+         *               most public methods due to its complexity and Java's lack of a native 128-bit
+         *               primitive type.
          */
         Bitmask
     }
@@ -259,15 +257,14 @@ public abstract class Grid {
      * of grid operations and ensuring that all methods operate within the valid range of rows.
      * </p>
      * 
-     * @since 2025.03.20 - Grid Definition
-     * @threading This constant is immutable and safe to use across threads.
-     * @performance O(1) access time, as it is a constant value.
-     * @optimization Using a constant to avoid recalculating the number of rows and to prevent magic
-     *              numbers in the code.
-     * @see #ROW_OFFSETS
-     * @see #NUM_CELLS
      * @see #EVEN_NUM_COLS
+     * @see #NUM_CELLS
      * @see #ODD_NUM_COLS
+     * @see #ROW_OFFSETS
+     * @since 2025.03 - Grid Definition
+     * @performance {@code O(1)} access time.
+     * @threading This constant is immutable and thread-safe.
+     * @optimization Using a named constant improves code clarity and maintainability.
      */
     public static final int NUM_ROWS = 7;
     /**
@@ -281,15 +278,14 @@ public abstract class Grid {
      * of grid operations and ensuring that all methods operate within the valid range of columns.
      * </p>
      * 
-     * @since 2025.03.20 - Grid Definition
-     * @threading This constant is immutable and safe to use across threads.
-     * @performance O(1) access time, as it is a constant value.
-     * @optimization Using a constant to avoid recalculating the number of columns and to prevent magic
-     *               numbers in the code.
-     * @see #ROW_OFFSETS
+     * @see #EVEN_NUM_COLS
      * @see #NUM_CELLS
      * @see #NUM_ROWS
-     * @see #EVEN_NUM_COLS
+     * @see #ROW_OFFSETS
+     * @since 2025.03 - Grid Definition
+     * @performance {@code O(1)} access time.
+     * @threading This constant is immutable and thread-safe.
+     * @optimization Using a named constant improves code clarity and maintainability.
      */
     public static final int ODD_NUM_COLS = 15;
     /**
@@ -303,15 +299,14 @@ public abstract class Grid {
      * of grid operations and ensuring that all methods operate within the valid range of columns.
      * </p>
      * 
-     * @since 2025.03.20 - Grid Definition
-     * @threading This constant is immutable and safe to use across threads.
-     * @performance O(1) access time, as it is a constant value.
-     * @optimization Using a constant to avoid recalculating the number of columns and to prevent magic
-     *               numbers in the code.
-     * @see #ROW_OFFSETS
      * @see #NUM_CELLS
      * @see #NUM_ROWS
      * @see #ODD_NUM_COLS
+     * @see #ROW_OFFSETS
+     * @since 2025.03 - Grid Definition
+     * @performance {@code O(1)} access time.
+     * @threading This constant is immutable and thread-safe.
+     * @optimization Using a named constant improves code clarity and maintainability.
      */
     public static final int EVEN_NUM_COLS = 16;
     /**
@@ -332,15 +327,15 @@ public abstract class Grid {
      * Packed -> Index conversions.
      * </p>
      * 
-     * @since 2025.06.04 - BitSet Grid state
-     * @threading This array is immutable after initialization and is safe to use across threads.
-     * @performance O(1) lookup time for offsets, as they are stored in a static array.
-     * @optimization Using a static array to avoid the overhead of runtime calculations.
-     * @see #NUM_ROWS
      * @see #EVEN_NUM_COLS
+     * @see #NUM_ROWS
      * @see #ODD_NUM_COLS
      * @see #computePackedToIndex(short)
      * @see ValueFormat
+     * @since 2025.06 - BitSet Grid State
+     * @performance {@code O(1)} lookup time.
+     * @threading This array is immutable after static initialization and is thread-safe.
+     * @optimization Using a pre-computed static array for conversions avoids runtime calculations.
      */
     public static final short[] ROW_OFFSETS = {0, 16, 31, 47, 62, 78, 93};
     /**
@@ -360,17 +355,16 @@ public abstract class Grid {
      * of grid operations and ensuring that all methods operate within the valid range of cells.
      * </p>
      * 
-     * @since 2025.04.15 - Static Block Initialization
-     * @threading This constant is immutable and safe to use across threads.
-     * @performance O(1) access time, as it is a constant value.
-     * @optimization Using a constant to avoid recalculating the number of cells and to prevent magic
-     *               numbers in the code.
-     * @see #ROW_OFFSETS
-     * @see #NUM_ROWS
      * @see #EVEN_NUM_COLS
-     * @see #ODD_NUM_COLS
      * @see #gridState
+     * @see #NUM_ROWS
+     * @see #ODD_NUM_COLS
+     * @see #ROW_OFFSETS
      * @see #trueCellsCount
+     * @since 2025.04 - Static Block Initialization
+     * @performance {@code O(1)} access time.
+     * @threading This constant is immutable and thread-safe.
+     * @optimization Using a named constant improves code clarity and maintainability.
      */
     public static final int NUM_CELLS = 109;
 
@@ -415,17 +409,16 @@ public abstract class Grid {
      * can represent a 128-bit value without allocations, we will stick with this approach.
      * </p>
      * 
-     * @since 2025.07.13 - Bitmasked Grid state
-     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) lookup time for each 64-bit long in the gridState array and O(1) bitwise operations
-     * @optimization Uses a primitive bitmask of longs to represent the grid state, allowing for fast access and
-     *              manipulation of each cell while keeping memory usage low. 
+     * @see #clearBit(int)
+     * @see #getBit(int)
      * @see #getGridState()
      * @see #printGrid()
-     * @see #getBit(int index)
-     * @see #setBit(int index)
-     * @see #clearBit(int index)
+     * @see #setBit(int)
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} access and update time.
+     * @threading Not thread-safe. Access must be synchronized externally.
+     * @optimization Uses a primitive {@code long[]} bitmask to avoid object allocation overhead, enabling
+     *               extremely fast, cache-friendly state manipulation via bitwise operations.
      */
     protected final long[] gridState = new long[2];
     /**
@@ -433,15 +426,14 @@ public abstract class Grid {
      * {@link #isSolved() solution checks} and to optimize certain operations. Updated whenever
      * {@link #getTrueCount()} is called and {@link #recalculationNeeded} is <code>true</code>.
      * 
-     * @since 2025.07.13 - Bitmasked Grid state
-     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) access time when up to date (and O(1) updates, since
-     *              {@link java.lang.Long#bitCount(long) Long.bitCount()} is O(1))
-     * @optimization Caches the count of true cells to avoid recalculating it on every check, improving
-     *               performance for operations that frequently check the solved state.
      * @see #getTrueCount()
      * @see #isSolved()
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} access. The value is updated lazily.
+     * @threading Not thread-safe. This field is mutated by {@link #click(short)} and read by
+     *            {@link #getTrueCount()}.
+     * @optimization Caches the number of "on" cells to make {@link #isSolved()} checks instantaneous. The
+     *               count is recalculated only when necessary, controlled by {@link #recalculationNeeded}.
      */
     protected int trueCellsCount = 0;
     /**
@@ -450,14 +442,14 @@ public abstract class Grid {
      * certain operations. Updated whenever {@link #findFirstTrueCell(ValueFormat)} is called and
      * {@link #recalculationNeeded} is <code>true</code>.
      * 
-     * @since 2025.07.16 - First True Cell Caching
-     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) access time when up to date, and O(n) updates in the worst case (where n is the
-     *              {@link #NUM_CELLS number of cells in the grid}).
-     * @optimization Caches the index of the first true cell to avoid scanning the entire grid on every
-     *               check, improving performance for operations that frequently need this information.
      * @see #findFirstTrueCell()
+     * @since 2025.07 - First True Cell Caching
+     * @performance {@code O(1)} access. The value is updated lazily.
+     * @threading Not thread-safe. This field is mutated by {@link #click(short)} and read by
+     *            {@link #findFirstTrueCell()}.
+     * @optimization Caches the index of the first "on" cell, a critical optimization for pruning the
+     *               search space in the generator. Recalculated only when needed via
+     *               {@link #recalculationNeeded}.
      */
     protected short firstTrueCell = -1;
     /**
@@ -466,14 +458,14 @@ public abstract class Grid {
      * (e.g., via a click operation) and reset to <code>false</code> after the next call to
      * {@link #getTrueCount()} or {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()}.
      * 
-     * @since 2025.07.13 - Bitmasked Grid state
-     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) access and update time, as it is a simple boolean flag.
-     * @optimization Uses a boolean flag to track whether recalculation is needed, avoiding unnecessary
-     *               recalculations.
      * @see #firstTrueCell
      * @see #trueCellsCount
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} access.
+     * @threading Not thread-safe. This flag coordinates lazy recalculations.
+     * @optimization Implements a lazy evaluation strategy for {@link #trueCellsCount} and
+     *               {@link #firstTrueCell}, ensuring that expensive recalculations are only performed
+     *               when the state has been modified.
      */
     protected boolean recalculationNeeded = false;
 
@@ -498,15 +490,14 @@ public abstract class Grid {
      * fields in this class.
      * </p>
      * 
-     * @since 2025.04.15 - Static Block Initialization
-     * @threading This array is initialized in a static block and is immutable after that point.
-     * @performance O(1) lookup time for adjacency masks, as they are pre-computed and stored in a
-     *              static array.
-     * @optimization Uses a static array to avoid the overhead of runtime calculations. Standardized to
-     *               use the {@link ValueFormat#Index Index} format and to use 2 longs per cell for
-     *               consistency and simplicity.
      * @see #NUM_CELLS
-     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @since 2025.04 - Static Block Initialization
+     * @performance {@code O(1)} lookup time.
+     * @threading This array is immutable after static initialization and is thread-safe.
+     * @optimization Pre-computing adjacency masks is the core optimization that makes {@link #click(short)} an
+     *               {@code O(1)} operation. Each mask represents the bitwise change required to toggle all
+     *               cells adjacent to a given cell.
      */
     private static final long[][] ADJACENCY_MASKS = new long[NUM_CELLS][2];
     
@@ -526,14 +517,13 @@ public abstract class Grid {
      * the {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
      * </p>
      * 
-     * @since 2025.05.29 - HashSet -> Array for Adjacency Storage
-     * @threading This array is initialized in a static block and is immutable after that point.
-     * @performance O(1) lookup time for adjacency arrays, as they are pre-computed and stored in a
-     *              static array.
-     * @optimization Uses a static array to avoid the overhead of runtime calculations. Standardized to
-     *               use the {@link ValueFormat#Index Index} format for consistency.
      * @see #NUM_CELLS
-     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @since 2025.05 - Adjacency Storage Optimization
+     * @performance {@code O(1)} lookup time.
+     * @threading This array is immutable after static initialization and is thread-safe.
+     * @optimization Pre-computing adjacency lists in this array allows the {@link #findAdjacents} methods to
+     *               be fast lookups rather than expensive computations.
      */
     private static final short[][] adjacencyArray = new short[NUM_CELLS][]; // Index format
     /**
@@ -551,13 +541,13 @@ public abstract class Grid {
      * operations.
      * </p>
      * 
-     * @since 2025.06.25 - O(1) areAdjacent() checks
-     * @threading This array is initialized in a static block and is immutable after that point.
-     * @performance O(1) lookup time for adjacency checks, as it is a pre-computed 2D array.
-     * @optimization Uses a static 2D array to avoid the overhead of runtime calculations. Standardized to
-     *               use the {@link ValueFormat#Index Index} format for consistency.
      * @see #NUM_CELLS
-     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @since 2025.06 - O(1) Adjacency Check
+     * @performance {@code O(1)} lookup time.
+     * @threading This array is immutable after static initialization and is thread-safe.
+     * @optimization A pre-computed boolean matrix that provides a near-instantaneous way to check if two
+     *               cells are adjacent, used by {@link #areAdjacent(short, short)}.
      */
     private static final boolean[][] ADJACENCY_CACHE = new boolean[NUM_CELLS][NUM_CELLS]; // Index format
     /**
@@ -574,15 +564,14 @@ public abstract class Grid {
      * calculations.
      * </p>
      * 
-     * @since 2025.06.15 - PackedInt -> Index Precomputation
-     * @threading This array is initialized in a static block and is immutable after that point.
-     * @performance O(1) lookup time for PackedInt to Index conversions, as it is a pre-computed
-     *              array.
-     * @optimization Uses a static array to avoid the overhead of runtime calculations. Standardized to
-     *               use the {@link ValueFormat#Index Index} format for consistency.
      * @see #NUM_CELLS
      * @see #computePackedToIndex(short)
      * @see ValueFormat
+     * @since 2025.06 - PackedInt to Index Precomputation
+     * @performance {@code O(1)} lookup time.
+     * @threading This array is immutable after static initialization and is thread-safe.
+     * @optimization A cache to accelerate the conversion from the human-readable {@link ValueFormat#PackedInt}
+     *               format to the performance-oriented {@link ValueFormat#Index} format.
      */
     private static final short[] PACKED_TO_INDEX_CACHE = new short[(NUM_ROWS - 1) * 100 + EVEN_NUM_COLS];
 
@@ -678,21 +667,16 @@ public abstract class Grid {
      *         up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
-     * @since 2025.07.16 - Format Support
-     * @performance If outputFormat is <code>PackedInt</code>, O(1) input conversion (if necessary) + 6
-     *              * O(1) adjacency computation + O(6) output filtering = O(1) complexity.
-     * @performance If outputFormat is <code>Index</code>, O(1) input conversion (if necessary) + 6 *
-     *              O(1) adjacency computation + O(6) output filtering + O(n) conversion to index format
-     *              (where n is fixed as 6 or less) = O(1) complexity.
-     * @threading This method is thread-safe, as it does not modify any instance or static state.
-     * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
-     *         required for <code>ArrayList</code>s and allowing for easy conversion to a properly-sized
-     *         short array.
-     * @optimization Using a <code>ShortList</code> avoids the need for counting the number of valid
-     *               adjacent cells before initializing a presized array and avoids the boxing overhead
-     *               associated with <code>ArrayList</code>s.
      * @see #findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
      * @see ShortList
+     * @since 2025.07 - Format Support
+     * @performance Overall {@code O(1)} complexity. The number of adjacent cells is small and constant.
+     * @threading This method is thread-safe as it is a pure function with no side effects.
+     * @memory Uses a {@code ShortList} from FastUtil to avoid boxing primitive {@code short} values,
+     *         reducing garbage collection pressure compared to a standard {@code ArrayList<Short>}.
+     * @optimization Internal calculations are performed in {@link ValueFormat#PackedInt} for simpler
+     *               arithmetic. The use of {@code ShortList} avoids an initial pass to count valid
+     *               neighbors before creating a perfectly sized array.
      */
     public static ShortList computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         ShortList affectedPieces = new ShortArrayList(6);
@@ -765,18 +749,13 @@ public abstract class Grid {
      *         items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) input conversion (if necessary) + 6 * O(1) adjacency computation + O(6) output
-     *              filtering = O(1) complexity.
-     * @threading This method is thread-safe, as it does not modify any instance or static state.
-     * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
-     *         required for <code>ArrayList</code>s and allowing for efficient storage and retrieval of
-     *         short values.
-     * @optimization Using a <code>ShortList</code> avoids the need for counting the number of valid
-     *               adjacent cells before initializing a presized array and avoids the boxing overhead
-     *               associated with <code>ArrayList</code>s.
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @see ShortList
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity. Delegates to the main implementation.
+     * @threading This method is thread-safe.
+     * @memory Creates a new {@code ShortList} for the result.
+     * @optimization Convenience overload.
      */
     public static ShortList computeAdjacents(short cell, ValueFormat format) {
         return computeAdjacents(cell, format, format);
@@ -793,18 +772,13 @@ public abstract class Grid {
      *         containing up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) input conversion (if necessary) + 6 * O(1) adjacency computation + O(6) output
-     *              filtering = O(1) complexity.
-     * @threading This method is thread-safe, as it does not modify any instance or static state.
-     * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
-     *         required for <code>ArrayList</code>s and allowing for efficient storage and retrieval of
-     *         short values.
-     * @optimization Using a <code>ShortList</code> avoids the need for counting the number of valid
-     *               adjacent cells before initializing a presized array and avoids the boxing overhead
-     *               associated with <code>ArrayList</code>s.
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @see ShortList
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity. Delegates to the main implementation.
+     * @threading This method is thread-safe.
+     * @memory Creates a new {@code ShortList} for the result.
+     * @optimization Convenience overload with default format.
      */
     public static ShortList computeAdjacents(short cell) {
         return computeAdjacents(cell, ValueFormat.Index);
@@ -848,18 +822,16 @@ public abstract class Grid {
      *                                        represent a single cell in that format.
      * @throws ArrayIndexOutOfBoundsException if the input cell is out of bounds for the specified input
      *                                        format (implicitly checked by array accesses).
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) input conversion (if necessary) + O(1) adjacency lookup {+ O(n) output
-     *              conversion (where n is fixed as 6 or less)} = O(1) for simplest case, O(n) worst
-     *              case complexity.
-     * @threading This method is thread-safe, since it only reads from static, immutable data.
-     * @memory Uses a fixed-size array to store the results, avoiding dynamic memory allocation and
-     *         temporary object creation.
-     * @optimization Uses a pre-computed adjacency array for fast lookups and minimizes memory usage by
-     *               using fixed-size arrays.
      * @see #adjacencyArray
      * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
      * @see ValueFormat
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} for {@link ValueFormat#Index} output, {@code O(k)} for other formats due to
+     *              conversion, where {@code k} is the number of adjacent cells (max 6).
+     * @threading This method is thread-safe, as it relies only on immutable, pre-computed static data.
+     * @memory Allocates a new {@code short[]} for the result only if format conversion is necessary.
+     * @optimization The primary lookup from {@link #adjacencyArray} is an {@code O(1)} operation. The main
+     *               performance consideration is the potential overhead of format conversion.
      */
     public static short[] findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] result;
@@ -912,16 +884,12 @@ public abstract class Grid {
      *         items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) input conversion (if necessary) + O(1) adjacency lookup {+ O(n) output
-     *              conversion (where n is fixed as 6 or less)} = O(1) for simplest case, O(n) worst
-     *              case complexity.
-     * @threading This method is thread-safe, since it only reads from static, immutable data.
-     * @memory Uses a fixed-size array to store the results, avoiding dynamic memory allocation and
-     *         temporary object creation.
-     * @optimization Uses a pre-computed adjacency array for fast lookups and minimizes memory usage by
-     *               using fixed-size arrays.
      * @see #findAdjacents(short)
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity. Delegates to the main implementation.
+     * @threading This method is thread-safe.
+     * @memory May allocate a new {@code short[]} if format conversion occurs.
+     * @optimization Convenience overload.
      */
     public static short[] findAdjacents(short cell, ValueFormat format) {
         return findAdjacents(cell, format, format);
@@ -938,14 +906,13 @@ public abstract class Grid {
      *         containing up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) adjacency lookup
-     * @threading This method is thread-safe, since it only reads from static, immutable data.
-     * @memory Uses a fixed-size array to store the results, avoiding dynamic memory allocation and
-     *         temporary object creation.
-     * @optimization Uses a pre-computed adjacency array for fast lookups and minimizes memory usage by
-     *               using fixed-size arrays.
      * @see #findAdjacents(short, ValueFormat)
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} adjacency lookup.
+     * @threading This method is thread-safe.
+     * @memory Returns a reference to a statically allocated array, avoiding new allocations.
+     * @optimization The most direct and efficient way to get adjacents, as no format conversion is
+     *               needed.
      */
     public static short[] findAdjacents(short cell) {
         return findAdjacents(cell, ValueFormat.Index);
@@ -986,12 +953,11 @@ public abstract class Grid {
      * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
      * @throws ArrayIndexOutOfBoundsException (implicitly) if the input packed value is out of bounds
      *                                   (less than 0 or greater than 615).
-     * @since 2025.06.15 - PackedInt → Index Precomputation
-     * @performance O(1) complexity due to a fixed number of arithmetic operations and array lookups.
-     * @threading This method is thread-safe, as it does not modify any instance or static state.
-     * @memory Uses a small, fixed-size array for row offsets and uses primitive types to avoid allocations.
-     * @optimization Uses a pre-defined array of row offsets to avoid repeated calculations, minimizing
-     *               memory usage by using primitive types and avoiding dynamic allocations.
+     * @since 2025.06 - PackedInt to Index Precomputation
+     * @performance {@code O(1)} complexity due to direct arithmetic and a single array lookup.
+     * @threading This method is thread-safe as it is a pure function.
+     * @memory Does not allocate memory.
+     * @optimization Relies on the pre-computed {@link #ROW_OFFSETS} for fast calculation.
      */
     private static short computePackedToIndex(short packed) {
         short row = (short) (packed / 100);
@@ -1027,17 +993,14 @@ public abstract class Grid {
      * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
      * @throws IllegalArgumentException if the input packed value is out of bounds (less than 0 or
      *                                  greater than 615).
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) lookup time in the cache + O(1) computation time for uncached values = O(1)
-     *              complexity.
-     * @threading This method is thread-safe, as it reads from an immutable static cache and writes to
-     *            it in a thread-safe manner.
-     * @memory Pulls from a static cache to minimize memory usage, preventing the need for dynamic
-     *         allocations.
-     * @optimization Uses a cache to speed up conversions for commonly used values, reducing the need
-     *               for repeated calculations.
      * @see #PACKED_TO_INDEX_CACHE
      * @see #computePackedToIndex(short)
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity due to direct cache lookup.
+     * @threading This method is thread-safe. The cache is populated statically.
+     * @memory Does not allocate memory.
+     * @optimization Provides an {@code O(1)} alternative to the arithmetic conversion. Declared
+     *               {@code final} to encourage JIT inlining.
      */
     public final static short packedToIndex(short packed) {
         if (packed >= 0 && packed < PACKED_TO_INDEX_CACHE.length) {
@@ -1076,14 +1039,13 @@ public abstract class Grid {
      *         format.
      * @throws IllegalArgumentException if the input index is out of bounds (less than 0 or greater than
      *                                  108).
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) complexity due to a fixed number of conditional checks.
-     * @threading This method is thread-safe, as it does not modify any shared state and only uses local
-     *            variables.
-     * @memory Uses only local variables, minimizing memory usage and avoiding dynamic allocations.
-     * @optimization Uses a series of conditional checks to quickly determine the correct row and column
-     *               for the given index, avoiding the need for complex calculations or data structures.
      * @see #packedToIndex(short)
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity. The series of comparisons is constant time.
+     * @threading This method is thread-safe as it is a pure function.
+     * @memory Does not allocate memory.
+     * @optimization A branch-based approach that is friendly to modern CPU branch predictors. Declared
+     *               {@code final} to encourage JIT inlining.
      */
     public final static short indexToPacked(short index) {
         if (index < 16) return  (short) (0 * 100 + index);
@@ -1106,9 +1068,9 @@ public abstract class Grid {
      * to define their own initial configurations.
      * </p>
      * 
-     * @since 2025.03.29 - Abstract Grid Introduction
-     * @threading Thread-safe since each call operates on a new instance.
      * @see #initialize()
+     * @since 2025.03 - Abstract Grid Introduction
+     * @threading The constructor is thread-safe as it operates on a new instance.
      */
     public Grid() {
         initialize();
@@ -1124,12 +1086,11 @@ public abstract class Grid {
      * this method will depend on the requirements of the subclass.
      * </p>
      * 
-     * @since 2025.03.29 - Abstract Grid Introduction
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
      * @see Grid13
      * @see Grid22
      * @see Grid35
+     * @since 2025.03 - Abstract Grid Introduction
+     * @threading Not thread-safe. This method modifies the instance's state.
      */
     abstract void initialize();
 
@@ -1158,14 +1119,13 @@ public abstract class Grid {
      * 
      * @param index The index of the bit to set (0-108).
      * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
-     * @since 2025.07.13 - Bitmasked Grid state
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) lookup time in the gridState array + O(1) bitwise operation to set the bit =
-     *              O(1) complexity.
-     * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
-     * @see #getBit(int index)
-     * @see #clearBit(int index)
+     * @see #clearBit(int)
+     * @see #getBit(int)
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization This is a low-level helper. For performance reasons, it does not perform bounds
+     *               checking; the caller is responsible for providing a valid index.
      */
     protected void setBit(int index) {
         int longIndex = index / 64;
@@ -1194,14 +1154,12 @@ public abstract class Grid {
      * 
      * @param index The index of the bit to clear (0-108).
      * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
-     * @since 2025.07.13 - Bitmasked Grid state
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) lookup time in the gridState array + O(1) bitwise operation to clear the bit =
-     *              O(1) complexity.
-     * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
-     * @see #getBit(int index)
-     * @see #setBit(int index)
+     * @see #getBit(int)
+     * @see #setBit(int)
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization Low-level helper. The caller is responsible for providing a valid index.
      **/
     protected void clearBit(int index) {
         int longIndex = index / 64;
@@ -1233,13 +1191,12 @@ public abstract class Grid {
      * @param index The index of the bit to check (0-108).
      * @return true if the bit is set, false otherwise.
      * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
-     * @since 2025.07.13 - Bitmasked Grid state
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @performance O(1) lookup time for the proper <code>long</code> in the gridState array.
-     * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
-     * @see #setBit(int index)
-     * @see #clearBit(int index)
+     * @see #clearBit(int)
+     * @see #setBit(int)
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe, as it reads potentially mutable state.
+     * @optimization Low-level helper. The caller is responsible for providing a valid index.
      */
     protected boolean getBit(int index) {
         int longIndex = index / 64;
@@ -1292,20 +1249,16 @@ public abstract class Grid {
      * @throws IllegalArgumentException if the format is Bitmask, (since that would just be the Grid
      *                                  itself). Use {@link #getGridState()} instead to fulfill that
      *                                  purpose.
-     * @since 2025.07.16 - Format Support
-     * @performance If format is {@link ValueFormat#Index}, O(n) loop through the grid state (where n is
-     *              the index of the last true cell, up to 108) + O(1) lookup via {@link #getBit(int)}
-     *              per iteration + O(1) array insertion for every true cell found = O(n) complexity.
-     * @performance If format is {@link ValueFormat#PackedInt}, O(n) loop through the grid state (where
-     *              n is the index of the last true cell, up to 108) + O(1) lookup via
-     *              {@link #getBit(int)} per iteration + O(1) array insertion for every true cell found
-     *              + O(n) conversion to packed int format = O(n) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @optimization Uses a pre-sized array to avoid resizing during insertion, and exits the for loop
-     *               when all true cells are found.
+     * @see #findFirstTrueCell(ValueFormat)
      * @see #findTrueCells()
-     * @see #findFirstTrueCell(ValueFormat format)
+     * @since 2025.07 - Format Support
+     * @performance {@code O(N)} where N is the {@link #NUM_CELLS}. A more optimized version could use
+     *              {@link Long#numberOfTrailingZeros(long)} to find set bits directly, but this method
+     *              is not on a critical performance path.
+     * @threading Not thread-safe, as it reads the mutable {@link #gridState}.
+     * @memory Allocates a new {@code short[]} for the results.
+     * @optimization Creates a perfectly sized array based on the cached {@link #trueCellsCount} to avoid
+     *               resizing. It also stops iterating as soon as all true cells have been found.
      */
     public short[] findTrueCells(ValueFormat format) {
         short[] trueCellsArray = new short[trueCellsCount];
@@ -1349,16 +1302,13 @@ public abstract class Grid {
      * </p>
      * 
      * @return An array of true cells in the specified format.
-     * @since 2025.04.08 - Adjacency Optimizations
-     * @performance O(n) loop through the grid state (where n is the index of the last true cell, up to
-     *              108) + O(1) lookup via {@link #getBit(int)} per iteration + O(1) array insertion for
-     *              every true cell found = O(n) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @optimization Uses a pre-sized array to avoid resizing during insertion, and exits the for loop
-     *               when all true cells are found.
-     * @see #findTrueCells(ValueFormat format)
-     * @see #findFirstTrueCell(ValueFormat format)
+     * @see #findFirstTrueCell(ValueFormat)
+     * @see #findTrueCells(ValueFormat)
+     * @since 2025.04 - Adjacency Optimizations
+     * @performance {@code O(N)} where N is the {@link #NUM_CELLS}.
+     * @threading Not thread-safe.
+     * @memory Allocates a new {@code short[]} for the results.
+     * @optimization A {@code final} convenience overload that defaults to the most common format.
      */
     public final short[] findTrueCells() {
         short[] trueCellsArray = new short[trueCellsCount];
@@ -1415,20 +1365,18 @@ public abstract class Grid {
      * @return The first true cell in the specified format, or -1 if no true cell is found.
      * @throws IllegalArgumentException if the format is Bitmask (since bitmasks aren't supported for
      *                                  single values).
-     * @since 2025.07.16 - Format Support
-     * @performance O(1) lookup time for the flag and true cells count + O(1) bitwise check to find the
-     *              first true cell + 2 * O(1) bitcounts on the bitmask + O(1) conversion to the
-     *              requested format = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @algorithm Uses Java's built-in methods for finding the first set bit and counting the number of
-     *            set bits in a long, which are highly optimized.
-     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded
-     *               recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
-     * @see #findFirstTrueCell()
-     * @see #click(short, ValueFormat)
      * @see #click(short[])
-     * @see #findTrueCells(ValueFormat format)
+     * @see #click(short, ValueFormat)
+     * @see #findFirstTrueCell()
+     * @see #findTrueCells(ValueFormat)
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe due to lazy evaluation of cached fields.
+     * @algorithm Uses the highly optimized {@link Long#numberOfTrailingZeros(long)} and
+     *              {@link Long#bitCount(long)} intrinsics for recalculation.
+     * @optimization Implements lazy recalculation. The cached {@link #firstTrueCell} and
+     *               {@link #trueCellsCount} are only recomputed if the {@link #recalculationNeeded}
+     *               flag is set.
      */
     public short findFirstTrueCell(ValueFormat format) {
         if (!recalculationNeeded && trueCellsCount == 0) 
@@ -1484,18 +1432,15 @@ public abstract class Grid {
      * </p>
      * 
      * @return The first true cell in Index format, or -1 if no true cell is found.
-     * @since 2025.04.08 - Adjacency Optimizations
-     * @performance O(1) lookup time for the flag and true cells count + O(1) bitwise check to find the
-     *              first true cell + 2 * O(1) bitcounts on the bitmask = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *           or with proper synchronization.
-     * @algorithm Uses Java's built-in methods for finding the first set bit and counting the number of set bits
-     *           in a long, which are highly optimized.
-     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
-     * @see #findFirstTrueCell(ValueFormat format)
-     * @see #click(short, ValueFormat)
      * @see #click(short[])
+     * @see #click(short, ValueFormat)
+     * @see #findFirstTrueCell(ValueFormat)
      * @see #findTrueCells()
+     * @since 2025.04 - Adjacency Optimizations
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe.
+     * @algorithm Delegates to the main implementation, using {@link ValueFormat#Index}.
+     * @optimization A {@code final} convenience overload for the most common use case.
      */
     public final short findFirstTrueCell() {
         if (!recalculationNeeded && trueCellsCount == 0) 
@@ -1560,15 +1505,14 @@ public abstract class Grid {
      *                                        another unsupported format.
      * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
      *                                        array accesses).
-     * @since 2025.07.16 - Format Support
-     * @performance If format is {@link ValueFormat#Index Index}, 2 * O(1) click operations using
-     *              pre-computed adjacency bitmasks = O(1) complexity. Otherwise, an additional O(1)
-     *              conversion is necessary (resulting in O(1) complexity overall).
-     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
-     *            instances of Grid or synchronize access to this method.
-     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
-     * @see #click(short cell)
-     * @see #click(short[] cells)
+     * @see #click(short)
+     * @see #click(short[])
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization The core of this operation is two bitwise XORs against the pre-computed
+     *               {@link #ADJACENCY_MASKS}, which is extremely fast. It also lazily marks the state for
+     *               recalculation.
      */
     public void click(short cell, ValueFormat format) {
         switch (format) 
@@ -1622,18 +1566,18 @@ public abstract class Grid {
      * @param cell The cell to click, in Index format (0-108).
      * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
      *                                        array accesses).
-     * @since 2025.07.19 - Inlining Improvements
-     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
-     *            instances of Grid or synchronize access to this method.
-     * @performance Two O(1) click operations using pre-computed adjacency bitmasks = O(1) complexity.
-     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
-     *               Declared as final to encourage JIT inlining. Assumes the cell is in
-     *               <code>Index</code> format (0-108) to avoid format checks.
-     * @see #click(short cell, ValueFormat format)
-     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
-     * @see #areAdjacent(short cellA, short cellB, ValueFormat format)
-     * @deprecated As of 2025.07.28, replaced by {@link #click(short[] cells)} for bulk operations on
-     *             combinations in {@link TestClickCombination monkeys}.
+     * @see #areAdjacent(short, short, ValueFormat)
+     * @see #click(short, ValueFormat)
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @since 2025.07 - Inlining Improvements
+     * @deprecated As of 2025.07, this has been replaced by {@link #click(short[])} for bulk operations
+     *             in {@link TestClickCombination}. Single-click operations are no longer on the hot
+     *             path.
+     * @performance {@code O(1)} complexity. This is a hot-path method.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization This minimal implementation is declared {@code final} to encourage JIT inlining. It
+     *               avoids any format-checking overhead by requiring the {@link ValueFormat#Index}
+     *               format.
      */
     public final void click(short cell) {
         // XOR the grid state with the pre-computed adjacency mask
@@ -1652,15 +1596,12 @@ public abstract class Grid {
      * @param col The column of the cell to click.
      * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
      *                                        array accesses).
-     * @since 2025.03.20 - Initial Commit
-     * @performance O(1) conversion from packed int to index + 2 * O(1) click operations using
-     *              pre-computed adjacency bitmasks = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
-     *            instances of Grid or synchronize access to this method.
-     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
-     *               Declared as final to encourage JIT inlining. Assumes the cell is in
-     *               <code>PackedInt</code> format (row and column) to avoid format checks.
-     * @see #click(short cell, ValueFormat format)
+     * @see #click(short, ValueFormat)
+     * @since 2025.03 - Initial Creation
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization A {@code final} convenience overload that handles {@link ValueFormat#PackedInt} conversion
+     *               before performing the click. Designed to be inlined.
      */
     public final void click(short row, short col) {
         // Convert packed int to index format first
@@ -1695,13 +1636,12 @@ public abstract class Grid {
      * </p>
      * @param bitmask The bitmask representing the adjacents to toggle, as a long array of length 2.
      * @throws IllegalArgumentException if the bitmask is not of length 2.
-     * @since 2025.07.17 - Click Format Support
-     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
-     *            instances of Grid or synchronize access to this method.
-     * @performance O(1) bitwise operations on the grid state = O(1) complexity.
-     * @optimization Assumes the bitmask is of length 2 to avoid format checks.
-     * @see #click(short cell, ValueFormat format)
-     * @see #click(short cell)
+     * @see #click(short)
+     * @see #click(short, ValueFormat)
+     * @since 2025.07 - Click Format Support
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization Directly applies a pre-computed bitmask, avoiding any lookup overhead.
      */
     public void click(long[] bitmask) {
         if (bitmask.length != 2) {
@@ -1754,17 +1694,15 @@ public abstract class Grid {
      *                                  accesses).
      * @throws NullPointerException     if the cells array is null (implicitly thrown by the for-each
      *                                  loop).
-     * @since 2025.07.28 - Bulk Clicks
-     * 
-     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
-     *            instances of Grid or synchronize access to this method.
-     * @performance O(n) loop * (2 O(1) bitwise operations per cell) = O(n) complexity, where n is the
-     *              number of cells clicked.
-     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
-     *               Declared as final to encourage JIT inlining. Assumes the cells are in Index format
-     *               and the array is non-null to avoid format checks.
-     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
-     * @see #areAdjacent(short cellA, short cellB, ValueFormat format)
+     * @see #areAdjacent(short, short, ValueFormat)
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @since 2025.07 - Bulk Clicks
+     * @performance {@code O(N)} where N is the number of cells in the input array. This is a hot-path
+     *              method for worker threads.
+     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
+     * @optimization This method is the primary replacement for single-cell clicks. It processes an array
+     *               of clicks in a tight loop. It is {@code final} to encourage JIT inlining and
+     *               assumes valid input to avoid branching and checks inside the loop.
      */
     public final void click(short[] cells) {
         for (short cell : cells) {
@@ -1822,15 +1760,14 @@ public abstract class Grid {
      * @return An array of adjacent cells in the requested format, or <code>null</code> if no true cell
      *         exists.
      * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask}.
-     * @since 2025.04.08 - First True Adjacents Method Creation
-     * @performance O(1) lookup of the first true cell + O(1) retrieval of its adjacents {+ O(n)
-     *              conversion to the requested format if necessary, where n is up to 6} = O(1) best
-     *              case complexity, O(n) worst case complexity.
-     * @threading This method is <b>not</b> thread-safe. Each thread should have its own instance of
-     *            Grid or synchronize access to this method.
-     * @optimization Avoids unnecessary recalculations by leveraging the existing
-     *               {@link #findFirstTrueCell()} method and reusing its result. Uses a simple lookup for the adjacency list.
      * @see #findAdjacents(short, ValueFormat)
+     * @since 2025.04 - First True Adjacents Method Creation
+     * @performance {@code O(1)} for {@link ValueFormat#Index}, {@code O(k)} for others, where {@code k} is the
+     *              number of adjacent cells (max 6).
+     * @threading Not thread-safe, as it depends on the result of non-thread-safe methods.
+     * @memory Allocates a new {@code short[]} for the result.
+     * @optimization Leverages the lazy evaluation of {@link #findFirstTrueCell()} and the pre-computed
+     *               {@link #adjacencyArray}.
      */
     public short[] findFirstTrueAdjacents(ValueFormat format) {
         if (format == ValueFormat.Bitmask) {
@@ -1853,11 +1790,11 @@ public abstract class Grid {
      * 
      * @return An array of adjacent cells in {@link ValueFormat#Index Index} format, or
      *         <code>null</code> if no true cell exists.
-     * @since 2025.07.17 - Format Support for findFirstTrueAdjacents
-     * @performance O(1) lookup of the first true cell + O(1) retrieval of its adjacents = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. Each thread should have its own instance of
-     *            Grid or synchronize access to this method.
-     * @optimization Convenience overload to avoid specifying the format when Index is desired.
+     * @since 2025.07 - Format Support
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe.
+     * @memory Allocates a new {@code short[]}.
+     * @optimization Convenience overload.
      */
     public short[] findFirstTrueAdjacents() {
         return findFirstTrueAdjacents(ValueFormat.Index);
@@ -1908,21 +1845,18 @@ public abstract class Grid {
      *         exist.
      * @throws IllegalArgumentException if either format is {@link ValueFormat#Bitmask Bitmask} (since
      *                                  bitmasks aren't supported for single values) or anything else.
-     * @since 2025.07.16 - Format Support
-     * @performance O(log n) binary search on the adjacency array (where n is up to 6) + O(m) array copy
-     *              (where m is up to 6) + O(m) conversion to packed int format if necessary = O(n)
-     *              complexity overall.
-     * @threading This method is <b>not</b> thread-safe. Each thread should have its own instance of
-     *            Grid or synchronize access to this method.
-     * @algorithm Uses binary search to efficiently find the first adjacent cell greater than the
-     *            specified cell.
-     * @optimization Avoids unnecessary recalculations by leveraging the existing
-     *               {@link #findFirstTrueAdjacents(ValueFormat) findFirstTrueAdjacents()} method and
-     *               reusing its result. Uses binary search for efficient searching in the small
-     *               adjacency array.
      * @see #findAdjacents(short)
      * @see #findFirstTrueAdjacents(ValueFormat)
      * @see #findFirstTrueCell()
+     * @since 2025.07 - Format Support
+     * @performance {@code O(log k + m)} where {@code k} is the number of adjacents (max 6) and {@code m} is
+     *              the number of remaining adjacents to copy. Effectively constant time.
+     * @threading Not thread-safe.
+     * @algorithm Performs a binary search on the sorted adjacency list of the first true cell to find
+     *            the subset of neighbors that appear after the given cell.
+     * @memory Allocates a new {@code short[]} for the result.
+     * @optimization A specialized method for the generator to efficiently prune the search space by only
+     *               considering relevant subsequent clicks.
      */
     public short[] findFirstTrueAdjacentsAfter(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] firstTrueAdjacents = findFirstTrueAdjacents(inputFormat);
@@ -1995,11 +1929,10 @@ public abstract class Grid {
      * avoiding code duplication.
      * 
      * @return <code>true</code> if the grid is solved (no true cells), <code>false</code> otherwise.
-     * @since 2025.03.20 - Initial Commit
-     * @performance O(1) to check the true cells count (with potential recalculation) = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
      * @see #recalculationNeeded
+     * @since 2025.03 - Initial Creation
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe, as it calls the non-thread-safe {@link #getTrueCount()}.
      */
     public boolean isSolved() {
         return getTrueCount() == 0;
@@ -2010,13 +1943,12 @@ public abstract class Grid {
      * calculation, it recalculates the count using {@link Long#bitCount(long) bitwise operations}.
      * 
      * @return the number of true cells in the grid.
-     * @since 2025.03.21 - Dynamic True Cell Count Tracking
-     * @performance O(1) for checking the flag + O(1) for recalculating the count using bitwise operations = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded
-     *               recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
      * @see #recalculationNeeded
+     * @since 2025.03 - Dynamic True Cell Count Tracking
+     * @performance {@code O(1)} complexity.
+     * @threading Not thread-safe due to lazy evaluation of a mutable field.
+     * @optimization Implements lazy evaluation; the count is only recalculated using fast bitwise
+     *               operations when the {@link #recalculationNeeded} flag is true.
      */
     public int getTrueCount() {
         if (recalculationNeeded) {
@@ -2038,15 +1970,16 @@ public abstract class Grid {
      * 
      * @return A deep copy of this <code>Grid</code> instance.
      * @throws RuntimeException if the cloning process fails due to reflection issues.
-     * @since 2025.03.26 - Cloning Introduction
-     * @performance O(1) for creating a new instance + O(1) for copying the grid state and fields = O(1) complexity.
-     * @threading Thread-safe, as it creates a new instance and does not modify any shared state.
      * @see #firstTrueCell
      * @see #gridState
      * @see #recalculationNeeded
      * @see #trueCellsCount
-     * @see java.lang.Cloneable
      * @see java.lang.Object#clone()
+     * @see java.lang.Cloneable
+     * @since 2025.03 - Cloning Introduction
+     * @performance {@code O(1)} complexity.
+     * @threading Thread-safe, as it returns a new, independent instance.
+     * @memory Allocates a new {@code Grid} object and a new {@code long[2]} for its state.
      */
     public Grid clone() {
         try {
@@ -2093,14 +2026,15 @@ public abstract class Grid {
      * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask} (since
      *                                  bitmasks aren't supported for single values) or another
      *                                  unsupported format.
-     * @since 2025.07.16 - Format Support and Adjacency Optimizations
-     * @performance O(1) checks for edge cases + O(1) conversion to index format if necessary + O(1)
-     *              binary search on a small, fixed-size array of adjacents = O(1) complexity.
-     * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
-     * @optimization Short-circuits for edge cases and uses binary search for adjacency checks.
-     * @see #areAdjacent(short cellA, short cellB, ValueFormat format)
-     * @see #findAdjacents(short cell, ValueFormat format)
-     * @see #findFirstTrueCell(ValueFormat format)
+     * @see #areAdjacent(short, short, ValueFormat)
+     * @see #findAdjacents(short, ValueFormat)
+     * @see #findFirstTrueCell(ValueFormat)
+     * @since 2025.07 - Format and Adjacency Optimizations
+     * @performance {@code O(log k)} where k is the number of adjacent cells (max 6). Effectively constant
+     *              time.
+     * @threading This method is thread-safe as it is a pure function.
+     * @optimization A specialized pruning helper for the generator. Uses an efficient binary search on the
+     *               pre-sorted adjacency list.
      */
     public static boolean canAffectFirstTrueCell(short firstTrueCell, short clickCell, ValueFormat format) {
         if (firstTrueCell == -1) return true; // No true cells, any click can create one
@@ -2200,15 +2134,14 @@ public abstract class Grid {
      *                                        another unsupported format.
      * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
      *                                        array access).
-     * @since 2025.07.18 - Index Format Usage for Internal Grid Methods
-     * @performance O(1) conversion to index format if necessary + O(1) lookup in the adjacency cache =
-     *              O(1) complexity.
-     * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
-     * @optimization Uses a pre-computed adjacency cache for fast lookups. Short-circuits for
-     *               unsupported formats.
      * @see #ADJACENCY_CACHE
      * @see #areAdjacent(short, short)
      * @see #canAffectFirstTrueCell(short, short, ValueFormat)
+     * @since 2025.07 - Index Format Usage
+     * @performance {@code O(1)} complexity.
+     * @threading Thread-safe, as it only reads from immutable static data.
+     * @optimization Directly uses the {@link #ADJACENCY_CACHE} for an instantaneous lookup after handling
+     *               any necessary format conversion.
      */
     public static boolean areAdjacent(short cellA, short cellB, ValueFormat format) {
         // Convert both cells to index format if necessary
@@ -2238,10 +2171,10 @@ public abstract class Grid {
      * @return <code>true</code> if the cells are adjacent, <code>false</code> otherwise.
      * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
      *                                        array access).
-     * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
-     * @performance O(1) lookup in the adjacency cache = O(1) complexity.
-     * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
-     * @optimization Convenience overload to avoid specifying the format when Index is desired.
+     * @since 2025.06 - Odd Adjacency Pruning
+     * @performance {@code O(1)} lookup.
+     * @threading Thread-safe.
+     * @optimization The most direct way to check adjacency, assuming {@link ValueFormat#Index} format.
      */
     public static boolean areAdjacent(short cellA, short cellB) {
         return areAdjacent(cellA, cellB, ValueFormat.Index);
@@ -2258,14 +2191,13 @@ public abstract class Grid {
      * </p>
      * 
      * @return A copy of the current grid state as a bitmask (array of two longs).
-     * @since 2025.07.13 - Bitmasked Grid State
-     * @performance 2 * O(1) to clone the grid state array = O(1) complexity.
-     * @threading Thread-safe, as it returns a copy of the internal state and does not modify any shared
-     *            state.
-     * @memory Allocates a new array of two longs for the copy to ensure immutability of the internal
-     *         state.
-     * @see #click(long[] bitmask)
+     * @see #click(long[])
      * @see ValueFormat#Bitmask
+     * @since 2025.07 - Bitmasked Grid State
+     * @performance {@code O(1)} complexity.
+     * @threading This method is thread-safe because it returns a defensive copy of the state.
+     * @memory Allocates a new {@code long[2]} array to prevent external modification of the instance's
+     *         internal state.
      */
     public long[] getGridState() {
         return gridState.clone();
@@ -2276,33 +2208,23 @@ public abstract class Grid {
      * format, with '1' representing true cells and '0' representing false cells. Rows are indented to
      * reflect the hexagonal layout, matching the format used in the PDC puzzle code.
      * 
-     * @since 2025.03.20 - Grid Printing Method Creation
-     * @performance O(n) to iterate through all cells and build the string representation, where n is
-     *              the number of cells (109) = O(n) complexity.
-     * @optimization Uses a StringBuilder to efficiently build each row's string representation.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
-     * @memory Allocates a new {@link java.lang.StringBuilder StringBuilder} for each row to build the
-     *         string representation. For better performance, we could modify this method to take a
-     *         single <code>StringBuilder</code> as a parameter and append to it (similar to
-     *         {@link CombinationMessage#formatTo(StringBuilder)}), delegating the responsibility of
-     *         logging to the caller. However, given the infrequent nature of this operation, we've
-     *         chosen to keep it simple.
-     * 
      * @see #EVEN_NUM_COLS
      * @see #NUM_ROWS
      * @see #ODD_NUM_COLS
-     * @see #getBit(int bitIdx)
-     * @see #indexToPacked(short index)
-     * @see #packedToIndex(short packed)
-     * @see ValueFormat#PackedInt
+     * @see #getBit(int)
+     * @see #indexToPacked(short)
+     * @see #packedToIndex(short)
      * @see ValueFormat#Index
+     * @see ValueFormat#PackedInt
      * @see java.lang.StringBuilder
-     * @see java.lang.StringBuilder#append(String)
-     * @see java.lang.StringBuilder#toString()
      * @see org.apache.logging.log4j.Logger
-     * @see org.apache.logging.log4j.Logger#info(String)
      * @see org.apache.logging.log4j.LogManager
+     * @since 2025.03 - Grid Printing Method Creation
+     * @performance {@code O(N)} where N is the number of cells. This is a debugging method and is not
+     *              performance-critical.
+     * @threading Not thread-safe, as it iterates over the mutable grid state.
+     * @memory Allocates a new {@link StringBuilder} for each row.
+     * @optimization Uses a {@link StringBuilder} for efficient string concatenation within each row.
      */
     public void printGrid() {
         Logger logger = LogManager.getLogger();

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -92,8 +92,6 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * avoiding synchronization and locks allows for faster operations in the hot path.
  * </p>
  * 
- * <h3>44/52 - ~84.6% of documentation completed</h3>
- * 
  * @since 2025.03.20 - Initial creation
  * @performance Core operations like clicking a cell and checking for the solved state are designed
  *              to be O(1), with most of the complexity hidden in the static initialization block.
@@ -953,36 +951,98 @@ public abstract class Grid {
         return findAdjacents(cell, ValueFormat.Index);
     }
 
-    // Packed int <-> compact array index conversion
-    private static short computePackedToIndex(short packed) 
-    {
+    /**
+     * Computes the conversion from {@link ValueFormat#PackedInt PackedInt} format to
+     * {@link ValueFormat#Index Index} format. This method performs the necessary arithmetic to
+     * determine the correct index for a given packed int value.
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The conversion is based on the structure of the grid, which has rows of varying lengths. The
+     * first row has 16 columns, the second row has 15 columns, and this pattern continues to alternate.
+     * To convert a packed int value (which encodes the row and column) to an index value (which is a
+     * single integer representing the cell's position in a flattened array), we need to account for the
+     * varying row lengths.
+     * </p>
+     * 
+     * <p>
+     * After obtaining the row and column from the packed int value, we use a {@link #ROW_OFFSETS
+     * pre-defined array of row offsets} to determine the starting index of the row in the flattened
+     * array. We then add the column to this offset to get the final index.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be used by the static block of the Grid class to pre-compute a
+     * {@link #PACKED_TO_INDEX_CACHE cache} for fast lookups. While the method itself is O(1) in
+     * complexity, it is not intended to be called frequently during the program's execution. Instead,
+     * it serves as a utility for initializing the cache, which can then be used for O(1) lookups in
+     * performance-critical paths. The method does not perform any bounds checking on the input packed
+     * value, as it is assumed that the static block will only call it with valid values.
+     * </p>
+     * 
+     * @param packed the <code>short</code> representing the cell in {@link ValueFormat#PackedInt
+     *               PackedInt} format.
+     * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
+     * @throws ArrayIndexOutOfBoundsException (implicitly) if the input packed value is out of bounds
+     *                                   (less than 0 or greater than 615).
+     * @since 2025.06.15 - PackedInt → Index Precomputation
+     * @performance O(1) complexity due to a fixed number of arithmetic operations and array lookups.
+     * @threading This method is thread-safe, as it does not modify any instance or static state.
+     * @memory Uses a small, fixed-size array for row offsets and uses primitive types to avoid allocations.
+     * @optimization Uses a pre-defined array of row offsets to avoid repeated calculations, minimizing
+     *               memory usage by using primitive types and avoiding dynamic allocations.
+     */
+    private static short computePackedToIndex(short packed) {
         short row = (short) (packed / 100);
         short col = (short) (packed % 100);
         return (short) (ROW_OFFSETS[row] + col);
     }
 
     /**
-     * Converts a cell from {@link ValueFormat#PackedInt PackedInt} format to
-     * {@link ValueFormat#Index Index} format. This method uses a cache to speed up conversions for
-     * commonly used values, and {@link #computePackedToIndex(short) calculates} new values as needed.
+     * Converts a cell from {@link ValueFormat#PackedInt PackedInt} format to {@link ValueFormat#Index
+     * Index} format. This method uses a cache to speed up conversions for commonly used values, and
+     * {@link #computePackedToIndex(short) calculates} new values as needed.
      * 
-     * @param packed A <code>short</code> representing the cell in {@link ValueFormat#PackedInt PackedInt} format.
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be efficient, using a cache to store previously computed conversions
+     * for fast lookups. If a value is not found in the cache, it is computed on-the-fly using the
+     * {@link #computePackedToIndex(short) computePackedToIndex()} method.
+     * </p>
+     * 
+     * <p>
+     * A potential area for optimization would be to explicitly compute the entire cache in the static
+     * block to avoid the need for on-the-fly calculations. Doing this would increase the startup time
+     * slightly, but would eliminate the need for any calculations during runtime, allowing us to remove
+     * the check for uncached values and make this method smaller, improving its chances of being
+     * inlined by the JVM. We've chosen not to do this for now, since conversions from the
+     * human-friendly <code>PackedInt</code> format to the memory efficient <code>Index</code> format
+     * are not a common operation in performance-critical paths (we try to use <code>Index</code>
+     * internally as much as possible), but the option remains open for the future.
+     * </p>
+     * 
+     * @param packed A <code>short</code> representing the cell in {@link ValueFormat#PackedInt
+     *               PackedInt} format.
      * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
-     * @throws IllegalArgumentException if the input packed value is out of bounds (less than 0 or greater than 615).
+     * @throws IllegalArgumentException if the input packed value is out of bounds (less than 0 or
+     *                                  greater than 615).
      * @since 2025.07.16 - Format Support
-     * @performance O(1) lookup time in the cache + O(1) computation time for uncached values = O(1) complexity.
-     * @threading This method is thread-safe, as it reads from an immutable static cache and writes to it in a
-     *            thread-safe manner.
-     * @memory Pulls from a static cache to minimize memory usage, preventing the need for dynamic allocations.
-     * @optimization Uses a cache to speed up conversions for commonly used values, reducing the need for repeated calculations.
+     * @performance O(1) lookup time in the cache + O(1) computation time for uncached values = O(1)
+     *              complexity.
+     * @threading This method is thread-safe, as it reads from an immutable static cache and writes to
+     *            it in a thread-safe manner.
+     * @memory Pulls from a static cache to minimize memory usage, preventing the need for dynamic
+     *         allocations.
+     * @optimization Uses a cache to speed up conversions for commonly used values, reducing the need
+     *               for repeated calculations.
      * @see #PACKED_TO_INDEX_CACHE
      * @see #computePackedToIndex(short)
      */
     public final static short packedToIndex(short packed) {
-        if (packed >= 0 && packed < PACKED_TO_INDEX_CACHE.length) 
-        {
-            if (PACKED_TO_INDEX_CACHE[packed] == 0 && packed != 0) 
-            {
+        if (packed >= 0 && packed < PACKED_TO_INDEX_CACHE.length) {
+            // TODO: Explicitly pre-compute the entire cache in the static block to avoid on-the-fly calculations.
+            if (PACKED_TO_INDEX_CACHE[packed] == 0 && packed != 0) {
                 // If the cache is not initialized, compute it
                 PACKED_TO_INDEX_CACHE[packed] = computePackedToIndex(packed);
             }
@@ -1718,14 +1778,62 @@ public abstract class Grid {
     }
 
     /**
-     * Returns the adjacents of the first true cell in the requested format.
-     * @param format The desired output format (Index or PackedInt).
-     * @return An array of adjacent cells, or null if no true cell exists.
+     * Returns an array of adjacents of the {@link #findFirstTrueCell() first true cell} in the
+     * requested {@link ValueFormat format}. If no true cell exists, returns <code>null</code>.
+     * 
+     * <p>
+     * Since clicks are limited in scope to the adjacents of one cell (excluding itself), we can derive
+     * an important property of the solution: It must contain at least one click on the adjacents of the
+     * first true cell in the initial grid state. This may seem obvious, but it allows us to establish
+     * bounds for generation, limiting the maximum cell that needs to be considered for the first click
+     * to the last adjacent of the first true cell. This method gives us an easy way to extract and test
+     * those adjacents.
+     * </p>
+     * 
+     * <p>
+     * As a note, we currently prevent the use of {@link ValueFormat#Bitmask Bitmask} formats here,
+     * since bitmasks aren't well-suited for representing small sets of values. If we were to support
+     * them, we would either need to create a <code>long[]</code> of length 2 (to match the internal
+     * grid size) or a <code>short[]</code> with a length of 7 to cover 116 bits (the closest multiple
+     * of 16 above 109). The former would likely require a new method due to the incompatible return
+     * type (unless we made the return type <code>Object</code>, which would be messy), while the latter
+     * would waste space and require additional conversions. Given the limited utility of bitmasks in
+     * this context, we opt to exclude them for now.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be efficient, performing a simple lookup of the first true cell and
+     * then retrieving its adjacents. The operation is O(1) due to the fixed size of the adjacency list
+     * (up to 6 elements).
+     * </p>
+     * 
+     * <p>
+     * To optimize performance further, we could consider caching the result of the operation if the
+     * state has not changed since the last call, but given the simplicity of the operation and the
+     * small size of the adjacency list, the current implementation is sufficient. If the first true
+     * cell were to change, we would need to invalidate the cache anyway, requiring an allocation of a
+     * new array; we would also need to clone the array before returning it to avoid external
+     * modifications, which would negate the performance benefits of caching in the first place.
+     * </p>
+     * 
+     * @param format The desired output format ({@link ValueFormat#Index Index} or
+     *               {@link ValueFormat#PackedInt PackedInt}).
+     * @return An array of adjacent cells in the requested format, or <code>null</code> if no true cell
+     *         exists.
+     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask}.
+     * @since 2025.04.08 - First True Adjacents Method Creation
+     * @performance O(1) lookup of the first true cell + O(1) retrieval of its adjacents {+ O(n)
+     *              conversion to the requested format if necessary, where n is up to 6} = O(1) best
+     *              case complexity, O(n) worst case complexity.
+     * @threading This method is <b>not</b> thread-safe. Each thread should have its own instance of
+     *            Grid or synchronize access to this method.
+     * @optimization Avoids unnecessary recalculations by leveraging the existing
+     *               {@link #findFirstTrueCell()} method and reusing its result. Uses a simple lookup for the adjacency list.
+     * @see #findAdjacents(short, ValueFormat)
      */
-    public short[] findFirstTrueAdjacents(ValueFormat format) 
-    {
-        if (format == ValueFormat.Bitmask) 
-        {
+    public short[] findFirstTrueAdjacents(ValueFormat format) {
+        if (format == ValueFormat.Bitmask) {
             throw new IllegalArgumentException("Bitmask format is not supported for this operation.");
         }
         
@@ -1738,8 +1846,20 @@ public abstract class Grid {
         return trueAdjacents;
     }
 
-    public short[] findFirstTrueAdjacents() 
-    {
+    /**
+     * Overload of {@link #findFirstTrueAdjacents(ValueFormat)} that assumes the output format is
+     * {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls the main
+     * method with the <code>Index</code> format.
+     * 
+     * @return An array of adjacent cells in {@link ValueFormat#Index Index} format, or
+     *         <code>null</code> if no true cell exists.
+     * @since 2025.07.17 - Format Support for findFirstTrueAdjacents
+     * @performance O(1) lookup of the first true cell + O(1) retrieval of its adjacents = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. Each thread should have its own instance of
+     *            Grid or synchronize access to this method.
+     * @optimization Convenience overload to avoid specifying the format when Index is desired.
+     */
+    public short[] findFirstTrueAdjacents() {
         return findFirstTrueAdjacents(ValueFormat.Index);
     }
 
@@ -1867,15 +1987,39 @@ public abstract class Grid {
         return result;
     }
 
-    public boolean isSolved() 
-    {
+    /**
+     * Checks if the grid is completely solved (i.e., all cells are false). We use the
+     * {@link #getTrueCount()} method to determine if there are any true cells remaining rather than
+     * directly checking the {@link #gridState grid state} or the {@link #trueCellsCount true cells
+     * count} to ensure that any necessary recalculations are performed before making the check while
+     * avoiding code duplication.
+     * 
+     * @return <code>true</code> if the grid is solved (no true cells), <code>false</code> otherwise.
+     * @since 2025.03.20 - Initial Commit
+     * @performance O(1) to check the true cells count (with potential recalculation) = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @see #recalculationNeeded
+     */
+    public boolean isSolved() {
         return getTrueCount() == 0;
     }
 
-    public int getTrueCount() 
-    {
-        if (recalculationNeeded) 
-        {
+    /**
+     * Returns the count of true cells in the grid. If the grid state has changed since the last
+     * calculation, it recalculates the count using {@link Long#bitCount(long) bitwise operations}.
+     * 
+     * @return the number of true cells in the grid.
+     * @since 2025.03.21 - Dynamic True Cell Count Tracking
+     * @performance O(1) for checking the flag + O(1) for recalculating the count using bitwise operations = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @optimization Avoids unnecessary recalculations by checking the {@link #recalculationNeeded
+     *               recalculationNeeded} flag and the {@link #trueCellsCount trueCellsCount} field.
+     * @see #recalculationNeeded
+     */
+    public int getTrueCount() {
+        if (recalculationNeeded) {
             trueCellsCount = Long.bitCount(gridState[0]) + Long.bitCount(gridState[1]);
             recalculationNeeded = false;
         }
@@ -2056,7 +2200,7 @@ public abstract class Grid {
      *                                        another unsupported format.
      * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
      *                                        array access).
-     * @since 2025.07.16 - Format Support and Adjacency Optimizations
+     * @since 2025.07.18 - Index Format Usage for Internal Grid Methods
      * @performance O(1) conversion to index format if necessary + O(1) lookup in the adjacency cache =
      *              O(1) complexity.
      * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
@@ -2084,27 +2228,89 @@ public abstract class Grid {
         return ADJACENCY_CACHE[cellA][cellB];
     }
 
-    public static boolean areAdjacent(short cellA, short cellB) 
-    {
+    /**
+     * Overload of {@link #areAdjacent(short, short, ValueFormat)} that assumes the input format is
+     * {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls the main
+     * method with the <code>Index</code> format.
+     * 
+     * @param cellA the first cell to check, in {@link ValueFormat#Index Index} format (0-108).
+     * @param cellB the second cell to check, in {@link ValueFormat#Index Index} format (0-108).
+     * @return <code>true</code> if the cells are adjacent, <code>false</code> otherwise.
+     * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
+     *                                        array access).
+     * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
+     * @performance O(1) lookup in the adjacency cache = O(1) complexity.
+     * @threading Thread-safe, as it only reads input parameters and does not modify any shared state.
+     * @optimization Convenience overload to avoid specifying the format when Index is desired.
+     */
+    public static boolean areAdjacent(short cellA, short cellB) {
         return areAdjacent(cellA, cellB, ValueFormat.Index);
     }
 
-    // Legacy compatibility - expose bitmask for direct access when needed
-    public long[] getGridState() 
-    {
+    /**
+     * Returns a copy of the current {@link #gridState grid state} as a bitmask (array of two longs).
+     * 
+     * <p>
+     * This method exists to provide direct access to the grid's internal state. While no current code
+     * paths leverage this method (in part due to the allocation it requires), it may be useful for
+     * debugging, logging, or future features that require direct manipulation or inspection of the grid
+     * state.
+     * </p>
+     * 
+     * @return A copy of the current grid state as a bitmask (array of two longs).
+     * @since 2025.07.13 - Bitmasked Grid State
+     * @performance 2 * O(1) to clone the grid state array = O(1) complexity.
+     * @threading Thread-safe, as it returns a copy of the internal state and does not modify any shared
+     *            state.
+     * @memory Allocates a new array of two longs for the copy to ensure immutability of the internal
+     *         state.
+     * @see #click(long[] bitmask)
+     * @see ValueFormat#Bitmask
+     */
+    public long[] getGridState() {
         return gridState.clone();
     }
 
-    public void printGrid() 
-    {
-        Logger logger = LogManager.getLogger(Grid.class);
-        for (int row = 0; row < NUM_ROWS; row++) 
-        {
+    /**
+     * Prints the current grid state to the {@link LogManager#getLogger() logger} in a human-readable
+     * format, with '1' representing true cells and '0' representing false cells. Rows are indented to
+     * reflect the hexagonal layout, matching the format used in the PDC puzzle code.
+     * 
+     * @since 2025.03.20 - Grid Printing Method Creation
+     * @performance O(n) to iterate through all cells and build the string representation, where n is
+     *              the number of cells (109) = O(n) complexity.
+     * @optimization Uses a StringBuilder to efficiently build each row's string representation.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @memory Allocates a new {@link java.lang.StringBuilder StringBuilder} for each row to build the
+     *         string representation. For better performance, we could modify this method to take a
+     *         single <code>StringBuilder</code> as a parameter and append to it (similar to
+     *         {@link CombinationMessage#formatTo(StringBuilder)}), delegating the responsibility of
+     *         logging to the caller. However, given the infrequent nature of this operation, we've
+     *         chosen to keep it simple.
+     * 
+     * @see #EVEN_NUM_COLS
+     * @see #NUM_ROWS
+     * @see #ODD_NUM_COLS
+     * @see #getBit(int bitIdx)
+     * @see #indexToPacked(short index)
+     * @see #packedToIndex(short packed)
+     * @see ValueFormat#PackedInt
+     * @see ValueFormat#Index
+     * @see java.lang.StringBuilder
+     * @see java.lang.StringBuilder#append(String)
+     * @see java.lang.StringBuilder#toString()
+     * @see org.apache.logging.log4j.Logger
+     * @see org.apache.logging.log4j.Logger#info(String)
+     * @see org.apache.logging.log4j.LogManager
+     */
+    public void printGrid() {
+        Logger logger = LogManager.getLogger();
+        for (int row = 0; row < NUM_ROWS; row++) {
             StringBuilder sb = new StringBuilder();
             if (row % 2 != 0) sb.append(" ");
             int cols = (row % 2 == 0) ? EVEN_NUM_COLS : ODD_NUM_COLS;
-            for (int col = 0; col < cols; col++) 
-            {
+            for (int col = 0; col < cols; col++) {
                 int bitIdx = packedToIndex((short) (row * 100 + col));
                 sb.append(getBit(bitIdx) ? "1 " : "0 ");
             }

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -24,7 +24,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>5/50 - 10% of documentation completed</h3>
+ * <h3>6/50 - 12% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]
@@ -96,7 +96,83 @@ public abstract class Grid
         }
     }
 
-    // Computes the adjacent cells for a given cell in the grid, internally requiring the cell to be in packed int format.
+    /**
+     * Determines the hexagonally adjacent cells for a cell in the grid. This overload allows the user
+     * to specify the input and output formats, providing flexibility in how the static block for this
+     * class is built.
+     * 
+     * <p>
+     * Unlike a traditional grid, a cell in a hexagonal grid has up to 6 adjacent cells. The cells
+     * adjacent to a given cell aren't just based on the row and column, but also on the row's parity
+     * (even or odd), making calculations much more complex than a simple rectangular grid. This problem
+     * is exacerbated by the fact that the Grid is represented in a flattened, bitmask format, doing
+     * away with the concept of rows and columns entirely for memory efficiency. Since
+     * <code>click</code> operations affect the adjacent cells, we need some way to determine which
+     * cells are adjacent to a given cell. This method provides that functionality.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * For a given cell n (in packed int format) in an even row, the adjacent cells include:
+     * <ul>
+     * <li>n - 101 (row - 1, col - 1)</li>
+     * <li>n - 100 (row - 1, col)</li>
+     * <li>n - 1 (row, col - 1)</li>
+     * <li>n + 1 (row, col + 1)</li>
+     * <li>n + 99 (row + 1, col - 1)</li>
+     * <li>n + 100 (row + 1, col)</li>
+     * </ul>
+     * 
+     * For a cell in an odd row, the adjacent cells include:
+     * <ul>
+     * <li>n - 100 (row - 1, col)</li>
+     * <li>n - 99 (row - 1, col + 1)</li>
+     * <li>n - 1 (row, col - 1)</li>
+     * <li>n + 1 (row, col + 1)</li>
+     * <li>n + 100 (row + 1, col)</li>
+     * <li>n + 101 (row + 1, col + 1)</li>
+     * </ul>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Internal computations are performed in <code>PackedInt</code> format for efficiency, as it allows
+     * for straightforward arithmetic operations to determine adjacency. The method has to convert
+     * between formats as needed, which adds some overhead, but this is offset by our use of the method
+     * in the static block to pre-compute an {@link #adjacencyArray adjacency table}. Future
+     * calls to find adjacents can then use this pre-computed table for O(1) lookups. 
+     * </p>
+     * <p>
+     * Since cells in different grid positions can have a different number of valid adjacent cells
+     * (due to edges and corners), we use a dynamic list (<code>ShortList</code>) to store the results,
+     * letting the calling method handle conversion to a fixed-size array if needed. Fastutil's
+     * primitive collections are used to avoid boxing overhead and allow for efficient storage
+     * and retrieval of short values.
+     * </p>
+     * 
+     * @param cell         A short representing the cell in the grid, expected to be in the same format
+     *                     as inputFormat.
+     * @param inputFormat  The ValueFormat of the input cell, which can either be Index or PackedInt.
+     * @param outputFormat The ValueFormat of the output cell, which can either be Index or PackedInt.
+     * @return affectedPieces A ShortList of adjacent cells in the specified output format, containing
+     *         up to 6 items.
+     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
+     *                                  represent a single cell in that format.
+     * @since 2025.05.15 - Static Adjacency Computations
+     * @performance If outputFormat is <code>PackedInt</code>, O(1) input conversion (if necessary) + 6
+     *              * O(1) adjacency computation + O(6) output filtering = O(1) complexity.
+     * @performance If outputFormat is <code>Index</code>, O(1) input conversion (if necessary) + 6 *
+     *              O(1) adjacency computation + O(6) output filtering + O(n) conversion to index format
+     *              (where n is fixed as 6 or less) = O(1) complexity.
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
+     *         required for <code>ArrayList</code>s and allowing for easy conversion to a properly-sized
+     *         short array.
+     * @optimization Using a <code>ShortList</code> avoids the need for counting the number of valid
+     *               adjacent cells before initializing a presized array and avoids the boxing overhead
+     *               associated with <code>ArrayList</code>s.
+     * @see #findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see ShortList
+     */
     public static ShortList computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
     {
         ShortList affectedPieces = new ShortArrayList(6);
@@ -269,7 +345,7 @@ public abstract class Grid
      * used in any method of the codebase.
      * </p>
      * 
-     * <h2>Performance Considerations</h2>
+     * <h3>Performance Considerations</h3>
      * <p>
      * For performance reasons, this method does not perform bounds checking on the index. It is the
      * caller's responsibility to ensure that the index is within the valid range (0-108).
@@ -288,9 +364,8 @@ public abstract class Grid
      * @performance O(1) lookup time in the gridState array + O(1) bitwise operation to set the bit =
      *              O(1) complexity.
      * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
-     * @see {@link #getBit(int index)} - Method to get a bit from the grid state, the "getter".
-     * @see {@link #clearBit(int index)} - Method to clear a bit in the grid state, the opposite of this
-     *      method.
+     * @see #getBit(int index)
+     * @see #clearBit(int index)
      */
     protected void setBit(int index) {
         int longIndex = index / 64;
@@ -311,7 +386,7 @@ public abstract class Grid
      * used in any method of the codebase.
      * </p>
      * 
-     * <h2>Performance Considerations</h2>
+     * <h3>Performance Considerations</h3>
      * <p>
      * For performance reasons, this method does not perform bounds checking on the index. It is the
      * caller's responsibility to ensure that the index is within the valid range (0-108).
@@ -325,9 +400,8 @@ public abstract class Grid
      * @performance O(1) lookup time in the gridState array + O(1) bitwise operation to clear the bit =
      *              O(1) complexity.
      * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
-     * @see {@link #getBit(int index)} - Method to get a bit from the grid state, the "getter".
-     * @see {@link #setBit(int index)} - Method to set a bit in the grid state, the opposite of this
-     *      method.
+     * @see #getBit(int index)
+     * @see #setBit(int index)
      **/
     protected void clearBit(int index)
     {
@@ -351,7 +425,7 @@ public abstract class Grid
      * grid state.}
      * </p>
      * 
-     * <h2>Performance Considerations</h2>
+     * <h3>Performance Considerations</h3>
      * <p>
      * For performance reasons, this method does not perform bounds checking on the index. It is the
      * caller's responsibility to ensure that the index is within the valid range (0-108).
@@ -365,8 +439,8 @@ public abstract class Grid
      *            or with proper synchronization.
      * @performance O(1) lookup time for the proper <code>long</code> in the gridState array.
      * @optimization Avoids unnecessary bounds checks and uses bitwise operations for fast access.
-     * @see {@link #setBit(int index)} - Method to set a bit in the grid state, the "setter".
-     * @see {@link #clearBit(int index)} - Method to clear a bit in the grid state, the "clearer".
+     * @see #setBit(int index)
+     * @see #clearBit(int index)
      */
     protected boolean getBit(int index) {
         int longIndex = index / 64;
@@ -576,12 +650,9 @@ public abstract class Grid
      * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
      *               Declared as final to encourage JIT inlining. Assumes the cell is in
      *               <code>Index</code> format (0-108) to avoid format checks.
-     * @see {@link #click(short cell, ValueFormat format)} - Method overload for different formats.
-     * @see {@link #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)} -
-     *      Computes the adjacent cells for a given cell, overloaded for different input and output
-     *      formats. Used internally to generate the masks used in this method.
-     * @see {@link #areAdjacent(short cellA, short cellB, ValueFormat format)} - Checks if two cells are
-     *      adjacent in the grid.
+     * @see #click(short cell, ValueFormat format)
+     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see #areAdjacent(short cellA, short cellB, ValueFormat format)
      * @deprecated As of 2025.07.28, replaced by {@link #click(short[] cells)} for bulk operations on
      *             combinations in {@link TestClickCombination monkeys}.
      */
@@ -674,11 +745,8 @@ public abstract class Grid
      * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
      *               Declared as final to encourage JIT inlining. Assumes the cells are in Index format
      *               and the array is non-null to avoid format checks.
-     * @see {@link #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)} -
-     *      Computes the adjacent cells for a given cell, overloaded for different input and output
-     *      formats and used internally to generate the masks used in this method.
-     * @see {@link #areAdjacent(short cellA, short cellB, ValueFormat format)} - Checks if two cells are
-     *      adjacent in the grid.
+     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     * @see #areAdjacent(short cellA, short cellB, ValueFormat format)
      */
     public final void click(short[] cells) {
         for (short cell : cells) {

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -86,12 +86,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * performance. Static members are effectively immutable after initialization and are safe to be
  * shared across threads.
  * </p>
- *
- * @see CombinationGeneratorTask
- * @see Grid13
- * @see Grid22
- * @see Grid35
- * @see TestClickCombination
+ * 
  * @since 2025.03 - Initial Creation
  * @performance Critical operations like {@link #click(short)} and state checks are {@code O(1)} due
  *              to extensive pre-computation. The majority of computational complexity is handled
@@ -104,160 +99,85 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  */
 public abstract class Grid {
     /**
-     * Format specification for cell values in the grid.
-     * 
+     * Defines the different formats used to represent a cell's location on the grid.
+     *
      * <p>
-     * The grid can represent cell values in three different formats, each with its own advantages and
-     * disadvantages. The {@link #PackedInt PackedInt} format is human-readable and easy to work with
-     * for adjacency calculations, but it isn't the most efficient for storage. The {@link #Index Index}
-     * format is more memory-efficient and is easier for generators to work with, but it isn't as easily
-     * understood by humans. The {@link #Bitmask Bitmask} format allows for compact storage and fast
-     * operations using bitwise logic, but it is the least human-readable and requires more complex
-     * logic to work with.
+     * To balance performance, memory usage, and readability, the solver uses multiple ways to identify
+     * a cell. This {@code enum} provides a type-safe way to distinguish between them and prevents the
+     * use of "magic numbers," improving maintainability.
      * </p>
      * 
-     * <p>
-     * To streamline the codebase and clarify the operations used, we defined these formats as an enum,
-     * letting us switch between them easily and avoid magic numbers. This also facilitates future
-     * expansions or modifications to the formats, as we can simply add new enum values and update the
-     * relevant methods accordingly, improving maintainability.
-     * </p>
-     * 
-     * @since 2025.07 - ValueFormat Enum Introduction
+     * @since 2025.07 - {@code ValueFormat} Enum Introduction
      * @performance {@code O(1)} access time.
-     * @threading This enum is immutable and therefore thread-safe.
-     * @optimization Using an enum improves code clarity and maintainability by avoiding "magic numbers" for
-     *               format types.
+     * @threading Thread-safe as an immutable {@code enum}.
+     * @memory Minimal memory overhead as a singleton per {@code enum} constant.
      */
     public enum ValueFormat {
         /**
-         * A format where each cell is represented as a packed integer, with the row and column encoded as
-         * {@code row * 100 + col}. For example, the cell at row 3, column 5 would be represented as
-         * 305.
-         * 
+         * A human-readable format where a cell's location is encoded as {@code (row * 100 + col)}.
+         *
          * <p>
-         * This format is human-readable and easy to work with for adjacency calculations, as the row and
-         * column can be easily extracted using simple arithmetic. However, it isn't the most efficient for
-         * storage, as it uses more bits than necessary to represent the cell values.
+         * For example, the cell at row 3, column 5 is represented as {@code 305}. This format is intuitive
+         * and simplifies adjacency arithmetic, but it is not as memory-efficient as {@link #Index}. It is
+         * primarily used for debugging, configuration, and initial adjacency calculations during static
+         * initialization. While cell identifiers are stored as {@code short}s, the "PackedInt" name is
+         * retained for historical consistency.
          * </p>
-         * 
-         * <p>
-         * It's worth noting that, as of July 24th, 2025, most of our codebase has been updated to use
-         * {@code short}s instead of {@code int}s for cell values, due to the grid's size fitting
-         * comfortably within the range of a {@code short}. However, the naming has persisted for
-         * clarity and consistency, as the format's structure remains unchanged. "PackedShort" would be more
-         * accurate, but it would require modifying a significant portion of the codebase, which may not be
-         * worth the effort at this time.
-         * </p>
-         * 
-         * <h3>Performance Considerations</h3>
-         * <p>
-         * While this format is easy to understand and work with, it does incur some overhead in terms of
-         * storage and computation. Each packed integer requires more bits than necessary, and operations
-         * like adjacency checks require additional arithmetic to extract the row and column.
-         * </p>
-         * 
-         * <p>
-         * Our codebase uses this format primarily for human-readable outputs and for operations that
-         * benefit from the clarity of row and column representation (e.g., adjacency calculations).
-         * However, we avoid using it in performance-critical paths where efficiency is paramount.
-         * </p>
-         * 
+         *
          * @see #indexToPacked(short)
          * @see #packedToIndex(short)
-         * @since 2025.07 - ValueFormat Enum Introduction
+         * @since 2025.07 - {@code ValueFormat} Enum Introduction
          * @performance {@code O(1)} access time.
-         * @threading This enum value is an immutable constant and is thread-safe.
-         * @optimization This format is used for human-readable output and for clarity in adjacency
-         *               calculations. It is avoided in performance-critical paths, which prefer the
-         *               {@link #Index} format.
+         * @threading Thread-safe as an immutable {@code enum}.
+         * @memory Minimal memory overhead as a singleton per enum constant.
          */
         PackedInt,
         /**
-         * A format where each cell is represented as a zero-based index, ranging from {@code 0} to
-         * {@code 108} for our {@value Grid#NUM_CELLS}-cell grid. The index is calculated based on the
-         * cell's position in a flattened array representation of the grid.
-         * 
+         * A zero-based index from {@code 0} to {@code 108}, representing a cell's position in the flattened
+         * grid.
+         *
          * <p>
-         * This format is more memory-efficient than {@link #PackedInt PackedInt}, as it uses the minimum
-         * number of bits necessary to represent the cell values. It is also easier for generators to work
-         * with, as they can simply iterate over the indices to generate combinations. However, it isn't as
-         * easily understood by humans, as the row and column information is not directly encoded in the
-         * index.
+         * This is the primary format used in many performance-critical code paths, such as in caches and
+         * generator tasks. It offers a compact and efficient way to iterate over cells and is the native
+         * format for most internal data structures (along with {@link #Bitmask}). However, it is less
+         * intuitive for humans to read compared to {@link #PackedInt}.
          * </p>
-         * 
-         * <h3>Performance Considerations</h3>
-         * <p>
-         * In comparison with the {@code PackedInt} format, this format is more efficient in terms of
-         * storage, as it uses fewer bits to represent the cell values. However, operations that require
-         * multiple cell accesses and/or modifications may benefit from using the {@link #Bitmask Bitmask}
-         * format instead, as it can allow for operations in parallel.
-         * </p>
-         * 
+         *
          * @see #indexToPacked(short)
          * @see #packedToIndex(short)
-         * @since 2025.07 - ValueFormat Enum Introduction
+         * @since 2025.07 - {@code ValueFormat} Enum Introduction
          * @performance {@code O(1)} access time.
-         * @threading This enum value is an immutable constant and is thread-safe.
-         * @optimization This format provides a compact, efficient representation for iterating through
-         *               cells, making it ideal for generator tasks.
+         * @threading Thread-safe as an immutable {@code enum}.
+         * @memory Minimal memory overhead as a singleton per enum constant.
          */
         Index,
         /**
-         * A format where the entire grid state is represented as a bitmask, with each bit corresponding to
-         * a cell in the grid. A bit value of 1 indicates that the cell is "on" ({@code true}), while a bit
-         * value of 0 indicates that the cell is "off" ({@code false}).
-         * 
+         * A format representing the entire grid state as a bitmask. This format is not used to identify
+         * individual cells but is included for completeness.
+         *
          * <p>
-         * This format allows for compact storage and fast operations using bitwise logic, as multiple cell
-         * states can be manipulated in parallel. However, it is the least human-readable of the three
-         * formats, as the individual cell states are not directly visible. It also requires more complex
-         * logic to work with, as operations like adjacency checks and cell clicks need to be implemented
-         * using bitwise operations.
+         * The {@link #gridState grid state} is stored internally as a {@code long[2]} bitmask. This
+         * {@code enum} value signifies operations or data related to this internal representation, such as
+         * the {@link #click(long[])} method. Methods that accept or return a single cell value will
+         * typically throw an {@link IllegalArgumentException} if this format is specified.
          * </p>
-         * 
-         * <h3>Performance Considerations</h3>
-         * <p>
-         * While this format carries several efficiency advantages, it is rarely used in our current
-         * codebase due to its trade-offs. Further complicating matters is Java's lack of a native 128-bit
-         * primitive type, which would be ideal for representing our 109-cell grid in a single bitmask.
-         * Without such a type, we are forced to split the grid state across two 64-bit {@code long}s, which
-         * adds complexity and slightly diminishes the performance benefits of using a bitmask.
-         * </p>
-         * 
-         * <p>
-         * Despite this, we could still see some benefits from using this format in certain scenarios.
-         * Combinations of clicks could be represented as bitmasks, allowing for fast application to the
-         * grid state using two bitwise OR operations. Our current codebase hasn't explored this avenue yet,
-         * but it remains a potential optimization for the future to squeeze out additional performance,
-         * especially for operations involving very long click combinations.
-         * </p>
-         * 
+         *
          * @see #gridState
          * @see #clearBit(int)
          * @see #click(long[])
          * @see #getBit(int)
+         * @see #getGridState()
          * @see #setBit(int)
-         * @since 2025.07 - ValueFormat Enum Introduction
+         * @since 2025.07 - {@code ValueFormat} Enum Introduction
          * @performance {@code O(1)} access time.
-         * @threading This enum value is an immutable constant and is thread-safe.
-         * @optimization This format is primarily for internal grid state representation and is not exposed
-         *               in most public methods due to its complexity and Java's lack of a native 128-bit
-         *               primitive type.
+         * @threading Thread-safe as an immutable {@code enum}.
+         * @memory Minimal memory overhead as a singleton per enum constant.
          */
         Bitmask
     }
-    
+
     /**
-     * The number of rows in the grid. This is a constant value of {@value #NUM_ROWS}, as the grid is
-     * defined to have {@value #NUM_ROWS} rows.
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
-     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
-     * of grid operations and ensuring that all methods operate within the valid range of rows.
-     * </p>
+     * The number of rows in the hexagonal grid.
      * 
      * @see #EVEN_NUM_COLS
      * @see #NUM_CELLS
@@ -265,20 +185,12 @@ public abstract class Grid {
      * @see #ROW_OFFSETS
      * @since 2025.03 - Grid Definition
      * @performance {@code O(1)} access time.
-     * @threading This constant is immutable and thread-safe.
-     * @optimization Using a named constant improves code clarity and maintainability.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     public static final int NUM_ROWS = 7;
     /**
-     * The number of columns in odd-indexed rows of the grid. This is a constant value of
-     * {@value #ODD_NUM_COLS}, as defined by the grid's structure.
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
-     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
-     * of grid operations and ensuring that all methods operate within the valid range of columns.
-     * </p>
+     * The number of columns in the odd-indexed rows of the grid (rows 1, 3, 5).
      * 
      * @see #EVEN_NUM_COLS
      * @see #NUM_CELLS
@@ -286,20 +198,12 @@ public abstract class Grid {
      * @see #ROW_OFFSETS
      * @since 2025.03 - Grid Definition
      * @performance {@code O(1)} access time.
-     * @threading This constant is immutable and thread-safe.
-     * @optimization Using a named constant improves code clarity and maintainability.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     public static final int ODD_NUM_COLS = 15;
     /**
-     * The number of columns in even-indexed rows of the grid. This is a constant value of
-     * {@value #EVEN_NUM_COLS}, as defined by the grid's structure.
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
-     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
-     * of grid operations and ensuring that all methods operate within the valid range of columns.
-     * </p>
+     * The number of columns in the even-indexed rows of the grid (rows 0, 2, 4, 6).
      * 
      * @see #NUM_CELLS
      * @see #NUM_ROWS
@@ -307,279 +211,207 @@ public abstract class Grid {
      * @see #ROW_OFFSETS
      * @since 2025.03 - Grid Definition
      * @performance {@code O(1)} access time.
-     * @threading This constant is immutable and thread-safe.
-     * @optimization Using a named constant improves code clarity and maintainability.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     public static final int EVEN_NUM_COLS = 16;
     /**
-     * Offsets for each row in the grid, used to convert between {@link ValueFormat#PackedInt PackedInt}
-     * and {@link ValueFormat#Index Index} formats.
-     * 
+     * Pre-computed offsets for the starting index of each row in the flattened grid.
+     *
      * <p>
-     * {@code PackedInt} format is human-readable and easy to work with for adjacency calculations, but
-     * it isn't the most efficient for storage. {@code Index} format is more memory-efficient and is
-     * easier for generators to work with, but it isn't as easily understood by humans. The offsets
-     * bridge the gap between these two formats, allowing us to convert between them without losing
-     * information.
+     * This array is used to accelerate the conversion from {@link ValueFormat#PackedInt} to
+     * {@link ValueFormat#Index} by providing an {@code O(1)} lookup for the base index of any given
+     * row. For example, {@code ROW_OFFSETS[2]} gives the index of the first cell in row 2.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Lookup time for the offsets is {@code O(1)} since they are stored in a static array. Testing has
-     * shown that using a static array is more efficient than calculating the offsets at runtime, at
-     * least for {@code PackedInt} -> {@code Index} conversions.
-     * </p>
-     * 
+     *
      * @see #EVEN_NUM_COLS
      * @see #NUM_ROWS
      * @see #ODD_NUM_COLS
      * @see #computePackedToIndex(short)
      * @see ValueFormat
-     * @since 2025.06 - BitSet Grid State
-     * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after static initialization and is thread-safe.
-     * @optimization Using a pre-computed static array for conversions avoids runtime calculations.
+     * @since 2025.06 - {@link java.util.BitSet BitSet} Grid State
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 14 bytes (7 shorts) as a {@code short[]}.
      */
     public static final short[] ROW_OFFSETS = {0, 16, 31, 47, 62, 78, 93};
     /**
-     * The total number of cells in the grid. This is a constant value of {@value #NUM_CELLS}, derived
-     * from the grid's structure of {@value #NUM_ROWS} rows with alternating counts of
-     * {@value #EVEN_NUM_COLS} and {@value #ODD_NUM_COLS} columns.
-     * 
+     * The total number of cells in the grid.
+     *
      * <p>
-     * The grid consists of {@value #NUM_ROWS} rows, where even-indexed rows (0, 2, 4, 6) contain
-     * {@value #EVEN_NUM_COLS} columns each, and odd-indexed rows (1, 3, 5) contain
-     * {@value #EVEN_NUM_COLS} columns each. This results in a total of 4 * {@value #EVEN_NUM_COLS} + 3
-     * * {@value #ODD_NUM_COLS} = {@value NUM_CELLS} cells.
+     * Calculated from the number of rows and their respective column counts: <code>(4 rows ×
+     * {@value #EVEN_NUM_COLS} cols) + (3 rows × {@value #ODD_NUM_COLS} cols) =
+     * {@value #NUM_CELLS}</code> total cells. This constant is used to define the size of arrays and
+     * loop bounds throughout the class.
      * </p>
      * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
-     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
-     * of grid operations and ensuring that all methods operate within the valid range of cells.
-     * </p>
-     * 
-     * @see #EVEN_NUM_COLS
      * @see #gridState
      * @see #NUM_ROWS
-     * @see #ODD_NUM_COLS
      * @see #ROW_OFFSETS
      * @see #trueCellsCount
      * @since 2025.04 - Static Block Initialization
      * @performance {@code O(1)} access time.
-     * @threading This constant is immutable and thread-safe.
-     * @optimization Using a named constant improves code clarity and maintainability.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     public static final int NUM_CELLS = 109;
 
     /**
-     * The current state of the grid as an array of two{@code long}s. Each long contains a bitmask, with
-     * the first representing the first 64 cells and the second representing the last 45 cells.
-     * 
+     * The state of the grid, represented as a 128-bit {@link ValueFormat#Bitmask bitmask} split across
+     * two {@code long} values.
+     *
      * <p>
-     * The core part of the grid state is, well, the grid state. We need something that can efficiently
-     * represent the state of the grid, allowing for fast access and manipulation of each cell while
-     * also keeping memory usage low. The bitmask approach fits both of these requirements, making
-     * operations very efficient.
+     * A {@code 1} at a given bit position indicates the cell is {@code true} while a {@code 0}
+     * indicates it is {@code false} The first {@code long} ({@code gridState[0]}) stores the state for
+     * cells 0-63, and the second ({@code gridState[1]}) stores the state for cells 64-108.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
+     *
      * <p>
-     * The fundamental rule of JVM optimization: <b>Don't allocate</b>. To achieve a throughput of tens
-     * of billions of {@code click}s per second, we need to avoid unnecessary allocations and use
-     * primitive types wherever possible. This takes most collections off the table.
+     * This primitive array representation was chosen over {@link java.util.BitSet} and the Vector API
+     * to eliminate object allocation overhead and ensure cache-friendliness in the hot path. While
+     * Java's lack of a 128-bit primitive adds complexity, this approach provides the highest
+     * performance on the modern JVM for the solver's workload.
      * </p>
-     * 
-     * <p>
-     * An array of {@code boolean}s seems like a good fit, but a {@code boolean} takes up 1 byte at
-     * minimum in Java (with arrays using extra padding), which would require 109 bytes for the grid. In
-     * addition, clicks act on adjacent cells, meaning that each operation would require 6 lookups and 6
-     * updates, which is suboptimal.
-     * </p>
-     * 
-     * <p>
-     * {@link java.util.BitSet BitSets} are a good fit, but they incur some overhead in terms of object
-     * headers and the need to perform up to 6 XOR operations per click. Their internals give way to the
-     * best implementation: a bitmask. We can make custom masks to represent click operations, turning
-     * clicks into a single operation (technically two because of size limitations) and storing our grid
-     * in an array that takes up just 128 bits (or 16 bytes).
-     * </p>
-     * 
-     * <p>
-     * There could be some further optimizations in the future, but we're running against the limits of
-     * Java as a whole. There is no 128-bit primitive type, so we can't use that. LongVectors seemed
-     * promising, but the Vector API allocates TERRIBLY (we're talking 4 allocations per lanewise
-     * operation, all from the internal non-overridable logic of the API). Until we can find something
-     * that can represent a 128-bit value without allocations, we will stick with this approach.
-     * </p>
-     * 
+     *
      * @see #clearBit(int)
      * @see #getBit(int)
      * @see #getGridState()
      * @see #printGrid()
      * @see #setBit(int)
      * @since 2025.07 - Bitmasked Grid State
-     * @performance {@code O(1)} access and update time.
-     * @threading Not thread-safe. Access must be synchronized externally.
-     * @optimization Uses a primitive {@code long[]} bitmask to avoid object allocation overhead,
-     *               enabling extremely fast, cache-friendly state manipulation via bitwise operations.
+     * @performance {@code O(1)} accesses and modifications using bitwise operations.
+     * @threading Not thread-safe. Instances of {@code Grid} must not be shared between threads without
+     *            external synchronization.
+     * @memory Fixed memory footprint of 16 bytes (2 {@code long}s) per instance.
      */
     protected final long[] gridState = new long[2];
     /**
-     * Cached value of the number of cells that are currently {@code true} (on) in the grid. Used for
-     * quick {@link #isSolved() solution checks} and to optimize certain operations. Updated whenever
-     * {@link #getTrueCount()} is called and {@link #recalculationNeeded} is {@code true}.
-     * 
-     * @see #getTrueCount()
-     * @see #isSolved()
+     * A cached count of the number of "on" ({@code true}) cells in the grid.
+     *
+     * <p>
+     * This value is updated lazily. It is only recalculated by methods like {@link #getTrueCount()} or
+     * {@link #findFirstTrueCell(ValueFormat)} when the {@link #recalculationNeeded} flag is
+     * {@code true}. This makes {@link #isSolved()} checks instantaneous in most cases.
+     * </p>
+     *
      * @since 2025.07 - Bitmasked Grid State
-     * @performance {@code O(1)} access. The value is updated lazily.
-     * @threading Not thread-safe. This field is mutated by {@link #click(short)} and read by
-     *            {@link #getTrueCount()}.
-     * @optimization Caches the number of "on" cells to make {@link #isSolved()} checks instantaneous.
-     *               The count is recalculated only when necessary, controlled by
-     *               {@link #recalculationNeeded}.
+     * @performance {@code O(1)} accesses and {@code O(1)} {@link #getTrueCount() recalculations}.
+     * @threading Not thread-safe. Instances of {@code Grid} must not be shared between threads without
+     *            external synchronization.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     protected int trueCellsCount = 0;
     /**
-     * A cached index of the first cell that is currently {@code true} (on) in the grid. Stored in
-     * {@link ValueFormat#Index Index} format and used to optimize constraint satisfaction checks and
-     * certain operations. Updated whenever {@link #findFirstTrueCell(ValueFormat)} is called and
-     * {@link #recalculationNeeded} is {@code true}.
-     * 
-     * @see #findFirstTrueCell()
+     * A cached index of the first "on" ({@code true}) cell in the grid, in {@link ValueFormat#Index}
+     * format.
+     *
+     * <p>
+     * This value is critical for pruning the search space in the {@link CombinationGeneratorTask}, as
+     * any valid solution must interact with the first {@code true} cell. It is updated lazily whenever
+     * {@link #findFirstTrueCell()} is called and {@link #recalculationNeeded} is {@code true}. A value
+     * of {@code -1} indicates no cells are {@code true}.
+     * </p>
+     *
      * @since 2025.07 - First True Cell Caching
-     * @performance {@code O(1)} access. The value is updated lazily.
-     * @threading Not thread-safe. This field is mutated by {@link #click(short)} and read by
-     *            {@link #findFirstTrueCell()}.
-     * @optimization Caches the index of the first "on" cell, a critical optimization for pruning the
-     *               search space in the generator. Recalculated only when needed via
-     *               {@link #recalculationNeeded}.
+     * @performance {@code O(1)} access and {@code O(1)} {@link #findFirstTrueCell() recalculations}.
+     * @threading Not thread-safe. Instances of {@code Grid} must not be shared between threads without
+     *            external synchronization.
+     * @memory Fixed memory footprint of 2 bytes as a primitive {@code short}.
      */
     protected short firstTrueCell = -1;
     /**
-     * A flag indicating whether a recalculation of {@link #trueCellsCount} and/or
-     * {@link #firstTrueCell} is needed. Set to {@code true} whenever the grid state is modified
-     * (e.g., via a click operation) and reset to {@code false} after the next call to
-     * {@link #getTrueCount()} or {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()}.
+     * A dirty flag indicating that the {@link #gridState grid state} has been modified and cached
+     * values are stale.
+     *
+     * <p>
+     * This flag is set to {@code true} by any {@code click} operation. It signals to accessor methods
+     * like {@link #getTrueCount()} and {@link #findFirstTrueCell()} that they must recompute the
+     * {@link #trueCellsCount} and {@link #firstTrueCell} caches before returning a value. It is reset
+     * to {@code false} after the caches are updated.
+     * </p>
      * 
-     * @see #firstTrueCell
-     * @see #trueCellsCount
      * @since 2025.07 - Bitmasked Grid State
      * @performance {@code O(1)} access.
-     * @threading Not thread-safe. This flag coordinates lazy recalculations.
-     * @optimization Implements a lazy evaluation strategy for {@link #trueCellsCount} and
-     *               {@link #firstTrueCell}, ensuring that expensive recalculations are only performed
-     *               when the state has been modified.
+     * @threading Not thread-safe. Instances of {@code Grid} must not be shared between threads without
+     *            external synchronization.
+     * @memory Fixed memory footprint of 1 byte as a primitive {@code boolean}.
      */
     protected boolean recalculationNeeded = false;
 
     /**
-     * Adjacency masks for each cell in the grid. These are filled in during the {@code static} block of
-     * {@link Grid this class} and are used to quickly determine the adjacent cells for a given cell in
-     * the grid.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Pre-computed {@link ValueFormat#Bitmask bitmasks} representing the result of clicking each cell.
+     *
      * <p>
-     * Pre-computing these masks allows for {@code O(1)} lookups when determining the adjacent cells for
-     * a given cell, avoiding the need to compute adjacencies on-the-fly. This is crucial, as
-     * {@link TestClickCombination monkeys} perform tens of billions of {@code click}s per second (as of
-     * writing this), and we need to ensure that adjacency checks are as fast as possible.
+     * Each entry {@code ADJACENCY_MASKS[i]} is a {@code long[2]} bitmask where the set bits correspond
+     * to the cells adjacent to cell {@code i}. This is the core optimization that makes the
+     * {@link #click(short[]) click} operation an {@code O(1)} bitwise XOR, as it eliminates the need
+     * for runtime adjacency lookups.
      * </p>
-     * 
+     *
      * <p>
-     * We standardize the masks to use 2 {@code long}s for each cell since we have {@value #NUM_CELLS}
-     * cells, which fits comfortably within 128 bits. Though a click could only affect cells in the
-     * range of one of these {@code long}s, we use two for simplicity and to avoid additional complexity
-     * in the hot path. The indices are standardized to follow the {@link ValueFormat#Index Index}
-     * format, consistent with other fields in this class.
+     * This array is populated once in a static initializer block when the class is loaded. Though a
+     * click could only affect cells in one of the two {@code long}s, we store the full {@code long[2]}
+     * for simplicity and to avoid conditional logic in the hot path.
      * </p>
-     * 
+     *
      * @see #NUM_CELLS
-     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.04 - Static Block Initialization
-     * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after {@code static} initialization and is thread-safe.
-     * @optimization Pre-computing adjacency masks is the core optimization that makes
-     *               {@link #click(short)} an {@code O(1)} operation. Each mask represents the bitwise
-     *               change required to toggle all cells adjacent to a given cell.
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant after class initialization.
+     * @memory Fixed memory footprint of ~{@code NUM_CELLS × 2 × 8} bytes as a {@code long[][]}.
      */
     private static final long[][] ADJACENCY_MASKS = new long[NUM_CELLS][2];
-    
-    // Legacy support for existing code that expects adjacency arrays
     /**
-     * Adjacency array for each cell in the grid. Each entry contains a {@code short[]} of the indices
-     * of adjacent cells. These are filled in during the {@code static} block of {@code Grid}'s
-     * initialization, and are used to quickly retrieve results with the
-     * {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
-     * 
-     * <h3>Performance Considerations</h3>
+     * A pre-computed table storing the adjacent cells for each cell as an array of indices.
+     *
      * <p>
-     * Pre-computing these arrays allows for {@code O(1)} lookups when determining the adjacent cells
-     * for a given cell, avoiding the need to compute adjacencies on-the-fly. Previously, we used this
-     * array in the {@link #click(short, ValueFormat) click()} method, but we have since moved to using
-     * the {@link #ADJACENCY_MASKS adjacency masks} for better performance. The array is retained for
-     * use in the {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
+     * Each entry {@code adjacencyArray[i]} contains a {@code short[]} listing the neighbors of cell
+     * {@code i} in {@link ValueFormat#Index} format. This structure provides {@code O(1)} lookups for
+     * the {@link #findAdjacents(short, ValueFormat, ValueFormat)} method and serves as a legacy
+     * alternative to the bitmask-based approach, used in parts of the code that require iterating over
+     * neighbors.
      * </p>
-     * 
+     *
      * @see #NUM_CELLS
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.05 - Adjacency Storage Optimization
      * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after {@code static} initialization and is thread-safe.
-     * @optimization Pre-computing adjacency lists in this array allows the
-     *               {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} methods to
-     *               be fast lookups rather than expensive computations.
+     * @threading Thread-safe as a {@code static final} constant after class initialization.
+     * @memory Fixed memory footprint as a {@code short[][]}.
      */
     private static final short[][] adjacencyArray = new short[NUM_CELLS][]; // Index format
     /**
-     * A 2D {@code boolean} array representing adjacency between cells in the grid. This is a legacy
-     * structure, primarily used for quick adjacency checks between two cells in
-     * {@link #areAdjacent(short, short, ValueFormat) areAdjacent()}. It is filled in during the static
-     * block of Grid's initialization and is not used in performance-critical paths.
-     * 
-     * <h3>Performance Considerations</h3>
+     * A pre-computed boolean matrix for {@code O(1)} adjacency checks between any two cells.
+     *
      * <p>
-     * This structure allows for {@code O(1)} adjacency checks between two cells, which is useful for
-     * certain operations. However, it is not used in the hot path of the application, as most
-     * operations use the {@link #ADJACENCY_MASKS adjacency masks} or the {@link #adjacencyArray
-     * adjacency array} for better performance. The 2D array is retained for legacy support and for use
-     * in specialized operations.
+     * An entry {@code ADJACENCY_CACHE[i][j]} is {@code true} if cell {@code i} and cell {@code j} are
+     * adjacent. This cache is used by {@link #areAdjacent(short, short)} to provide near-instantaneous
+     * lookups. While not used in most hot paths, it is a useful utility for specific algorithmic
+     * checks.
      * </p>
-     * 
+     *
      * @see #NUM_CELLS
-     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.06 - {@code O(1)} Adjacency Check
      * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after static initialization and is thread-safe.
-     * @optimization A pre-computed {@code boolean} matrix that provides a near-instantaneous way to
-     *               check if two cells are adjacent, used by {@link #areAdjacent(short, short)}.
+     * @threading Thread-safe as a {@code static final} constant after class initialization.
      */
     private static final boolean[][] ADJACENCY_CACHE = new boolean[NUM_CELLS][NUM_CELLS]; // Index format
     /**
-     * A cache for converting {@link ValueFormat#PackedInt PackedInt} values to {@link ValueFormat#Index
-     * Index} values. This is filled in during the {@code static} block of {@code Grid}'s initialization
-     * and is used to quickly convert between these two formats without needing to compute the
-     * conversion on-the-fly.
-     * 
-     * <h3>Performance Considerations</h3>
+     * A pre-computed lookup table to accelerate {@link #packedToIndex(short) conversion} from
+     * {@link ValueFormat#PackedInt} to {@link ValueFormat#Index}.
+     *
      * <p>
-     * Pre-computing this cache allows for {@code O(1)} lookups when converting from {@code PackedInt}
-     * to {@code Index} format, avoiding the need to compute the conversion on-the-fly. This is useful
-     * for operations that need to work with both formats, as it allows for quick conversions without
-     * incurring the cost of calculations.
+     * The index of the array corresponds to a {@code PackedInt} value, and the element at that index is
+     * the corresponding {@code Index} value. This provides an {@code O(1)} conversion, avoiding the
+     * arithmetic typically required.
      * </p>
-     * 
+     *
      * @see #NUM_CELLS
      * @see #computePackedToIndex(short)
      * @see ValueFormat
      * @since 2025.06 - {@code PackedInt} to {@code Index} Precomputation
      * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after {@code static} initialization and is thread-safe.
-     * @optimization A cache to accelerate the conversion from the human-readable
-     *               {@link ValueFormat#PackedInt PackedInt} format to the performance-oriented
-     *               {@link ValueFormat#Index Index} format.
+     * @threading Thread-safe as a {@code static final} constant after class initialization.
      */
     private static final short[] PACKED_TO_INDEX_CACHE = new short[(NUM_ROWS - 1) * 100 + EVEN_NUM_COLS];
 
@@ -614,77 +446,55 @@ public abstract class Grid {
     }
 
     /**
-     * Determines the hexagonally adjacent cells for a cell in the grid. This overload allows the user
-     * to specify the input and output formats, providing flexibility in how the static block for this
-     * class is built.
-     * 
+     * Computes the hexagonally adjacent cells for a given cell, supporting flexible input and output
+     * formats.
+     *
      * <p>
-     * Unlike a traditional grid, a cell in a hexagonal grid has up to 6 adjacent cells. The cells
-     * adjacent to a given cell aren't just based on the row and column, but also on the row's parity
-     * (even or odd), making calculations much more complex than a simple rectangular grid. This problem
-     * is exacerbated by the fact that the Grid is represented in a flattened, bitmask format, doing
-     * away with the concept of rows and columns entirely for memory efficiency. Since {@code click}
-     * operations affect the adjacent cells, we need some way to determine which cells are adjacent to a
-     * given cell. This method provides that functionality.
+     * This method is primarily used during the {@code static} initialization block to build the
+     * {@link #adjacencyArray} and {@link #ADJACENCY_MASKS}. It handles the complex adjacency rules of a
+     * hexagonal grid, which vary based on a cell's row and column parity, unlike a simple rectangular
+     * grid.
      * </p>
-     * 
-     * <h3>Algorithm Details</h3> For a given cell {@code n} (in {@link ValueFormat#PackedInt} format)
-     * in an even row, the adjacent cells include:
+     *
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * Adjacency calculations are performed using the {@link ValueFormat#PackedInt} format internally
+     * due to its straightforward arithmetic for determining relative positions. The algorithm
+     * dynamically adds potential neighbors based on the cell's row parity (even or odd).
+     * </p>
      * <ul>
-     * <li>{@code n - 101} (row - 1, col - 1)</li>
-     * <li>{@code n - 100} (row - 1, col)</li>
-     * <li>{@code n - 1} (row, col - 1)</li>
-     * <li>{@code n + 1} (row, col + 1)</li>
-     * <li>{@code n + 99} (row + 1, col - 1)</li>
-     * <li>{@code n + 100} (row + 1, col)</li>
+     * <li><b>Even Rows:</b> Cells {@code (row-1, col-1)}, {@code (row-1, col)}, {@code (row, col-1)},
+     * {@code (row, col+1)}, {@code (row+1, col-1)}, {@code (row+1, col)}.</li>
+     * <li><b>Odd Rows:</b> Cells {@code (row-1, col)}, {@code (row-1, col+1)}, {@code (row, col-1)},
+     * {@code (row, col+1)}, {@code (row+1, col)}, {@code (row+1, col+1)}.</li>
      * </ul>
-     * 
-     * For a cell in an odd row, the adjacent cells include:
-     * <ul>
-     * <li>{@code n - 100} (row - 1, col)</li>
-     * <li>{@code n - 99} (row - 1, col + 1)</li>
-     * <li>{@code n - 1} (row, col - 1)</li>
-     * <li>{@code n + 1} (row, col + 1)</li>
-     * <li>{@code n + 100} (row + 1, col)</li>
-     * <li>{@code n + 101} (row + 1, col + 1)</li>
-     * </ul>
-     * 
+     * <p>
+     * After identifying potential neighbors, the method filters out any cells that fall outside the
+     * grid boundaries.
+     * </p>
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * Internal computations are performed in {@code PackedInt} format for efficiency, as it allows for
-     * straightforward arithmetic operations to determine adjacency. The method has to convert between
-     * formats as needed, which adds some overhead, but this is offset by our use of the method in the
-     * {@code static} block to pre-compute an {@link #adjacencyArray adjacency table}. Future calls to
-     * find adjacents can then use this pre-computed table for {@code O(1)} lookups.
+     * The method's complexity is {@code O(1)} because the number of potential neighbors is small and
+     * constant (at most 6). It uses FastUtil's {@link ShortArrayList} to efficiently store results
+     * without boxing overhead. While format conversions add minor overhead, this is acceptable as the
+     * method's primary use case is during the one-time {@code static} initialization.
      * </p>
-     * <p>
-     * Since cells in different grid positions can have a different number of valid adjacent cells (due
-     * to edges and corners), we use a dynamic list ({@code ShortList}) to store the results, letting
-     * the calling method handle conversion to a fixed-size array if needed. Fastutil's primitive
-     * collections are used to avoid boxing overhead and allow for efficient storage and retrieval of
-     * short values.
-     * </p>
-     * 
-     * @param cell         A short representing the cell in the grid, expected to be in the same format
-     *                     as inputFormat.
-     * @param inputFormat  The {@link ValueFormat} of the input cell, which can either be
-     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @param outputFormat The {@link ValueFormat} of the output cell, which can either be
-     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return affectedPieces A {@code ShortList} of adjacent cells in the specified output format,
-     *         containing up to 6 items.
-     * @throws IllegalArgumentException if the input or output format is {@link ValueFormat#Bitmask},
-     *                                  since we cannot represent a single cell in that format.
-     * @see #findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     *
+     * @param cell         The cell for which to find adjacents, in the specified {@code inputFormat}.
+     * @param inputFormat  The {@link ValueFormat} of the input {@code cell}.
+     * @param outputFormat The {@link ValueFormat} in which the adjacent cells should be returned.
+     * @return A {@link ShortList} of adjacent cells in the specified {@code outputFormat}.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used for {@code inputFormat}
+     *                                  or {@code outputFormat}, as it is not suitable for single-cell
+     *                                  representation.
+     * @see #findAdjacents(short, ValueFormat, ValueFormat)
+     * @see ShortArrayList#ShortArrayList(int)
      * @see ShortList
      * @since 2025.07 - Format Support
-     * @performance Overall {@code O(1)} complexity. The number of adjacent cells is small and constant.
-     * @threading This method is thread-safe as it is a pure function with no side effects.
-     * @memory Uses a {@code ShortList} from FastUtil to avoid boxing primitive {@code short} values,
-     *         reducing garbage collection pressure compared to a standard {@code ArrayList<Short>}.
-     * @optimization Internal calculations are performed in {@link ValueFormat#PackedInt} for simpler
-     *               arithmetic. The use of {@code ShortList} avoids an initial pass to count valid
-     *               neighbors before creating a perfectly sized array.
+     * @performance {@code O(1)} complexity due to constant number of potential neighbors.
+     * @threading Thread-safe; does not modify instance state.
+     * @memory Allocates a new {@code ShortArrayList} of capacity 6 for the result.
      */
     public static ShortList computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         ShortList affectedPieces = new ShortArrayList(6);
@@ -701,11 +511,11 @@ public abstract class Grid {
                 // If the cell is in packed int format, we can directly compute adjacents
                 break;
         }
-        
+
         int row = cell / 100;
 
         if (row % 2 == 0) // even rows with 16 columns
-        { 
+        {
             affectedPieces.add((short) (cell - 101)); // (row - 1, col - 1)
             affectedPieces.add((short) (cell - 100)); // (row - 1, col)
             affectedPieces.add((short) (cell - 1));   // (row, col - 1)
@@ -713,7 +523,7 @@ public abstract class Grid {
             affectedPieces.add((short) (cell + 99));  // (row + 1, col - 1)
             affectedPieces.add((short) (cell + 100)); // (row + 1, col)
         } else // odd rows with 15 columns
-        { 
+        {
             affectedPieces.add((short) (cell - 100)); // (row - 1, col)
             affectedPieces.add((short) (cell - 99));  // (row - 1, col + 1)
             affectedPieces.add((short) (cell - 1));   // (row, col - 1)
@@ -745,102 +555,81 @@ public abstract class Grid {
     }
 
     /**
-     * Overload of {@link #computeAdjacents(short, ValueFormat, ValueFormat) computeAdjacents()} that
-     * assumes the input and output formats are the same. This exists purely for convenience, as it
-     * simply calls the main method with the same format for both parameters.
-     * 
-     * @param cell   a {@code short} representing the cell in the grid, expected to be in the same
-     *               format as {@code format}.
-     * @param format the {@link ValueFormat} of both the input and output cell, which can either be
-     *               {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return A {@code ShortList} of adjacent cells in the specified format, containing up to 6
-     *         items.
-     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
-     *                                  represent a single cell in that format.
+     * Convenience overload for {@link #computeAdjacents(short, ValueFormat, ValueFormat)} that assumes
+     * the input and output formats are the same.
+     *
+     * @param cell   The cell for which to find adjacents.
+     * @param format The {@link ValueFormat} for both the input cell and the output adjacent cells.
+     * @return A {@link ShortList} of adjacent cells in the specified {@code format}.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used.
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
-     * @see ShortList
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity. Delegates to the main implementation.
-     * @threading This method is thread-safe.
-     * @memory Creates a new {@code ShortList} for the result.
-     * @optimization Convenience overload.
+     * @performance Delegates to the main implementation; {@code O(1)} complexity.
+     * @threading Thread-safe; delegates to a {@link #computeAdjacents(short, ValueFormat, ValueFormat)
+     *            thread-safe method}.
+     * @memory Allocates a new {@code ShortArrayList} with a capacity of 6 for the result.
      */
     public static ShortList computeAdjacents(short cell, ValueFormat format) {
         return computeAdjacents(cell, format, format);
     }
 
     /**
-     * Overload of {@link #computeAdjacents(short, ValueFormat) computeAdjacents()} that assumes that
-     * the format is {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply
-     * calls the main method with {@code Index} for both parameters.
-     * 
-     * @param cell a {@code short} representing the cell in the grid, expected to be in
-     *             {@link ValueFormat#Index Index} format.
-     * @return A {@code ShortList} of adjacent cells in {@link ValueFormat#Index Index} format,
-     *         containing up to 6 items.
-     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
-     *                                  represent a single cell in that format.
+     * Convenience overload for {@link #computeAdjacents(short, ValueFormat)} that assumes
+     * {@link ValueFormat#Index} for both input and output.
+     *
+     * @param cell The cell for which to find adjacents, in {@link ValueFormat#Index} format.
+     * @return A {@link ShortList} of adjacent cells in {@link ValueFormat#Index} format.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is implicitly used (though
+     *                                  unlikely with this overload).
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
-     * @see ShortList
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity. Delegates to the main implementation.
-     * @threading This method is thread-safe.
-     * @memory Creates a new {@code ShortList} for the result.
-     * @optimization Convenience overload with default format.
+     * @performance Delegates to the main implementation; {@code O(1)} complexity.
+     * @threading Thread-safe; delegates to a {@link #computeAdjacents(short, ValueFormat) thread-safe
+     *            method}.
+     * @memory Allocates a new {@link ShortArrayList} with a capacity of 6 for the result.
      */
     public static ShortList computeAdjacents(short cell) {
         return computeAdjacents(cell, ValueFormat.Index);
     }
 
     /**
-     * Finds the hexagonally adjacent cells for a given cell in the grid, parsing inputs and outputting
-     * in the requested formats.
-     * 
+     * Finds the hexagonally adjacent cells for a given cell, supporting flexible input and output
+     * formats.
+     *
      * <p>
-     * Since our grid is hexagonal, each cell can have up to 6 adjacent cells, depending on the cell's
-     * position and the grid's boundaries. This method provides a way to retrieve those adjacent cells
-     * in various formats, making it versatile for different use cases.
+     * This method retrieves {@link #computeAdjacents(short, ValueFormat, ValueFormat) pre-computed}
+     * adjacency data from the {@link #adjacencyArray}. It handles format conversions as needed, making
+     * it versatile for different use cases, such as debugging, logging, or specific algorithmic checks.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * While this method does pull from a {@link #adjacencyArray pre-computed adjacency array} for
-     * {@code O(1)} lookups, it is forced to convert each of the results to the requested output format,
-     * which adds some overhead and makes the method {@code O(adjacencyArray[cell].length)} in
-     * complexity (with the length being 6 at most). In addition, the large {@code switch} statements
-     * for format handling limit this method's ability to be inlined by the JVM.
+     * The core lookup from {@code adjacencyArray} is an {@code O(1)} operation. However, if the
+     * {@code outputFormat} is not {@link ValueFormat#Index}, the method incurs additional overhead for
+     * converting each adjacent cell's format. This makes the method's complexity {@code O(k)} where
+     * {@code k} is the number of adjacent cells (at most 6). The presence of {@code switch} statements
+     * also limits JIT inlining opportunities.
      * </p>
-     * 
      * <p>
-     * A potential area for optimization would be to pre-compute adjacency arrays for each format
-     * combination, but this method is designed to be called infrequently (if at all) during the
-     * lifetime of the program, so the added complexity and memory usage may not be worth it.
+     * Though specialized caches for each format could solve these problems, since this method is not on
+     * the critical performance path, the overhead of format conversion and branching is deemed
+     * acceptable. For hot paths requiring adjacency information, direct access to
+     * {@link #ADJACENCY_MASKS} or {@code adjacencyArray} in {@link ValueFormat#Index} is preferred.
      * </p>
-     * 
-     * @param cell         A {@code short} representing the cell in the grid, expected to be in the same
-     *                     format as {@code inputFormat}.
-     * @param inputFormat  The {@link ValueFormat} of the input cell, which can either be
-     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @param outputFormat The {@link ValueFormat} of the output cell, which can either be
-     *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return A {@code short[]} of adjacent cells in the specified output format, containing up to 6
-     *         items.
-     * @throws IllegalArgumentException       if the input or output format is
-     *                                        {@link ValueFormat#Bitmask Bitmask}, since we cannot
-     *                                        represent a single cell in that format.
-     * @throws ArrayIndexOutOfBoundsException if the input cell is out of bounds for the specified input
-     *                                        format (implicitly checked by array accesses).
-     * @see #adjacencyArray
-     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
-     * @see ValueFormat
+     *
+     * @param cell         The cell for which to find adjacents.
+     * @param inputFormat  The {@link ValueFormat} of the input {@code cell}.
+     * @param outputFormat The {@link ValueFormat} in which the adjacent cells should be returned.
+     * @return A {@code short[]} of adjacent cells in the specified {@code outputFormat}.
+     * @throws IllegalArgumentException       if {@link ValueFormat#Bitmask} is used for
+     *                                        {@code inputFormat} or {@code outputFormat}.
+     * @throws ArrayIndexOutOfBoundsException if the input {@code cell} is out of bounds for the
+     *                                        specified {@code inputFormat}.
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} for {@link ValueFormat#Index} output,
-     *              {@code O(adjacencyArray[cell].length)} for other formats due to conversion.
-     * @threading This method is thread-safe, as it relies only on immutable, pre-computed
-     *            {@code static} data.
+     * @performance {@code O(1)} for {@link ValueFormat#Index} output, otherwise {@code O(k)} where
+     *              {@code k} is the number of adjacent cells (max 6).
+     * @threading Thread-safe; accesses immutable, pre-computed {@code static} data.
      * @memory Allocates a new {@code short[]} for the result only if format conversion is necessary.
-     * @optimization The primary lookup from {@link #adjacencyArray} is an {@code O(1)} operation. The
-     *               main performance consideration is the potential overhead of format conversion.
      */
     public static short[] findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] result;
@@ -881,92 +670,65 @@ public abstract class Grid {
     }
 
     /**
-     * Overload of {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} that assumes
-     * the input and output formats are the same. This exists purely for convenience, as it simply calls
-     * the main method with the same format for both parameters.
-     * 
-     * @param cell   a {@code short} representing the cell in the grid, expected to be in the same
-     *               format as {@code format}.
-     * @param format the {@link ValueFormat} of both the input and output cell, which can either be
-     *               {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return A {@code short[]} of adjacent cells in the specified format, containing up to 6 items.
-     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
-     *                                  represent a single cell in that format.
-     * @see #findAdjacents(short)
+     * Convenience overload for {@link #findAdjacents(short, ValueFormat, ValueFormat)} that assumes the
+     * input and output formats are the same.
+     *
+     * @param cell   The cell for which to find adjacents.
+     * @param format The {@link ValueFormat} for both the input cell and the output adjacent cells.
+     * @return A {@code short[]} of adjacent cells in the specified {@code format}.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used.
+     * @see #findAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity. Delegates to the main implementation.
-     * @threading This method is thread-safe.
-     * @memory May allocate a new {@code short[]} if format conversion occurs.
-     * @optimization Convenience overload.
+     * @performance Delegates to the main implementation; {@code O(k)} complexity where {@code k} is the
+     *              number of adjacent cells.
+     * @threading Thread-safe; delegates to a {@link #findAdjacents(short, ValueFormat, ValueFormat)
+     *            thread-safe method}.
+     * @memory Allocates a new {@code short[]} for the result only if format conversion is necessary.
      */
     public static short[] findAdjacents(short cell, ValueFormat format) {
         return findAdjacents(cell, format, format);
     }
 
     /**
-     * Overload of {@link #findAdjacents(short, ValueFormat) findAdjacents()} that assumes that the
-     * format is {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls
-     * the main method with {@code Index} for both parameters.
-     * 
-     * @param cell a {@code short} representing the cell in the grid, expected to be in
-     *             {@link ValueFormat#Index Index} format.
-     * @return A {@code short[]} of adjacent cells in {@link ValueFormat#Index Index} format, containing
-     *         up to 6 items.
-     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
-     *                                  represent a single cell in that format.
-     * @see #findAdjacents(short, ValueFormat)
+     * Convenience overload for {@link #findAdjacents(short, ValueFormat)} that assumes
+     * {@link ValueFormat#Index} for both input and output.
+     *
+     * @param cell The cell for which to find adjacents, in {@link ValueFormat#Index} format.
+     * @return A {@code short[]} of adjacent cells in {@link ValueFormat#Index} format.
+     * @see #findAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} adjacency lookup.
-     * @threading This method is thread-safe.
-     * @memory Returns a reference to a statically allocated array, avoiding new allocations.
-     * @optimization The most direct and efficient way to get adjacents, as no format conversion is
-     *               needed.
+     * @performance {@code O(1)} complexity as it directly returns a reference to a pre-computed array.
+     * @threading Thread-safe; delegates to a {@link #findAdjacents(short, ValueFormat) thread-safe
+     *            method}.
+     * @memory Does not allocate; returns a reference to an existing {@code short[]}.
      */
     public static short[] findAdjacents(short cell) {
         return findAdjacents(cell, ValueFormat.Index);
     }
 
     /**
-     * Computes the conversion from {@link ValueFormat#PackedInt PackedInt} format to
-     * {@link ValueFormat#Index Index} format. This method performs the necessary arithmetic to
-     * determine the correct {@code Index} for a given {@code PackedInt} value.
-     * 
-     * <h3>Algorithm Details</h3>
+     * Computes the {@link #packedToIndex(short) conversion} from {@link ValueFormat#PackedInt} to
+     * {@link ValueFormat#Index} format.
+     *
      * <p>
-     * The conversion is based on the structure of the grid, which has rows of varying lengths. The
-     * first row has {@value #EVEN_NUM_COLS} columns, the second row has {@value #ODD_NUM_COLS} columns,
-     * and this pattern continues to alternate. To convert a {@code PackedInt} value (which encodes the
-     * row and column) to an {@code Index} value (which is a single {@code short} representing the
-     * cell's position in a flattened array), we need to account for the varying row lengths.
+     * This method performs the necessary arithmetic to determine the correct {@code Index} for a given
+     * {@code PackedInt} value, taking into account the varying row lengths of the hexagonal grid. It
+     * extracts the row and column from the {@code PackedInt} and uses the {@link #ROW_OFFSETS} array to
+     * calculate the flattened index.
      * </p>
-     * 
+     *
      * <p>
-     * After obtaining the row and column from the {@code PackedInt} value, we use a {@link #ROW_OFFSETS
-     * pre-defined array of row offsets} to determine the starting index of the row in the flattened
-     * array. We then add the column to this offset to get the final index.
+     * This method is primarily used during {@code static} initialization to populate the
+     * {@link #PACKED_TO_INDEX_CACHE}. It does not perform bounds checking, assuming valid input during
+     * its intended use.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is designed to be used by the {@code static} block of the {@code Grid} class to
-     * pre-compute a {@link #PACKED_TO_INDEX_CACHE cache} for fast lookups. While the method itself is
-     * {@code O(1)} in complexity, it is not intended to be called frequently during the program's
-     * execution. Instead, it serves as a utility for initializing the cache, which can then be used for
-     * {@code O(1)} lookups in performance-critical paths. The method does not perform any bounds
-     * checking on the input packed value, as it is assumed that the static block will only call it with
-     * valid values.
-     * </p>
-     * 
-     * @param packed the {@code short} representing the cell in {@link ValueFormat#PackedInt PackedInt}
-     *               format.
-     * @return A {@code short} representing the cell in {@link ValueFormat#Index Index} format.
-     * @throws ArrayIndexOutOfBoundsException (implicitly) if the input packed value is out of bounds
-     *                                        (less than 0 or greater than 615).
-     * @since 2025.06 - PackedInt to Index Precomputation
+     *
+     * @param packed The cell in {@link ValueFormat#PackedInt} format.
+     * @return The cell in {@link ValueFormat#Index} format.
+     * @since 2025.06 - {@link ValueFormat#PackedInt} to {@link ValueFormat#Index} Precomputation
      * @performance {@code O(1)} complexity due to direct arithmetic and a single array lookup.
-     * @threading This method is thread-safe as it is a pure function.
-     * @memory Does not allocate memory.
-     * @optimization Relies on the pre-computed {@link #ROW_OFFSETS} for fast calculation.
+     * @threading Thread-safe; does not modify instance state.
+     * @memory Does not allocate.
      */
     private static short computePackedToIndex(short packed) {
         short row = (short) (packed / 100);
@@ -975,41 +737,32 @@ public abstract class Grid {
     }
 
     /**
-     * Converts a cell from {@link ValueFormat#PackedInt PackedInt} format to {@link ValueFormat#Index
-     * Index} format. This method uses a cache to speed up conversions for commonly used values, and
-     * {@link #computePackedToIndex(short) calculates} new values as needed.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Converts a cell from {@link ValueFormat#PackedInt} to {@link ValueFormat#Index} format using a
+     * pre-computed cache.
+     *
      * <p>
-     * This method is designed to be efficient, using a cache to store previously computed conversions
-     * for fast lookups. If a value is not found in the cache, it is computed on-the-fly using the
-     * {@link #computePackedToIndex(short) computePackedToIndex()} method.
+     * This method leverages the {@link #PACKED_TO_INDEX_CACHE} for {@code O(1)} lookups. If a value is
+     * not found in the cache (which should only happen for {@code packed = 0} during initial
+     * {@code static} setup), it is computed on-the-fly using {@link #computePackedToIndex(short)}.
      * </p>
-     * 
+     *
+     * <h3>Optimization Rationale</h3>
      * <p>
-     * A potential area for optimization would be to explicitly compute the entire cache in the
-     * {@code static} block to avoid the need for on-the-fly calculations. Doing this would increase the
-     * startup time slightly, but would eliminate the need for any calculations during runtime, allowing
-     * us to remove the check for uncached values and make this method smaller, improving its chances of
-     * being inlined by the JVM. We've chosen not to do this for now, since conversions from the
-     * human-friendly {@code PackedInt} format to the memory efficient {@code Index} format are not a
-     * common operation in performance-critical paths (we try to use {@code Index} internally as much as
-     * possible), but the option remains open for the future.
+     * The cache is partially populated during {@code static} initialization to avoid a full
+     * pre-computation of all possible {@code PackedInt} values, which would increase startup time for a
+     * conversion that is not frequently used in performance-critical paths. A TODO comment indicates a
+     * potential future optimization to fully pre-compute the cache, which would further reduce method
+     * size and improve JIT inlining chances.
      * </p>
-     * 
-     * @param packed A {@code short} representing the cell in {@link ValueFormat#PackedInt PackedInt}
-     *               format.
-     * @return A {@code short} representing the cell in {@link ValueFormat#Index Index} format.
-     * @throws IllegalArgumentException if the input packed value is out of bounds (less than 0 or
-     *                                  greater than 615).
+     *
+     * @param packed The cell in {@link ValueFormat#PackedInt} format.
+     * @return The cell in {@link ValueFormat#Index} format.
+     * @throws IllegalArgumentException if the input {@code packed} value is out of bounds.
      * @see #PACKED_TO_INDEX_CACHE
-     * @see #computePackedToIndex(short)
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity due to direct cache lookup.
-     * @threading This method is thread-safe. The cache is populated statically.
-     * @memory Does not allocate memory.
-     * @optimization Provides an {@code O(1)} alternative to the arithmetic conversion. Declared
-     *               {@code final} to encourage JIT inlining.
+     * @performance {@code O(1)} lookup.
+     * @threading Thread-safe; accesses immutable, pre-computed {@code static} data.
+     * @memory Does not allocate.
      */
     public final static short packedToIndex(short packed) {
         if (packed >= 0 && packed < PACKED_TO_INDEX_CACHE.length) {
@@ -1024,36 +777,29 @@ public abstract class Grid {
     }
 
     /**
-     * Converts a cell from {@link ValueFormat#Index Index} format to {@link ValueFormat#PackedInt
-     * PackedInt} format. This method uses a series of conditional checks to determine the correct row
-     * and column for the given {@code Index}.
-     * 
+     * Converts a cell from {@link ValueFormat#Index} to {@link ValueFormat#PackedInt} format.
+     *
      * <p>
-     * Note that this method does not explicitly check if the input {@code Index} is greater than
-     * {@code 0} for performance. Negative indices may return a value, but they are not valid packed int
-     * values.
+     * This method uses a series of conditional checks to determine the correct row and column for the
+     * given {@code Index}, leveraging the grid's alternating row lengths. It constructs the
+     * {@code PackedInt} value by combining the calculated row and column.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be efficient, using a series of conditional checks to quickly
-     * determine the correct row and column for the given index. If extra performance is needed, we
-     * could cache the results of this method (a similar approach is taken for
-     * {@link #packedToIndex(short)}), but since this method is not frequently called in
-     * performance-critical paths, the added complexity and memory usage may not be worth it.
+     * This method is {@code O(1)} in complexity due to the fixed number of comparisons. It is declared
+     * {@code final} to encourage JIT inlining, as it is a pure function with no side effects. While a
+     * cache could be implemented (similar to {@link #packedToIndex(short)}), it is not deemed necessary
+     * given that this conversion is not frequently called in performance-critical paths.
      * </p>
-     * 
-     * @param index A {@code short} representing the cell in {@link ValueFormat#Index Index} format.
-     * @return A {@code short} representing the cell in {@link ValueFormat#PackedInt PackedInt} format.
-     * @throws IllegalArgumentException if the input index is out of bounds (less than 0 or greater than
-     *                                  108).
-     * @see #packedToIndex(short)
+     *
+     * @param index The cell in {@link ValueFormat#Index} format.
+     * @return The cell in {@link ValueFormat#PackedInt} format.
+     * @throws IllegalArgumentException if the input {@code index} is out of bounds (0-108).
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity. The series of comparisons is constant time.
-     * @threading This method is thread-safe as it is a pure function.
-     * @memory Does not allocate memory.
-     * @optimization A branch-based approach that is friendly to modern CPU branch predictors. Declared
-     *               {@code final} to encourage JIT inlining.
+     * @performance {@code O(1)} comparisons and computation.
+     * @threading Thread-safe; does not modify instance state.
+     * @memory Does not allocate.
      */
     public final static short indexToPacked(short index) {
         if (index < 16) return  (short) (0 * 100 + index);
@@ -1067,75 +813,63 @@ public abstract class Grid {
     }
 
     /**
-     * Constructs a new {@code Grid} instance and initializes it to a specific starting state by calling
-     * the {@link #initialize()} method.
-     * 
+     * Constructs a new {@code Grid} instance and initializes it to a specific starting state.
+     *
      * <p>
-     * Since {@link Grid} is an abstract class, this constructor is called implicitly via a subclass's
-     * constructor. The {@link #initialize()} method is abstract and must be implemented by subclasses
-     * to define their own initial configurations.
+     * As {@code Grid} is an {@code abstract} class, this constructor is implicitly called by concrete
+     * subclass constructors (e.g., {@link Grid13}, {@link Grid22}, {@link Grid35}). It ensures that the
+     * grid is properly set up by invoking the abstract {@link #initialize()} method, which subclasses
+     * must implement to define their unique initial puzzle configurations.
      * </p>
-     * 
+     *
      * @see #initialize()
      * @since 2025.03 - Abstract {@code Grid} Introduction
-     * @threading The constructor is thread-safe as it operates on a new instance.
+     * @performance {@code O(1)} complexity for construction, plus the complexity of
+     *              {@link #initialize()}.
+     * @threading Thread-safe; each instance is independent.
      */
     public Grid() {
         initialize();
     }
 
     /**
-     * Initializes the {@code Grid} to a specific starting state. This method is abstract and must be
-     * implemented by subclasses to define their own initial configurations.
-     * 
+     * Initializes the {@code Grid} instance to a specific starting state.
+     *
      * <p>
-     * This method is called in the {@link #Grid() constructor} of the {@link Grid} class, ensuring that
-     * any subclass will have its {@link #gridState grid state} properly initialized upon instantiation.
-     * The specific implementation of this method will depend on the requirements of the subclass.
+     * This {@code abstract} method must be implemented by concrete subclasses to define their unique
+     * initial puzzle configurations. It is called by the {@link #Grid() constructor} during instance
+     * creation, ensuring the {@link #gridState grid state} is properly set up from the outset.
      * </p>
-     * 
+     *
      * @see Grid13
      * @see Grid22
      * @see Grid35
      * @since 2025.03 - Abstract {@code Grid} Introduction
-     * @threading Not thread-safe. This method modifies the instance's state.
+     * @performance Implementation-dependent.
+     * @threading Not thread-safe; this method modifies the instance's {@link #gridState}.
      */
     abstract void initialize();
 
-    // Core bitmask operations
-
     /**
-     * Sets the bit at the specified index in the {@link #gridState grid state}. We assume that the
-     * index is in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}) to save time on format
-     * checks.
-     * 
+     * Sets the bit at the specified {@link ValueFormat#Index index} in the {@link #gridState grid
+     * state} to {@code true}.
+     *
      * <p>
-     * While this method can be used to toggle a cell in the grid, we pre-compute
-     * {@link #ADJACENCY_MASKS adjacency masks} for each cell to perform clicks more efficiently. As
-     * such, this method is not used in any method of the codebase.
+     * This is a low-level helper method primarily used during grid initialization. It updates the
+     * {@link #gridState bitmask} and increments {@link #trueCellsCount} if the bit was previously
+     * {@code false}. For performance-critical click operations, {@link #click(short[])} is used
+     * instead, which leverages pre-computed {@link #ADJACENCY_MASKS}.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * For performance reasons, this method does not perform bounds checking on the index. It is the
-     * caller's responsibility to ensure that the index is within the valid range
-     * ({@code 0}-{@code 108}).
-     * </p>
-     * <p>
-     * This method checks internally if the bit is already set before setting it, but this move is not
-     * necessary for performance. Removing the check would be more efficient, but we don't utilize this
-     * method for any performance-critical paths.
-     * </p>
-     * 
-     * @param index The index of the bit to set ({@code 0}-{@code 108}).
-     * @throws IndexOutOfBoundsException if the index is out of bounds ({@code 0}-{@code 127}).
+     *
+     * @param index The {@link ValueFormat#Index index} of the bit to set (0-108).
+     * @throws IndexOutOfBoundsException (Implicitly) if the index is out of bounds for the
+     *                                   {@code long[]} array.
      * @see #clearBit(int)
      * @see #getBit(int)
      * @since 2025.07 - Bitmasked {@code Grid} State
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization This is a low-level helper. For performance reasons, it does not perform bounds
-     *               checking; the caller is responsible for providing a valid index.
+     * @performance {@code O(1)} bitwise operation.
+     * @threading Not thread-safe; modifies {@link #gridState} and {@link #trueCellsCount}.
+     * @memory Does not allocate.
      */
     protected void setBit(int index) {
         int longIndex = index / 64;
@@ -1147,70 +881,53 @@ public abstract class Grid {
     }
 
     /**
-     * Clears the bit at the specified index in the {@link #gridState grid state}. We assume that the
-     * index is in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}) to save time on format
-     * checks.
-     * 
+     * Clears the bit at the specified {@link ValueFormat#Index index} in the {@link #gridState grid
+     * state} to {@code false}.
+     *
      * <p>
-     * While this method can be used to clear a cell in the grid, we pre-compute {@link #ADJACENCY_MASKS
-     * adjacency masks} for each cell to perform clicks more efficiently. As such, this method is not
-     * used in any method of the codebase.
+     * This is a low-level helper method, analogous to {@link #setBit(int)}. It updates the
+     * {@link #gridState bitmask} and decrements {@link #trueCellsCount} if the bit was previously
+     * {@code true}. It is not used in performance-critical paths, which prefer {@link #click(short[])}.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * For performance reasons, this method does not perform bounds checking on the index. It is the
-     * caller's responsibility to ensure that the index is within the valid range
-     * ({@code 0}-{@code 108}).
-     * </p>
-     * 
-     * @param index The index of the bit to clear ({@code 0}-{@code 108}).
-     * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
+     *
+     * @param index The {@link ValueFormat#Index index} of the bit to clear (0-108).
+     * @throws IndexOutOfBoundsException (Implicitly) if the index is out of bounds for the
+     *                                   {@code long[]} array.
      * @see #getBit(int)
-     * @see #setBit(int)
      * @since 2025.07 - Bitmasked {@code Grid} State
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization Low-level helper. The caller is responsible for providing a valid index.
-     **/
+     * @performance {@code O(1)} bitwise operation.
+     * @threading Not thread-safe; modifies {@link #gridState} and {@link #trueCellsCount}.
+     * @memory Does not allocate.
+     */
     protected void clearBit(int index) {
         int longIndex = index / 64;
         int bitPosition = index % 64;
-        if ((gridState[longIndex] & (1L << bitPosition)) != 0)
-        {
+        if ((gridState[longIndex] & (1L << bitPosition)) != 0) {
             gridState[longIndex] &= ~(1L << bitPosition);
             trueCellsCount--;
         }
     }
 
     /**
-     * Extracts the bit at the specified index from the {@link #gridState grid state}. We assume that
-     * the index is in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}) to save time on
-     * format checks.
-     * 
+     * Checks the state of the bit at the specified {@link ValueFormat#Index index} in the
+     * {@link #gridState grid state}.
+     *
      * <p>
-     * This method is used to check if a specific cell in the grid is {@code true} (active) or
-     * {@code false} (inactive). We internally use this method for finding {@code true} cells in the
-     * grid, which is crucial for {@link #findTrueCells() outputting a list of true cells} or
-     * {@link #printGrid() printing the grid state.}
+     * This method is used to determine if a specific cell is {@code true} (on) or {@code false} (off).
+     * It is utilized internally for operations like {@link #printGrid()} or when iterating to find
+     * {@code true} cells.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * For performance reasons, this method does not perform bounds checking on the index. It is the
-     * caller's responsibility to ensure that the index is within the valid range
-     * ({@code 0}-{@code 108}).
-     * </p>
-     * 
-     * @param index The index of the bit to check ({@code 0}-{@code 108}).
-     * @return true if the bit is set, false otherwise.
-     * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
+     *
+     * @param index The {@link ValueFormat#Index index} of the bit to check (0-108).
+     * @return {@code true} if the bit is set (cell is "on"), {@code false} otherwise.
+     * @throws IndexOutOfBoundsException (Implicitly) if the index is out of bounds for the
+     *                                   {@code long[]} array.
      * @see #clearBit(int)
      * @see #setBit(int)
      * @since 2025.07 - Bitmasked {@code Grid} State
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe, as it reads potentially mutable state.
-     * @optimization Low-level helper. The caller is responsible for providing a valid index.
+     * @performance {@code O(1)} bitwise operation.
+     * @threading Not thread-safe; reads potentially mutable {@link #gridState}.
+     * @memory Does not allocate.
      */
     protected boolean getBit(int index) {
         int longIndex = index / 64;
@@ -1219,62 +936,43 @@ public abstract class Grid {
     }
 
     /**
-     * Scans the {@link #gridState grid bitmask} and returns an array of all {@code true} cells.
-     * Converts the result to the requested format ({@link ValueFormat#Index} or
-     * {@link ValueFormat#PackedInt}).
-     * 
+     * Scans the {@link #gridState grid bitmask} and returns an array of all {@code true} cells in the
+     * requested {@link ValueFormat format}.
+     *
      * <p>
-     * For {@link CombinationGeneratorTask generator} and {@link TestClickCombination monkey}
-     * efficiency, we perform several checks to prune combinations early. Many of these checks involve
-     * the initial state of the grid, so we need a way to conveniently extract the {@code true} bits
-     * from the bitmask and return them in a format that can be used for processing. This method
-     * provides that functionality, allowing for the efficient scanning of the grid state.
+     * This method is used by {@link CombinationGeneratorTask generators} and
+     * {@link TestClickCombination monkeys} to extract the current state of the grid for pruning or
+     * processing. It iterates through the grid's bits and collects the indices of all set bits.
      * </p>
-     * 
+     *
      * <h3>Algorithm Details</h3>
      * <p>
-     * We use the {@link #getBit(int index)} method to check each bit in the grid state, iterating
-     * across the values in the range 0-108 (inclusive). For each bit that is set, we add its index to
-     * an array that is pre-sized to the number of {@code true} cells in the grid. To avoid scanning the
-     * entire grid after finding the requisite number of {@code true} cells, we use a counter to track
-     * the index in the array and exit the for loop early when the array is full.
+     * The method iterates from {@code 0} to {@value #NUM_CELLS}-1, checking each bit's state using
+     * {@link #getBit(int)}. It populates a {@code short[]} which is pre-sized based on
+     * {@link #trueCellsCount} to avoid dynamic resizing. The iteration stops early once all expected
+     * {@code true} cells are found.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method isn't expected to be called frequently, as it is primarily used for obtaining the
-     * initial grid state. For this reason, we avoid {@link #recalculationNeeded checking for
-     * recalculation} or {@link #getTrueCount() recalculating the true cells count}, assuming the
-     * {@code true} count is correctly maintained by the {@link #setBit(int index)} and
-     * {@link #clearBit(int index)} methods. This avoids overhead, though it does allow for the
-     * possibility of an incorrectly sized array or missing {@code true} cells. A future update could
-     * target this.
+     * This method has a worst-case complexity of {@code O(NUM_CELLS)}. While a more optimized approach
+     * could use {@link Long#numberOfTrailingZeros(long)} to find set bits directly, this method is not
+     * on a critical performance path (as it's mainly used for initial state extraction or debugging)
+     * and the current implementation is clear and sufficient. The {@link #trueCellsCount} is assumed to
+     * be accurately maintained by {@link #setBit(int)} and {@link #clearBit(int)}.
      * </p>
-     * 
-     * <p>
-     * Another area for potential optimization is in the extraction of {@code true} cells. We could
-     * create two temporary {@code long}s to store the grid state, use the
-     * {@link Long#numberOfTrailingZeros(long)} method to find the first 1 in our bitmask, add the index
-     * to the array and turn off the bit (by ANDing with 0) and repeat until we have found all true
-     * cells. This would allow us to avoid the overhead of iterating over the entire grid state, but it
-     * would require additional complexity in the code that is unneeded at the moment.
-     * </p>
-     * 
-     * @param format the desired output format (Index or PackedInt).
-     * @return a {@code short[]} of {@code true} cells in the specified format.
-     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask}, (since
-     *                                  that would just be the Grid itself). Use {@link #getGridState()}
-     *                                  instead to fulfill that purpose.
+     *
+     * @param format The desired output format ({@link ValueFormat#Index} or
+     *               {@link ValueFormat#PackedInt}).
+     * @return A {@code short[]} of {@code true} cells in the specified format.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is provided, as it is not
+     *                                  suitable for representing individual cells.
      * @see #findFirstTrueCell(ValueFormat)
-     * @see #findTrueCells()
+     * @see #getGridState()
      * @since 2025.07 - Format Support
-     * @performance <code>O({@value #NUM_CELLS})</code>. A more optimized version could use
-     *              {@link Long#numberOfTrailingZeros(long)} to find set bits directly, but this method
-     *              is not on a critical performance path.
-     * @threading Not thread-safe, as it reads the mutable {@link #gridState}.
-     * @memory Allocates a new {@code short[]} for the results.
-     * @optimization Creates a perfectly sized array based on the cached {@link #trueCellsCount} to
-     *               avoid resizing. Stops iterating as soon as all {@code true} cells have been found.
+     * @performance {@code O(NUM_CELLS)} in the worst case.
+     * @threading Not thread-safe; reads the mutable {@link #gridState}.
+     * @memory Allocates a new {@code short[]} for the result.
      */
     public short[] findTrueCells(ValueFormat format) {
         short[] trueCellsArray = new short[trueCellsCount];
@@ -1309,22 +1007,19 @@ public abstract class Grid {
 
     /**
      * Scans the {@link #gridState grid bitmask} and returns an array of all {@code true} cells in
-     * {@link ValueFormat#Index Index} format (0-108).
-     * 
+     * {@link ValueFormat#Index Index} format.
+     *
      * <p>
-     * This method is a convenience overload of {@link #findTrueCells(ValueFormat format)} that defaults
-     * to the {@code Index} format, allowing for better inlining and performance if this method is on
-     * the hot path.
+     * This is a convenience overload of {@link #findTrueCells(ValueFormat)} that defaults to the
+     * {@link ValueFormat#Index} format, providing a simpler API for the most common use case.
      * </p>
-     * 
-     * @return An array of {@code true} cells in the specified format.
-     * @see #findFirstTrueCell(ValueFormat)
+     *
+     * @return A {@code short[]} of {@code true} cells in {@link ValueFormat#Index} format.
      * @see #findTrueCells(ValueFormat)
      * @since 2025.04 - Adjacency Optimizations
-     * @performance <code>O({@value #NUM_CELLS})</code>.
-     * @threading Not thread-safe.
-     * @memory Allocates a new {@code short[]} for the results.
-     * @optimization A {@code final} convenience overload that defaults to the most common format.
+     * @performance {@code O(NUM_CELLS)} in the worst case.
+     * @threading Not thread-safe; reads mutable state.
+     * @memory Allocates a new {@code short[]} for the result.
      */
     public final short[] findTrueCells() {
         short[] trueCellsArray = new short[trueCellsCount];
@@ -1340,62 +1035,44 @@ public abstract class Grid {
     }
 
     /**
-     * Scans the {@link #gridState grid} and returns the first {@code true} cell. Converts the result to
-     * the requested format ({@link ValueFormat#Index} or {@link ValueFormat#PackedInt}). If no
-     * {@code true} cell is found, returns -1.
-     * 
+     * Scans the {@link #gridState grid} and returns the first {@code true} cell in the requested
+     * {@link ValueFormat format}.
+     *
      * <p>
-     * Since {@code click}s are limited in scope to the adjacents of one cell, we can derive an
-     * important property of the solution: It must toggle the first {@code true} cell in the initial
-     * grid state. We can therefore optimize the search for the solution by pruning combinations that
-     * violate this condition, making it important to have a fast way to find the first {@code true}
-     * cell in the grid. While one could use the {@code findTrueCells()} method to find the first
-     * {@code true} cell, this method is optimized for that purpose.
+     * This method is crucial for optimizing the solution search. A core property of the puzzle is that
+     * any valid solution must interact with the first {@code true} cell in the initial grid state. This
+     * method provides a fast way to identify that cell, enabling early pruning of invalid combinations.
      * </p>
-     * 
+     *
      * <h3>Algorithm Details</h3>
      * <p>
-     * Java contains a built-in method for finding the first set bit in a {@code long}, called
-     * {@link Long#numberOfTrailingZeros(long)}. We can use this method to grab the first {@code true}
-     * cell and update the {@link #firstTrueCell} field. We also update {@link #trueCellsCount} field
-     * with another method, {@link Long#bitCount(long)}, which counts the number of set bits in a
-     * {@code long}.
+     * The method employs highly optimized {@link Long#numberOfTrailingZeros(long)} and
+     * {@link Long#bitCount(long)} intrinsics to efficiently determine the first {@code true} bit and
+     * the total count of {@code true} bits in the {@code long[2]} {@link #gridState}.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * If no changes have been made to the grid state since the last call to this method, we'd want to
-     * save on recalculating the value of the first true cell and the count of {@code true} cells. We
-     * can do this by checking the {@link #recalculationNeeded recalculationNeeded} flag and updating
-     * the values if it is {@code true}. In the case where the flag is {@code false} and the count of
-     * true cells is {@code 0}, we can short-circuit the method to avoid unnecessary calculations,
-     * returning {@code -1} immediately.
+     * This method implements a lazy recalculation strategy for {@link #firstTrueCell} and
+     * {@link #trueCellsCount}. These values are only recomputed if the {@link #recalculationNeeded}
+     * flag is {@code true}, ensuring {@code O(1)} performance in most cases. If no {@code true} cells
+     * exist, it short-circuits to return -1 immediately.
      * </p>
-     * 
-     * <p>
-     * The methods used to find the first {@code true} cell and count the number of true cells are
-     * {@code O(1)} due to some clever programming on the Java developers' part. Reinventing the wheel
-     * would be a waste of time (and likely less efficient), so we avoid that effort.
-     * </p>
-     * 
-     * @param format the desired output format ({@link ValueFormat#Index Index} or
-     *               {@link ValueFormat#PackedInt PackedInt}).
-     * @return the first {@code true} cell in the specified format, or -1 if no {@code true} cell is
+     *
+     * @param format The desired output format ({@link ValueFormat#Index} or
+     *               {@link ValueFormat#PackedInt}).
+     * @return The first {@code true} cell in the specified format, or -1 if no {@code true} cell is
      *         found.
-     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask} (since
-     *                                  bitmasks aren't supported for single values).
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used, as it is not suitable
+     *                                  for single-cell representation.
      * @see #click(short[])
-     * @see #click(short, ValueFormat)
-     * @see #findFirstTrueCell()
      * @see #findTrueCells(ValueFormat)
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe due to lazy evaluation of cached fields.
-     * @algorithm Uses the highly optimized {@link Long#numberOfTrailingZeros(long)} and
-     *            {@link Long#bitCount(long)} intrinsics for recalculation.
-     * @optimization Implements lazy recalculation. The cached {@link #firstTrueCell} and
-     *               {@link #trueCellsCount} are only recomputed if the {@link #recalculationNeeded}
-     *               flag is set.
+     * @performance {@code O(1)} complexity due to lazy evaluation and highly optimized intrinsics.
+     * @threading Not thread-safe due to lazy evaluation of mutable cached fields.
+     * @algorithm Uses {@link Long#numberOfTrailingZeros(long)} and {@link Long#bitCount(long)}
+     *            intrinsics.
+     * @memory Does not allocate.
      */
     public short findFirstTrueCell(ValueFormat format) {
         if (!recalculationNeeded && trueCellsCount == 0) 
@@ -1442,26 +1119,23 @@ public abstract class Grid {
 
     /**
      * Scans the {@link #gridState grid} and returns the first {@code true} cell in
-     * {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}). If no {@code true} cell is found,
-     * returns -1.
-     * 
+     * {@link ValueFormat#Index Index} format.
+     *
      * <p>
-     * This method is a convenience overload of {@link #findFirstTrueCell(ValueFormat format)} that
-     * defaults to the {@code Index} format, allowing for better inlining and performance if this method
-     * is on the hot path.
+     * This is a convenience overload of {@link #findFirstTrueCell(ValueFormat)} that strips the format
+     * conversion, providing a simpler API for the most common use case where the generator requires the
+     * index.
      * </p>
-     * 
-     * @return The first {@code true} cell in {@code Index} format, or -1 if no {@code true} cell is
-     *         found.
-     * @see #click(short[])
-     * @see #click(short, ValueFormat)
-     * @see #findFirstTrueCell(ValueFormat)
+     *
+     * @return The first {@code true} cell in {@link ValueFormat#Index} format, or -1 if no {@code true}
+     *         cell is found.
      * @see #findTrueCells()
      * @since 2025.04 - Adjacency Optimizations
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe.
-     * @algorithm Delegates to the main implementation, using {@link ValueFormat#Index}.
-     * @optimization A {@code final} convenience overload for the most common use case.
+     * @performance {@code O(1)} complexity due to lazy evaluation and optimized intrinsics.
+     * @threading Not thread-safe due to lazy evaluation of mutable cached fields.
+     * @algorithm Uses {@link Long#numberOfTrailingZeros(long)} and {@link Long#bitCount(long)}
+     *            intrinsics.
+     * @memory Does not allocate.
      */
     public final short findFirstTrueCell() {
         if (!recalculationNeeded && trueCellsCount == 0) 
@@ -1492,48 +1166,41 @@ public abstract class Grid {
     }
 
     /**
-     * Simulates a click on the {@code Grid} at the specified cell, which can be in any of the supported
-     * {@link ValueFormat formats} ({@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt
-     * PackedInt}).
-     * 
+     * Simulates a click on the {@code Grid} at the specified cell, supporting {@link ValueFormat#Index}
+     * or {@link ValueFormat#PackedInt} formats.
+     *
      * <p>
-     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
-     * simply by XORing the {@link #gridState grid state} with a pre-computed {@link #ADJACENCY_MASKS
-     * adjacency mask.}
+     * A click toggles the state of its adjacent cells (excluding itself). This operation is performed
+     * by XORing the {@link #gridState grid state} with a pre-computed {@link #ADJACENCY_MASKS adjacency
+     * mask} corresponding to the clicked cell.
      * </p>
-     * 
+     *
      * <p>
-     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to {@code true} ensures that
-     * the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will recalculate the
-     * {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of true cells}. This
-     * avoids unnecessary recalculations on every click, which is crucial for performance in
-     * high-frequency scenarios.
+     * The {@link #recalculationNeeded} flag is set to {@code true} to ensure that subsequent calls to
+     * {@link #findFirstTrueCell(ValueFormat)} or {@link #getTrueCount()} will recompute the cached
+     * {@link #firstTrueCell} and {@link #trueCellsCount} values. This lazy evaluation avoids
+     * unnecessary recalculations on every click.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit {@code long} for
-     * the grid state, meaning that we have to use two {@code long}s, and thus two adjacency masks per
-     * cell. Though we could strategically use a single {@code long} as a bitmask if the adjacent cells
-     * are localized to the same {@code long}, we choose to use two{@code long}s for simplicity and to
-     * avoid branching.
+     * This method achieves {@code O(1)} complexity due to the direct bitwise XOR operations on the
+     * {@code long[2]} {@link #gridState} using pre-computed masks. While the grid spans 109 cells,
+     * requiring two {@code long} values for the bitmask, the implementation avoids conditional
+     * branching based on cell position for simplicity and consistent performance.
      * </p>
-     * 
-     * @param cell   the cell to click, in the specified format.
-     * @param format the format of the cell ({@code Index} or {@code PackedInt}).
-     * @throws IllegalArgumentException       if the format is {@link ValueFormat#Bitmask Bitmask}
-     *                                        (since bitmasks aren't supported for single values) or
-     *                                        another unsupported format.
-     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
-     *                                        array accesses).
-     * @see #click(short)
+     *
+     * @param cell   The cell to click, in the specified {@code format}.
+     * @param format The {@link ValueFormat} of the input {@code cell} (Index or PackedInt).
+     * @throws IllegalArgumentException       if {@link ValueFormat#Bitmask} is used, as it is not
+     *                                        suitable for single-cell representation.
+     * @throws ArrayIndexOutOfBoundsException if the {@code cell} is out of bounds (implicitly checked
+     *                                        by array accesses).
      * @see #click(short[])
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization The core of this operation is two bitwise XORs against the pre-computed
-     *               {@link #ADJACENCY_MASKS}, which is extremely fast. It also lazily marks the state
-     *               for recalculation.
+     * @performance {@code O(1)} complexity due to bitwise operations and pre-computed masks.
+     * @threading Not thread-safe; modifies the instance's {@link #gridState}.
+     * @memory Does not allocate.
      */
     public void click(short cell, ValueFormat format) {
         switch (format) 
@@ -1558,48 +1225,40 @@ public abstract class Grid {
     }
 
     /**
-     * Simulates a click on the {@code Grid} at the specified cell. We assume that the cell is in
-     * {@link ValueFormat#Index {@code Index}} format ({@code 0}-{@code 108}) to save time on format
-     * checks.
-     * 
+     * Simulates a click on the {@code Grid} at the specified cell, assuming {@link ValueFormat#Index}
+     * format.
+     *
      * <p>
-     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
-     * simply by XORing the {@link #gridState grid state} with a pre-computed {@link #ADJACENCY_MASKS
-     * adjacency mask.}
+     * This is a highly optimized, {@code final} method designed for performance-critical paths. It
+     * directly applies the pre-computed adjacency mask to the {@link #gridState grid state} using
+     * bitwise XOR.
      * </p>
-     * 
+     *
      * <p>
-     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to {@code true} ensures that
-     * the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will recalculate the
-     * {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of true cells}. This
-     * avoids unnecessary recalculations on every click, which is crucial for performance in
-     * high-frequency scenarios.
+     * The {@link #recalculationNeeded} flag is set to {@code true} to trigger lazy recomputation of
+     * {@link #firstTrueCell} and {@link #trueCellsCount}.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit {@code long} for
-     * the grid state, meaning that we have to use two {@code long}s, and thus two adjacency masks per
-     * cell. Though we could strategically use a single {@code long} as a bitmask if the adjacent cells
-     * are localized to the same {@code long}, we choose to use two{@code long}s for simplicity and to
-     * avoid branching.
+     * This method is {@code O(1)} in complexity. It is declared {@code final} to encourage JIT inlining
+     * and avoids any format-checking overhead by requiring the {@link ValueFormat#Index} format. This
+     * method has largely been superseded by {@link #click(short[])} for bulk operations in
+     * {@link TestClickCombination}, as single-click operations are no longer the primary hot path.
      * </p>
-     * 
-     * @param cell The cell to click, in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}).
-     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
-     *                                        array accesses).
+     *
+     * @param cell The cell to click, in {@link ValueFormat#Index} format (0-108).
+     * @throws ArrayIndexOutOfBoundsException if the {@code cell} is out of bounds (implicitly checked
+     *                                        by array accesses).
      * @see #areAdjacent(short, short, ValueFormat)
      * @see #click(short, ValueFormat)
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.07 - Inlining Improvements
-     * @deprecated As of 2025.07, this has been replaced by {@link #click(short[])} for bulk operations
-     *             in {@link TestClickCombination}. Single-click operations are no longer on the hot
-     *             path.
-     * @performance {@code O(1)} complexity. This is a hot-path method.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization This minimal implementation is declared {@code final} to encourage JIT inlining. It
-     *               avoids any format-checking overhead by requiring the {@link ValueFormat#Index}
-     *               format.
+     * @deprecated As of 2025.07, replaced by {@link #click(short[])} for bulk operations. Single-click
+     *             operations are no longer on the hot path.
+     * @performance {@code O(1)} retrieval and bitwise operations.
+     * @threading Not thread-safe; modifies the instance's {@link #gridState}.
+     * @memory Does not allocate.
      */
     public final void click(short cell) {
         // XOR the grid state with the pre-computed adjacency mask
@@ -1611,19 +1270,23 @@ public abstract class Grid {
     }
 
     /**
-     * Specialized click method for the {@link ValueFormat#PackedInt PackedInt} format. Made
-     * {@code final} to encourage inlining.
-     * 
+     * Simulates a click on the {@code Grid} at the specified row and column.
+     *
+     * <p>
+     * This is a convenience {@code final} method that converts the row and column into a
+     * {@link ValueFormat#PackedInt} value, then converts it to {@link ValueFormat#Index} format, before
+     * delegating to the core {@link #click(short)} method.
+     * </p>
+     *
      * @param row The row of the cell to click.
      * @param col The column of the cell to click.
-     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
-     *                                        array accesses).
+     * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by array
+     *                                        accesses).
      * @see #click(short, ValueFormat)
      * @since 2025.03 - Initial Creation
      * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization A {@code final} convenience overload that handles {@link ValueFormat#PackedInt}
-     *               conversion before performing the click. Designed to be inlined.
+     * @threading Not thread-safe; modifies the instance's {@link #gridState}.
+     * @memory Does not allocate.
      */
     public final void click(short row, short col) {
         // Convert packed int to index format first
@@ -1638,34 +1301,27 @@ public abstract class Grid {
     }
 
     /**
-     * Specialized click method for the {@link ValueFormat#Bitmask Bitmask} format.
-     * 
+     * Applies a pre-computed bitmask to the {@link #gridState grid state}.
+     *
      * <p>
-     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click by
-     * XORing the {@link #gridState grid state} with the provided bitmask.
+     * This method provides a direct way to modify the grid state by XORing it with an external bitmask.
+     * It is intended for advanced scenarios where the caller has already calculated the cumulative
+     * effect of one or more clicks as a bitmask.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
+     *
      * <p>
-     * This method is built for scenarios where the caller has pre-computed the adjacency bitmask for a
-     * cell and wants to apply it directly, avoiding the overhead of format conversions or lookups.
-     * While our code does not currently leverage this method, it is provided for completeness and
-     * potential future use cases.
+     * The {@link #recalculationNeeded} flag is set to {@code true} to trigger lazy recomputation of
+     * {@link #firstTrueCell} and {@link #trueCellsCount}.
      * </p>
-     * 
-     * <p>
-     * To optimize performance further, we could make the method {@code final} to encourage inlining,
-     * but we leave it as-is for now to allow for potential overrides in subclasses.
-     * </p>
-     * 
-     * @param bitmask The bitmask representing the adjacents to toggle, as a {@code long[]} of length 2.
-     * @throws IllegalArgumentException if the bitmask is not of length 2.
-     * @see #click(short)
-     * @see #click(short, ValueFormat)
+     *
+     * @param bitmask The bitmask (a {@code long[2]} array) representing the changes to apply to the
+     *                grid.
+     * @throws IllegalArgumentException if the {@code bitmask} array is not of length 2.
+     * @see #click(short[])
      * @since 2025.07 - Click Format Support
-     * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization Directly applies a pre-computed bitmask, avoiding any lookup overhead.
+     * @performance {@code O(1)} bitwise operations.
+     * @threading Not thread-safe; modifies the instance's {@link #gridState}.
+     * @memory Does not allocate.
      */
     public void click(long[] bitmask) {
         if (bitmask.length != 2) {
@@ -1679,119 +1335,82 @@ public abstract class Grid {
     }
 
     /**
-     * Simulates a click on multiple cells in the {@code Grid}. We assume that the cells are in the
-     * {@link ValueFormat#Index {@code Index}} format ({@code 0}-{@code 108}) and the array is
-     * non-{@code null} to save on format checks.
-     * 
+     * Simulates clicks on multiple cells in the {@code Grid}.
+     *
      * <p>
-     * A click simply toggles the state of its adjacent cells (excluding itself), so we can perform a
-     * click by XORing the {@link #gridState grid state} with the pre-computed {@link #ADJACENCY_MASKS
-     * adjacency masks}. As opposed to the single cell {@link #click(short cell)} method, this method
-     * allows for bulk operations on combinations of cells, saving on the overhead of multiple method
-     * calls.
+     * This method efficiently processes an array of cells (in {@link ValueFormat#Index} format) by
+     * iteratively applying their corresponding {@link #ADJACENCY_MASKS} to the {@link #gridState grid
+     * state} using bitwise XOR operations. This is the primary method for applying click combinations
+     * in bulk, particularly within {@link TestClickCombination monkeys}.
      * </p>
-     * 
+     *
      * <p>
-     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to {@code true} ensures that
-     * the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will recalculate the
-     * {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of true cells}. This
-     * avoids unnecessary recalculations on every click, which is crucial for performance in
-     * high-frequency scenarios.
+     * The {@link #recalculationNeeded} flag is set to {@code true} once after all clicks are applied,
+     * ensuring lazy recomputation of {@link #firstTrueCell} and {@link #trueCellsCount}.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit {@code long} for
-     * the grid state, meaning that we have to use two {@code long}s, and thus two adjacency masks per
-     * cell. Though we could strategically use a single {@code long} as a bitmask if the adjacent cells
-     * are localized to the same {@code long}, we choose to use two {@code long}s for simplicity and to
-     * avoid branching.
+     * This method is a hot-path operation with {@code O(cells.length)} complexity. It is declared
+     * {@code final} to encourage JIT inlining and assumes valid input to minimize branching and checks
+     * within the loop. We avoid unrolling the loop to delegate the responsibility to the JIT compiler.
+     * Vectorization is also not applicable here, due to the non-predictable array accesses.
      * </p>
-     * <p>
-     * We avoid unrolling the loop here, since the JVM can handle that for us and it would deliver
-     * mediocre performance gains at best. Vectorization is also not applicable here, since we perform
-     * array accesses in a non-predictable manner.
-     * </p>
-     * 
-     * @param cells The array of cells to click, in Index format ({@code 0}-{@code 108}).
-     * @throws IllegalArgumentException if the clicks are out of bounds (implicitly checked by the array
-     *                                  accesses).
-     * @throws NullPointerException     if the cells array is {@code null} (implicitly thrown by the for-each
-     *                                  loop).
-     * @see #areAdjacent(short, short, ValueFormat)
-     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     *
+     * @param cells An array of cells (in {@link ValueFormat#Index} format) to click.
+     * @throws ArrayIndexOutOfBoundsException if any {@code cell} in the array is out of bounds.
+     * @throws NullPointerException           if the {@code cells} array is {@code null}.
+     * @see #click(short)
      * @since 2025.07 - Bulk Clicks
-     * @performance {@code O(cells.length)}. This is a hot-path method for worker threads.
-     * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization This method is the primary replacement for single-cell clicks. It processes an
-     *               array of clicks in a tight loop. It is {@code final} to encourage JIT inlining and
-     *               assumes valid input to avoid branching and checks inside the loop.
+     * @performance {@code O(cells.length)} for iterating over {@code cells}.
+     * @threading Not thread-safe; modifies the instance's {@link #gridState}.
+     * @memory Does not allocate.
      */
     public final void click(short[] cells) {
         for (short cell : cells) {
-            // XOR the grid state with the pre-computed adjacency mask
             gridState[0] ^= ADJACENCY_MASKS[cell][0];
             gridState[1] ^= ADJACENCY_MASKS[cell][1];
         }
-        
-        // Mark for recalculation of first true cell and count
         recalculationNeeded = true;
     }
 
     /**
-     * Returns an array of adjacents of the {@link #findFirstTrueCell() first true cell} in the
-     * requested {@link ValueFormat format}. If no {@code true} cell exists, returns {@code null}.
-     * 
+     * Returns an array of adjacent cells to the {@link #findFirstTrueCell() first true cell} in the
+     * requested {@link ValueFormat format}.
+     *
      * <p>
-     * Since clicks are limited in scope to the adjacents of one cell (excluding itself), we can derive
-     * an important property of the solution: It must contain at least one click on the adjacents of the
-     * first {@code true} cell in the initial grid state. This may seem obvious, but it allows us to
-     * establish bounds for generation, limiting the maximum cell that needs to be considered for the
-     * first click to the last adjacent of the first {@code true} cell. This method gives us an easy way
-     * to extract and test those adjacents.
+     * This method leverages the puzzle property that any solution must interact with the first
+     * {@code true} cell. It provides the generator with the adjacent cells of this critical point,
+     * enabling focused exploration of the search space.
      * </p>
      * 
      * <p>
-     * As a note, we currently prevent the use of {@link ValueFormat#Bitmask Bitmask} formats here,
-     * since bitmasks aren't well-suited for representing small sets of values. If we were to support
-     * them, we would either need to create a {@code long[]} of length 2 (to match the internal grid
-     * size) or a {@code short[]} with a length of 7 to cover 116 bits (the closest multiple of 16 above
-     * 109). The former would likely require a new method due to the incompatible return type (unless we
-     * made the return type {@code Object}, which would be messy), while the latter would waste space
-     * and require additional conversions. Given the limited utility of bitmasks in this context, we opt
-     * to exclude them for now.
+     * {@link ValueFormat#Bitmask Bitmask} formats are not supported for this method. While it's
+     * technically possible to represent small sets of values as bitmasks (e.g., a {@code long[2]} or a
+     * {@code short[7]}), the overhead of conversion and potential for wasted space makes it impractical
+     * for this context.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be efficient, performing a simple lookup of the first {@code true}
-     * cell and then retrieving its adjacents. The operation is {@code O(1)} due to the fixed size of
-     * the adjacency list (up to 6 elements).
+     * The operation is {@code O(1)} because it involves a simple lookup of the first {@code true} cell
+     * and then retrieving its pre-computed adjacents. While caching the result could be considered, the
+     * small, fixed size of the adjacency list (at most 6 elements) makes the current approach efficient
+     * enough without the overhead of cache management and defensive copying.
      * </p>
-     * 
-     * <p>
-     * To optimize performance further, we could consider caching the result of the operation if the
-     * state has not changed since the last call, but given the simplicity of the operation and the
-     * small size of the adjacency list, the current implementation is sufficient. If the first
-     * {@code true} cell were to change, we would need to invalidate the cache anyway, requiring an
-     * allocation of a new array; we would also need to clone the array before returning it to avoid
-     * external modifications, which would negate the performance benefits of caching in the first
-     * place.
-     * </p>
-     * 
-     * @param format The desired output format ({@link ValueFormat#Index Index} or
-     *               {@link ValueFormat#PackedInt PackedInt}).
-     * @return A {@code short[]} of adjacent cells in the requested format, or {@code null} if no true
-     *         cell exists.
-     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask}.
+     *
+     * @param format The desired output format ({@link ValueFormat#Index} or
+     *               {@link ValueFormat#PackedInt}).
+     * @return A {@code short[]} of adjacent cells to the first {@code true} cell, or {@code null} if no
+     *         {@code true} cell exists.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used, as it is not suitable
+     *                                  for representing individual cells.
      * @see #findAdjacents(short, ValueFormat)
+     * @see #findFirstTrueCell()
      * @since 2025.04 - First True Adjacents Method Creation
-     * @performance {@code O(1)} for {@link ValueFormat#Index},
-     *              <code>O({@link #adjacencyArray}[cell].length)</code> for others.
-     * @threading Not thread-safe, as it depends on the result of non-thread-safe methods.
+     * @performance {@code O(1)} operations and conversion due to fixed-size adjacency lists.
+     * @threading Not thread-safe; depends on the result of non-thread-safe methods.
      * @memory Allocates a new {@code short[]} for the result.
-     * @optimization Leverages the lazy evaluation of {@link #findFirstTrueCell()} and the pre-computed
-     *               {@link #adjacencyArray}.
      */
     public short[] findFirstTrueAdjacents(ValueFormat format) {
         if (format == ValueFormat.Bitmask) {
@@ -1808,78 +1427,64 @@ public abstract class Grid {
     }
 
     /**
-     * Overload of {@link #findFirstTrueAdjacents(ValueFormat)} that assumes the output format is
-     * {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls the main
-     * method with the {@code Index} format.
-     * 
-     * @return A {@code short[]} of adjacent cells in {@link ValueFormat#Index Index} format, or
-     *         {@code null} if no {@code true} cell exists.
+     * Convenience overload for {@link #findFirstTrueAdjacents(ValueFormat)} that assumes
+     * {@link ValueFormat#Index} for the output format.
+     *
+     * @return A {@code short[]} of adjacent cells to the first {@code true} cell in
+     *         {@link ValueFormat#Index} format, or {@code null} if no {@code true} cell exists.
+     * @see #findFirstTrueAdjacents(ValueFormat)
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} complexity.
+     * @performance Delegates to the main implementation; {@code O(1)} complexity.
      * @threading Not thread-safe.
-     * @memory Allocates a new {@code short[]}.
-     * @optimization Convenience overload.
+     * @memory Allocates a new {@code short[]} for the result.
      */
     public short[] findFirstTrueAdjacents() {
         return findFirstTrueAdjacents(ValueFormat.Index);
     }
 
     /**
-     * Returns an array of adjacents of the {@link #findFirstTrueCell() first true cell} that come after
-     * the specified cell, in the requested {@link ValueFormat format}. If no {@code true} cell exists,
-     * or if no {@code true} adjacents after the specified cell exist, returns {@code null}.
-     * 
+     * Returns an array of adjacent cells to the {@link #findFirstTrueCell() first true cell} that have
+     * an {@link ValueFormat#Index index} greater than the specified {@code cell}.
+     *
      * <p>
-     * Since clicks are limited in scope to the adjacents of one cell (excluding itself), we can derive
-     * an important property of the solution: It must contain at least one click on the adjacents of the
-     * first {@code true} cell in the initial grid state. This may seem obvious, but it allows us to
-     * establish bounds for generation, limiting the maximum cell that needs to be considered for the
-     * first click to the last adjacent of the first {@code true} cell. This method gives us an easy way
-     * to extract and test those adjacents.
+     * This method is a specialized pruning helper for the generator. It identifies potential subsequent
+     * clicks by filtering the adjacents of the first {@code true} cell, considering only those that
+     * appear after a given {@code cell} in the flattened grid order. This helps to establish bounds for
+     * combination generation.
      * </p>
-     * 
+     *
      * <h3>Algorithm Details</h3>
      * <p>
-     * We first {@link #findFirstTrueAdjacents(ValueFormat) find the adjacents of the first true cell}
-     * in the specified input format. If no {@code true} cell exists, we return {@code null}. We then
-     * convert the input cell to {@link ValueFormat#Index index} format if necessary, using the
-     * {@link #packedToIndex(short)} method for {@link ValueFormat#PackedInt packed int} format. We then
-     * perform a binary search on the array of adjacents to find the first adjacent cell that is greater
-     * than the specified cell. If no such adjacent exists, we return {@code null}. If we find such an
-     * adjacent, we create a new array containing all adjacents from that point onward. Finally, we
-     * convert the result to the desired output format if necessary and return it.
+     * The method first retrieves all adjacents of the first {@code true} cell using
+     * {@link #findFirstTrueAdjacents(ValueFormat)}. It then performs a binary search on this sorted
+     * list to find the first adjacent cell whose index is greater than the provided {@code cell}. A
+     * subarray containing only these subsequent adjacents is then returned, with optional format
+     * conversion.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be efficient, performing a logarithmic search on a small array of
-     * adjacents and linear copying the resulting subarray. For greater efficiency, we could consider
-     * caching the result of the operation or figuring out some way to avoid an array copy, but given
-     * the small size of the adjacency list (up to 6 elements) and the infrequent nature of this
-     * operation, the current implementation is sufficient.
+     * The complexity is dominated by the binary search and array copy, resulting in an effectively
+     * constant time operation {@code O(log(k) + m)}, where {@code k} is the number of adjacents (max 6)
+     * and {@code m} is the number of remaining adjacents to copy. Given the small size of {@code k},
+     * this method is highly efficient. Caching the result is generally not beneficial due to the
+     * dynamic nature of the {@code cell} parameter and the small performance gains from avoiding an
+     * array copy.
      * </p>
-     * 
-     * @param cell         the cell after which to find adjacents, in the specified input format.
-     * @param inputFormat  the {@link ValueFormat format} of the input cell ({@link ValueFormat#Index
-     *                     Index} or {@link ValueFormat#PackedInt PackedInt}).
-     * @param outputFormat the {@link ValueFormat format} of the output array ({@link ValueFormat#Index
-     *                     Index} or {@link ValueFormat#PackedInt PackedInt}).
-     * @return An array of adjacent cells after the specified cell, in the requested output format, or
-     *         {@code null} if no true cell exists or if no adjacents after the specified cell exist.
-     * @throws IllegalArgumentException if either format is {@link ValueFormat#Bitmask Bitmask} (since
-     *                                  bitmasks aren't supported for single values) or anything else.
+     *
+     * @param cell         The reference cell (in {@code inputFormat}) after which to find adjacents.
+     * @param inputFormat  The {@link ValueFormat} of the input {@code cell}.
+     * @param outputFormat The {@link ValueFormat} of the output adjacent cells.
+     * @return An array of adjacent cells that appear after the specified {@code cell}, or {@code null}
+     *         if no {@code true} cell exists or no such adjacents are found.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used for any format.
      * @see #findAdjacents(short)
      * @see #findFirstTrueAdjacents(ValueFormat)
      * @see #findFirstTrueCell()
      * @since 2025.07 - Format Support
-     * @performance <code>O(log({@link #adjacencyArray}[cell].length) + m)}</code> where {@code m} is
-     *              the number of remaining adjacents to copy. Effectively constant time.
-     * @threading Not thread-safe.
-     * @algorithm Performs a binary search on the sorted adjacency list of the first {@code true} cell
-     *            to find the subset of neighbors that appear after the given cell.
+     * @performance {@code O(1)} effectively, due to small, fixed-size lists.
+     * @threading Not thread-safe; relies on non-thread-safe methods.
      * @memory Allocates a new {@code short[]} for the result.
-     * @optimization A specialized method for the generator to efficiently prune the search space by
-     *               only considering relevant subsequent clicks.
      */
     public short[] findFirstTrueAdjacentsAfter(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] firstTrueAdjacents = findFirstTrueAdjacents(inputFormat);
@@ -1945,33 +1550,40 @@ public abstract class Grid {
     }
 
     /**
-     * Checks if the grid is completely solved (i.e., all cells are {@code false}). We use the
-     * {@link #getTrueCount()} method to determine if there are any true cells remaining rather than
-     * directly checking the {@link #gridState grid state} or the {@link #trueCellsCount true cells
-     * count} to ensure that any necessary recalculations are performed before making the check while
-     * avoiding code duplication.
-     * 
+     * Checks if the grid is completely solved (i.e., all cells are {@code false}).
+     *
+     * <p>
+     * This method determines if the puzzle is solved by checking if the {@link #getTrueCount()} is
+     * zero. It leverages the lazy evaluation of {@link #trueCellsCount} to ensure efficient and
+     * up-to-date checks without redundant calculations.
+     * </p>
+     *
      * @return {@code true} if the grid is solved (no {@code true} cells), {@code false} otherwise.
      * @see #recalculationNeeded
      * @since 2025.03 - Initial Creation
      * @performance {@code O(1)} complexity.
-     * @threading Not thread-safe, as it calls the non-thread-safe {@link #getTrueCount()}.
+     * @threading Not thread-safe; calls the non-thread-safe {@link #getTrueCount()}.
+     * @memory Does not allocate.
      */
     public boolean isSolved() {
         return getTrueCount() == 0;
     }
 
     /**
-     * Returns the count of {@code true} cells in the grid. If the grid state has changed since the last
-     * calculation, it recalculates the count using {@link Long#bitCount(long) bitwise operations}.
-     * 
-     * @return the number of true cells in the grid.
-     * @see #recalculationNeeded
+     * Returns the count of {@code true} cells in the grid.
+     *
+     * <p>
+     * This method implements a lazy evaluation strategy. If the grid state has been modified (indicated
+     * by {@link #recalculationNeeded}), it recalculates the count using highly optimized bitwise
+     * operations ({@link Long#bitCount(long)}); otherwise, it returns the cached
+     * {@link #trueCellsCount}.
+     * </p>
+     *
+     * @return The number of {@code true} cells in the grid.
      * @since 2025.03 - Dynamic True Cell Count Tracking
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe due to lazy evaluation of a mutable field.
-     * @optimization Implements lazy evaluation; the count is only recalculated using fast bitwise
-     *               operations when the {@link #recalculationNeeded} flag is true.
+     * @memory Does not allocate.
      */
     public int getTrueCount() {
         if (recalculationNeeded) {
@@ -1983,16 +1595,17 @@ public abstract class Grid {
 
     /**
      * Creates and returns a deep copy of this {@code Grid} instance.
-     * 
+     *
      * <p>
-     * The cloned instance has its own copy of the grid state, ensuring that modifications to
-     * the clone do not affect the original instance and vice versa. The method uses reflection to
-     * create a new instance of the same class, allowing for proper cloning of subclasses without
-     * needing to create overrides for each subclass.
+     * The cloned instance has its own independent copy of the grid state and cached values, ensuring
+     * that modifications to the clone do not affect the original. This method uses reflection to create
+     * a new instance of the same class, allowing for proper cloning of subclasses without requiring
+     * overrides in each subclass.
      * </p>
-     * 
+     *
      * @return A deep copy of this {@code Grid} instance.
-     * @throws RuntimeException if the cloning process fails due to reflection issues.
+     * @throws RuntimeException if the cloning process fails (e.g., due to reflection issues or an
+     *                          inaccessible constructor).
      * @see #firstTrueCell
      * @see #gridState
      * @see #recalculationNeeded
@@ -2000,7 +1613,7 @@ public abstract class Grid {
      * @see java.lang.Object#clone()
      * @see java.lang.Cloneable
      * @since 2025.03 - Cloning Introduction
-     * @performance {@code O(1)} complexity.
+     * @performance {@code O(1)} complexity (fixed number of field copies).
      * @threading Thread-safe, as it returns a new, independent instance.
      * @memory Allocates a new {@code Grid} object and a new {@code long[2]} for its state.
      */
@@ -2020,48 +1633,40 @@ public abstract class Grid {
     }
 
     /**
-     * Determines if a click on a specified cell can affect or create a new first {@code true} cell in
-     * the grid.
-     * 
+     * Determines if a prospective click on a {@code clickCell} can affect or create a new
+     * {@link #findFirstTrueCell() first true cell} in the grid.
+     *
      * <p>
-     * Since the solution must toggle the first {@code true} cell in the initial grid state, we can
-     * optimize our search for the solution by pruning combinations whose first click cannot affect or
-     * create a new first {@code true} cell. This method provides the logic to determine that.
+     * This method is a crucial pruning helper for the {@link CombinationGeneratorTask generator}. Since
+     * any valid solution must ultimately toggle the puzzle's {@code first true cell}, combinations
+     * whose initial clicks cannot influence this state can be discarded early.
      * </p>
-     * 
-     * <p>
-     * There are several scenarios that this program considers:
+     *
+     * <h3>Scenarios Considered:</h3>
      * <ul>
-     * <li>If there are no {@code true} cells, any click can create one. In the context of our solver,
-     * we shouldn't see this case happen too often, but it's included for short-circuiting
-     * purposes.</li>
-     * <li>If the first {@code true} cell is the top-left cell (0,0), only its adjacents can affect
-     * it.</li>
-     * <li>If the click is before or equal to the first {@code true} cell, it can create a new one.</li>
-     * <li>If the click is adjacent to the first {@code true} cell, it can affect it.</li>
+     * <li>If there are no {@code true} cells ({@code firstTrueCell == -1}), any click can create one,
+     * so it returns {@code true}.</li>
+     * <li>If the {@code clickCell} is at or before the {@code firstTrueCell} in flattened grid order,
+     * it is considered capable of affecting it, returning {@code true}.</li>
+     * <li>If the {@code clickCell} is adjacent to the {@code firstTrueCell}, it can directly affect its
+     * state, returning {@code true}.</li>
      * </ul>
-     * If none of these conditions are met, the click cannot affect or create a new first {@code true}
-     * cell.
-     * </p>
-     * 
-     * @param firstTrueCell the first {@code true} cell in the specified format.
-     * @param clickCell     the cell to be clicked, in the specified format.
-     * @param format        the {@link ValueFormat format} of both cells ({@link ValueFormat#Index
-     *                      Index} or {@link ValueFormat#PackedInt PackedInt}).
-     * @return {@code true} if the click can affect or create a new first {@code true} cell,
+     * If none of these conditions are met, the click cannot affect or create a new
+     * {@code firstTrueCell}, and the method returns {@code false}.
+     *
+     * @param firstTrueCell The current {@code first true cell} in the specified {@code format}.
+     * @param clickCell     The cell being considered for a click, in the specified {@code format}.
+     * @param format        The {@link ValueFormat} of both {@code firstTrueCell} and {@code clickCell}.
+     * @return {@code true} if the click can affect or create a new {@code first true cell},
      *         {@code false} otherwise.
-     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask} (since
-     *                                  bitmasks aren't supported for single values) or another
-     *                                  unsupported format.
+     * @throws IllegalArgumentException if {@link ValueFormat#Bitmask} is used for any format.
      * @see #areAdjacent(short, short, ValueFormat)
-     * @see #findAdjacents(short, ValueFormat)
      * @see #findFirstTrueCell(ValueFormat)
      * @since 2025.07 - Format and Adjacency Optimizations
-     * @performance <code>O(log({@link #adjacencyArray}[firstTrueCell].length))</code>. Effectively
-     *              constant time.
-     * @threading This method is thread-safe as it is a pure function.
-     * @optimization A specialized pruning helper for the generator. Uses an efficient binary search on
-     *               the pre-sorted adjacency list.
+     * @performance {@code O(1)} complexity due to fixed-size adjacency lookups and binary search on
+     *              small arrays.
+     * @threading Thread-safe; relies only on immutable static data and input parameters.
+     * @memory Does not allocate.
      */
     public static boolean canAffectFirstTrueCell(short firstTrueCell, short clickCell, ValueFormat format) {
         if (firstTrueCell == -1) return true; // No true cells, any click can create one
@@ -2131,44 +1736,34 @@ public abstract class Grid {
     }
 
     /**
-     * Determines if two cells are adjacent to each other in the grid. Leverages the pre-computed
-     * {@link #ADJACENCY_CACHE adjacency cache} for {@code O(1)} lookups.
-     * 
+     * Determines if two cells are adjacent to each other in the grid.
+     *
      * <p>
-     * Two cells are considered adjacent if they share a common edge or vertex. In a hexagonal grid,
-     * each cell can have up to 6 adjacent cells, depending on its position in the grid. Since clicks
-     * only affect adjacent cells, we rely on adjacency calculations to optimize our search for the
-     * solution to a state, factoring these calculations into much of our logic. Therefore, we need a
-     * {@code public} facing method to quickly determine adjacency between any two cells. This method
-     * fills that role.
+     * This method leverages the pre-computed {@link #ADJACENCY_CACHE} for {@code O(1)} lookups,
+     * providing a highly efficient way to check adjacency. Adjacency is critical for the puzzle's
+     * mechanics, as clicks only affect neighboring cells.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method performs {@code O(1)} lookups in a pre-computed adjacency cache, making it extremely
-     * fast. The overhead of converting between formats is likely larger than the lookup itself, so this
-     * method should be used judiciously in performance-critical paths, or redesigned to assume a single
-     * format if necessary.
+     * The core lookup in {@link #ADJACENCY_CACHE} is extremely fast. The primary performance
+     * consideration is the overhead of format conversion if {@link ValueFormat#PackedInt} is used. For
+     * optimal performance in hot paths, it is recommended to use {@link ValueFormat#Index} directly.
      * </p>
-     * 
-     * @param cellA  the first cell to check, in the specified format.
-     * @param cellB  the second cell to check, in the specified format.
-     * @param format the {@link ValueFormat format} of both cells ({@link ValueFormat#Index Index} or
-     *               {@link ValueFormat#PackedInt PackedInt}).
+     *
+     * @param cellA  The first cell to check.
+     * @param cellB  The second cell to check.
+     * @param format The {@link ValueFormat} of both input cells ({@link ValueFormat#Index} or
+     *               {@link ValueFormat#PackedInt}).
      * @return {@code true} if the cells are adjacent, {@code false} otherwise.
-     * @throws IllegalArgumentException       if the format is {@link ValueFormat#Bitmask Bitmask}
-     *                                        (since bitmasks aren't supported for single values) or
-     *                                        another unsupported format.
-     * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
-     *                                        array access).
-     * @see #ADJACENCY_CACHE
+     * @throws IllegalArgumentException       if {@link ValueFormat#Bitmask} is used for any format.
+     * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds.
      * @see #areAdjacent(short, short)
      * @see #canAffectFirstTrueCell(short, short, ValueFormat)
      * @since 2025.07 - Index Format Usage
-     * @performance {@code O(1)} complexity.
-     * @threading Thread-safe, as it only reads from immutable static data.
-     * @optimization Directly uses the {@link #ADJACENCY_CACHE} for an instantaneous lookup after
-     *               handling any necessary format conversion.
+     * @performance {@code O(1)} lookup in the cache, plus conversion overhead if applicable.
+     * @threading Thread-safe; accesses immutable, pre-computed {@code static} data.
+     * @memory Does not allocate.
      */
     public static boolean areAdjacent(short cellA, short cellB, ValueFormat format) {
         // Convert both cells to index format if necessary
@@ -2189,43 +1784,38 @@ public abstract class Grid {
     }
 
     /**
-     * Overload of {@link #areAdjacent(short, short, ValueFormat)} that assumes the input format is
-     * {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls the main
-     * method with the {@code Index} format.
-     * 
-     * @param cellA the first cell to check, in {@link ValueFormat#Index Index} format (0-108).
-     * @param cellB the second cell to check, in {@link ValueFormat#Index Index} format (0-108).
+     * Convenience overload for {@link #areAdjacent(short, short, ValueFormat)} that assumes
+     * {@link ValueFormat#Index} for both input cells.
+     *
+     * @param cellA The first cell to check, in {@link ValueFormat#Index} format.
+     * @param cellB The second cell to check, in {@link ValueFormat#Index} format.
      * @return {@code true} if the cells are adjacent, {@code false} otherwise.
-     * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
-     *                                        array access).
+     * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds.
      * @since 2025.06 - Odd Adjacency Pruning
      * @performance {@code O(1)} lookup.
      * @threading Thread-safe.
-     * @optimization The most direct way to check adjacency, assuming {@link ValueFormat#Index} format.
+     * @memory Does not allocate.
      */
     public static boolean areAdjacent(short cellA, short cellB) {
         return areAdjacent(cellA, cellB, ValueFormat.Index);
     }
 
     /**
-     * Returns a copy of the current {@link #gridState grid state} as a bitmask (array of two
-     * {@code long}s).
-     * 
+     * Returns a copy of the current {@link #gridState grid state} as a {@code long[2]} bitmask.
+     *
      * <p>
-     * This method exists to provide direct access to the grid's internal state. While no current code
-     * paths leverage this method (in part due to the allocation it requires), it may be useful for
-     * debugging, logging, or future features that require direct manipulation or inspection of the grid
-     * state.
+     * This method provides direct access to a snapshot of the grid's internal state. While it involves
+     * an allocation, it is useful for debugging, logging, or scenarios requiring immutable copies of
+     * the grid state without exposing the internal array directly.
      * </p>
-     * 
-     * @return A copy of the current grid state as a bitmask (array of two {@code long}s).
+     *
+     * @return A copy of the current grid state as a {@code long[2]} bitmask.
      * @see #click(long[])
      * @see ValueFormat#Bitmask
      * @since 2025.07 - Bitmasked Grid State
-     * @performance {@code O(1)} complexity.
-     * @threading The output is thread-safe, since it is a copy of the internal state.
-     * @memory Allocates a new {@code long[2]} array to prevent external modification of the instance's
-     *         internal state.
+     * @performance {@code O(1)} complexity (fixed-size array copy).
+     * @threading The returned array is thread-safe as it is a new, independent copy.
+     * @memory Allocates a new {@code long[2]} array.
      */
     public long[] getGridState() {
         return gridState.clone();
@@ -2233,9 +1823,14 @@ public abstract class Grid {
 
     /**
      * Prints the current grid state to the {@link LogManager#getLogger() logger} in a human-readable
-     * format, with '1' representing {@code true} cells and '0' representing {@code false} cells. Rows
-     * are indented to reflect the hexagonal layout, matching the format used in the PDC puzzle code.
-     * 
+     * format.
+     *
+     * <p>
+     * Cells are represented by '1' for {@code true} (on) and '0' for {@code false} (off). Rows are
+     * indented to visually reflect the hexagonal layout, matching the format used in the original PDC
+     * puzzle description. This method is primarily for debugging and visualization.
+     * </p>
+     *
      * @see #EVEN_NUM_COLS
      * @see #NUM_ROWS
      * @see #ODD_NUM_COLS
@@ -2248,11 +1843,9 @@ public abstract class Grid {
      * @see org.apache.logging.log4j.Logger
      * @see org.apache.logging.log4j.LogManager
      * @since 2025.03 - Grid Printing Method Creation
-     * @performance <code>O({@value Grid#NUM_CELLS})</code>. This is a debugging method and is not
-     *              performance-critical.
-     * @threading Not thread-safe, as it iterates over the mutable grid state.
+     * @performance {@code O(NUM_CELLS)} due to iteration over all cells. Not performance-critical.
+     * @threading Not thread-safe; iterates over the mutable grid state.
      * @memory Allocates a new {@link StringBuilder} for each row.
-     * @optimization Uses a {@link StringBuilder} for efficient string concatenation within each row.
      */
     public void printGrid() {
         Logger logger = LogManager.getLogger();

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -24,7 +24,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>9/50 - 18% of documentation completed</h3>
+ * <h3>16/50 - 32% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]
@@ -41,20 +41,220 @@ public abstract class Grid
         Bitmask // Unused for the moment, but we could directly store combinations as an array of two bitmasks
     }
     
-    // Constants
+    /**
+     * The number of rows in the grid. This is a constant value of 7, as the grid is defined to have 7 rows.
+     * 
+     * <h2>Performance Characteristics</h2>
+     * <p>
+     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
+     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
+     * of grid operations and ensuring that all methods operate within the valid range of rows.
+     * </p>
+     * 
+     * @since 2025.03.20 - Grid Definition
+     * @threading This constant is immutable and safe to use across threads.
+     * @performance O(1) access time, as it is a constant value.
+     * @optimization Using a constant to avoid recalculating the number of rows and to prevent magic
+     *              numbers in the code.
+     * @see #ROW_OFFSETS
+     * @see #NUM_CELLS
+     * @see #EVEN_NUM_COLS
+     * @see #ODD_NUM_COLS
+     */
     public static final int NUM_ROWS = 7;
+    /**
+     * The number of columns in odd-indexed rows of the grid. This is a constant value of 15, as defined
+     * by the grid's structure.
+     * 
+     * <h2>Performance Characteristics</h2>
+     * <p>
+     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
+     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
+     * of grid operations and ensuring that all methods operate within the valid range of columns.
+     * </p>
+     * 
+     * @since 2025.03.20 - Grid Definition
+     * @threading This constant is immutable and safe to use across threads.
+     * @performance O(1) access time, as it is a constant value.
+     * @optimization Using a constant to avoid recalculating the number of columns and to prevent magic
+     *               numbers in the code.
+     * @see #ROW_OFFSETS
+     * @see #NUM_CELLS
+     * @see #NUM_ROWS
+     * @see #EVEN_NUM_COLS
+     */
     public static final int ODD_NUM_COLS = 15;
+    /**
+     * The number of columns in even-indexed rows of the grid. This is a constant value of 16, as
+     * defined by the grid's structure.
+     * 
+     * <h2>Performance Characteristics</h2>
+     * <p>
+     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
+     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
+     * of grid operations and ensuring that all methods operate within the valid range of columns.
+     * </p>
+     * 
+     * @since 2025.03.20 - Grid Definition
+     * @threading This constant is immutable and safe to use across threads.
+     * @performance O(1) access time, as it is a constant value.
+     * @optimization Using a constant to avoid recalculating the number of columns and to prevent magic
+     *               numbers in the code.
+     * @see #ROW_OFFSETS
+     * @see #NUM_CELLS
+     * @see #NUM_ROWS
+     * @see #ODD_NUM_COLS
+     */
     public static final int EVEN_NUM_COLS = 16;
+    /**
+     * Offsets for each row in the grid, used to convert between {@link ValueFormat#PackedInt PackedInt}
+     * and {@link ValueFormat#Index Index} formats.
+     * 
+     * <p>
+     * PackedInt format is human-readable and easy to work with for adjacency calculations, but it isn't
+     * the most efficient for storage. Index format is more memory-efficient and is easier for
+     * generators to work with, but it isn't as easily understood by humans. The offsets bridge the gap
+     * between these two formats, allowing us to convert between them without losing information.
+     * </p>
+     * 
+     * <h2>Performance Characteristics</h2>
+     * <p>
+     * Lookup time for the offsets is O(1) since they are stored in a static array. Testing has shown
+     * that using a static array is more efficient than calculating the offsets at runtime, at least for
+     * Packed -> Index conversions.
+     * </p>
+     * 
+     * @since 2025.06.04 - BitSet Grid state
+     * @threading This array is immutable after initialization and is safe to use across threads.
+     * @performance O(1) lookup time for offsets, as they are stored in a static array.
+     * @optimization Using a static array to avoid the overhead of runtime calculations.
+     * @see #NUM_ROWS
+     * @see #EVEN_NUM_COLS
+     * @see #ODD_NUM_COLS
+     * @see #computePackedToIndex(short)
+     * @see ValueFormat
+     */
     public static final short[] ROW_OFFSETS = {0, 16, 31, 47, 62, 78, 93};
+    /**
+     * The total number of cells in the grid. This is a constant value of 109, derived from the grid's
+     * structure of 7 rows with alternating counts of 16 and 15 columns.
+     * 
+     * <p>
+     * The grid consists of 7 rows, where even-indexed rows (0, 2, 4, 6) contain 16 columns each, and
+     * odd-indexed rows (1, 3, 5) contain 15 columns each. This results in a total of 4 * 16 + 3 * 15 =
+     * 109 cells.
+     * </p>
+     * 
+     * <h2>Performance Characteristics</h2>
+     * <p>
+     * This constant is used throughout the class to define array sizes and loop bounds, ensuring
+     * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
+     * of grid operations and ensuring that all methods operate within the valid range of cells.
+     * </p>
+     * 
+     * @since 2025.04.15 - Static Block Initialization
+     * @threading This constant is immutable and safe to use across threads.
+     * @performance O(1) access time, as it is a constant value.
+     * @optimization Using a constant to avoid recalculating the number of cells and to prevent magic
+     *               numbers in the code.
+     * @see #ROW_OFFSETS
+     * @see #NUM_ROWS
+     * @see #EVEN_NUM_COLS
+     * @see #ODD_NUM_COLS
+     * @see #gridState
+     * @see #trueCellsCount
+     */
     public static final int NUM_CELLS = 109;
 
-    // Bitmask grid state - 109 cells fit in 2 longs (128 bits)
+    /**
+     * The current state of the grid as an array of two longs. Each long contains a bitmask,
+     * with the first representing the first 64 cells and the second representing the last 45 cells.
+     * 
+     * <p>
+     * The core part of the grid state is, well, the grid state. We need something that can efficiently
+     * represent the state of the grid, allowing for fast access and manipulation of each cell while
+     * also keeping memory usage low. The bitmask approach fits both of these requirements, making
+     * operations very efficient.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The fundamental rule of JVM optimization: <b>Don't allocate</b>. To achieve a throughput of tens
+     * of billions of <code>click</code>s per second, we need to avoid unnecessary allocations and use
+     * primitive types wherever possible. This takes most collections off the table.
+     * </p>
+     * 
+     * <p>
+     * An array of booleans seems like a good fit, but a boolean takes up 1 byte at minimum in Java
+     * (with arrays using extra padding), which would require 109 bytes for the grid. In addition,
+     * clicks act on adjacent cells, meaning that each operation would require 6 lookups and 6 updates,
+     * which is suboptimal.
+     * </p>
+     * 
+     * <p>
+     * BitSets are a good fit, but they incur some overhead in terms of object headers and the need to
+     * perform up to 6 XOR operations per click. Their internals give way to the best implementation: a
+     * bitmask. We can make custom masks to represent click operations, turning clicks into a single
+     * operation (technically two because of size limitations) and storing our grid in an array that
+     * takes up just 128 bits (or 16 bytes).
+     * </p>
+     * 
+     * <p>
+     * There could be some further optimizations in the future, but we're running against the limits of
+     * Java as a whole. There is no 128-bit primitive type, so we can't use that. LongVectors seemed
+     * promising, but the Vector API allocates TERRIBLY (we're talking 4 allocations per lanewise
+     * operation, all from the internal non-overridable logic of the API). Until we can find something that
+     * can represent a 128-bit value without allocations, we will stick with this approach.
+     * </p>
+     * 
+     * @since 2025.07.13 - Bitmasked Grid state
+     * @threading This field is <b>not</b> thread-safe. It should only be accessed from a single thread
+     *            or with proper synchronization.
+     * @performance O(1) lookup time for each 64-bit long in the gridState array and O(1) bitwise operations
+     * @optimization Uses a primitive bitmask of longs to represent the grid state, allowing for fast access and
+     *              manipulation of each cell while keeping memory usage low. 
+     * @see #getGridState()
+     * @see #printGrid()
+     * @see #getBit(int index)
+     * @see #setBit(int index)
+     * @see #clearBit(int index)
+     */
     protected final long[] gridState = new long[2];
     protected int trueCellsCount = 0;
     protected short firstTrueCell = -1; // The first true cell is in index format (0-108)
     protected boolean recalculationNeeded = false;
 
-    // Pre-computed adjacency masks for each possible cell (in bit index format)
+    /**
+     * Adjacency masks for each cell in the grid. These are filled in during the static block of
+     * {@link Grid this class} and are used to quickly determine the adjacent cells for a given cell in
+     * the grid.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Pre-computing these masks allows for O(1) lookups when determining the adjacent cells for a given
+     * cell, avoiding the need to compute adjacencies on-the-fly. This is crucial, as
+     * {@link TestClickCombination monkeys} perform tens of billions of <code>click</code>s per second
+     * (as of writing this), and we need to ensure that adjacency checks are as fast as possible.
+     * </p>
+     * 
+     * <p>
+     * We standardize the masks to use 2 longs for each cell since we have 109 cells, which fits
+     * comfortably within 128 bits. Though a click could only affect cells in the range of one of these
+     * longs, we use two for simplicity and to avoid additional complexity in the hot path. The indices
+     * are standardized to follow the {@link ValueFormat#Index Index} format, consistent with other
+     * fields in this class.
+     * </p>
+     * 
+     * @since 2025.04.15 - Static Block Initialization
+     * @threading This array is initialized in a static block and is immutable after that point.
+     * @performance O(1) lookup time for adjacency masks, as they are pre-computed and stored in a
+     *              static array.
+     * @optimization Uses a static array to avoid the overhead of runtime calculations. Standardized to
+     *               use the {@link ValueFormat#Index Index} format and to use 2 longs per cell for
+     *               consistency and simplicity.
+     * @see #NUM_CELLS
+     * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
+     */
     private static final long[][] ADJACENCY_MASKS = new long[NUM_CELLS][2];
     
     // Legacy support for existing code that expects adjacency arrays

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -8,34 +8,35 @@ import it.unimi.dsi.fastutil.shorts.ShortIterator;
 import it.unimi.dsi.fastutil.shorts.ShortList;
 
 /**
- * Represents the core hexagonal grid for a "Lights Out" style puzzle.
+ * A structure that represents the core hexagonal grid for a "Lights Out" style puzzle.
  *
  * <p>
- * This abstract class provides a high-performance, bitmask-based representation of a 109-cell
- * hexagonal grid. It is designed for a specific variant of the puzzle where clicking a cell toggles
- * the state of its <strong>adjacent cells only</strong>, not the cell itself. The primary goal is to turn
- * off all the lights on the grid.
+ * This abstract class provides a high-performance, bitmask-based representation of a
+ * {@value #NUM_CELLS}-cell hexagonal grid. It is designed for a specific variant of the puzzle
+ * where clicking a cell toggles the state of its <strong>adjacent cells only</strong>, not the cell
+ * itself. The primary goal is to turn off all the lights on the grid.
  * </p>
  *
  * <h2>Architecture Role</h2>
  * <p>
- * As the foundational data structure, {@code Grid} defines the puzzle's state and core
- * operations. It is extended by concrete implementations such as {@link Grid13}, {@link Grid22},
- * and {@link Grid35}, which provide specific initial puzzle configurations.
+ * As the foundational data structure, {@code Grid} defines the puzzle's state and core operations.
+ * It is extended by concrete implementations such as {@link Grid13}, {@link Grid22}, and
+ * {@link Grid35}, which provide specific initial puzzle configurations.
  * </p>
  *
  * <p>
  * {@link TestClickCombination Worker threads ("monkeys")} interact with cloned instances of this
- * class to test solutions. In contrast, {@link CombinationGeneratorTask generators} perform lighter,
- * more frequent checks and have limited direct interaction with this class. This separation ensures
- * that optimizations to this class primarily benefit the state-intensive work of the monkeys.
+ * class to test solutions. In contrast, {@link CombinationGeneratorTask generators} perform
+ * lighter, more frequent checks and have limited direct interaction with this class. This
+ * separation ensures that optimizations to this class primarily benefit the state-intensive work of
+ * the monkeys.
  * </p>
  *
  * <h2>Performance Characteristics</h2>
  * <p>
  * The grid state is stored in a {@code long[2]} array, treated as a 128-bit bitmask to represent
- * the 109 cells. This approach minimizes memory footprint and allows for extremely fast state
- * manipulation using bitwise operations. Adjacency information is pre-computed into
+ * the {@value #NUM_CELLS} cells. This approach minimizes memory footprint and allows for extremely
+ * fast state manipulation using bitwise operations. Adjacency information is pre-computed into
  * {@link #ADJACENCY_MASKS}, enabling {@code O(1)} complexity for the critical {@code click}
  * operation.
  * </p>
@@ -44,21 +45,21 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * Several alternatives were evaluated:
  * </p>
  * <ul>
- *   <li><b>{@link java.util.BitSet}:</b> Incurs unacceptable overhead from object headers and indirect
- *       memory access compared to a primitive array.</li>
- *   <li><b>Panama/Vector API:</b> Showed promise for 128-bit operations but suffered from excessive
- *       memory allocation (4+ allocations per lanewise operation in tested JDK versions), making it
- *       unsuitable for the hot path.</li>
+ * <li><b>{@link java.util.BitSet}:</b> Incurs unacceptable overhead from object headers and
+ * indirect memory access compared to a primitive array.</li>
+ * <li><b>Panama/Vector API:</b> Showed promise for 128-bit operations but suffered from excessive
+ * memory allocation (4+ allocations per lanewise operation in tested JDK versions), making it
+ * unsuitable for the hot path.</li>
  * </ul>
  * The primitive {@code long[]} array was ultimately chosen as the most performant solution on the
  * modern JVM, despite the complexity of managing two separate {@code long}s.
  *
  * <h2>Future Optimizations</h2>
  * <p>
- * Further performance gains are likely limited by the JVM itself. Potential avenues for
- * exploration include off-heap memory storage or the availability of true 128-bit primitives
- * in a future Java version (e.g., via Project Valhalla), which would simplify the bitmask logic to a
- * single {@code long}.
+ * Further performance gains are likely limited by the JVM itself. Potential avenues for exploration
+ * include off-heap memory storage or the availability of true 128-bit primitives in a future Java
+ * version (e.g., via Project Valhalla), which would simplify the bitmask logic to a single
+ * {@code long}.
  * </p>
  *
  * <h2>Static Initialization</h2>
@@ -67,14 +68,14 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * runs only once when the class is loaded and pre-computes several critical data structures:
  * </p>
  * <ul>
- *   <li>{@link #ADJACENCY_MASKS}: Bitmasks for every cell, allowing a {@code click} to be a simple
- *       XOR operation.</li>
- *   <li>{@link #adjacencyArray}: A legacy structure providing adjacent cell indices for algorithms
- *       that require iteration.</li>
- *   <li>{@link #ADJACENCY_CACHE}: A boolean matrix for {@code O(1)} adjacency checks between any two
- *       cells.</li>
- *   <li>{@link #PACKED_TO_INDEX_CACHE}: A lookup table for fast conversion from human-readable
- *       {@link ValueFormat#PackedInt} to the internal {@link ValueFormat#Index}.</li>
+ * <li>{@link #ADJACENCY_MASKS}: Bitmasks for every cell, allowing a {@code click} to be a simple
+ * XOR operation.</li>
+ * <li>{@link #adjacencyArray}: A legacy structure providing adjacent cell indices for algorithms
+ * that require iteration.</li>
+ * <li>{@link #ADJACENCY_CACHE}: A boolean matrix for {@code O(1)} adjacency checks between any two
+ * cells.</li>
+ * <li>{@link #PACKED_TO_INDEX_CACHE}: A lookup table for fast conversion from human-readable
+ * {@link ValueFormat#PackedInt} to the internal {@link ValueFormat#Index}.</li>
  * </ul>
  * This pre-computation offloads complex calculations from the performance-critical runtime paths.
  *
@@ -92,9 +93,9 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * @see Grid35
  * @see TestClickCombination
  * @since 2025.03 - Initial Creation
- * @performance Critical operations like {@link #click(short)} and state checks are {@code O(1)} due to
- *              extensive pre-computation. The majority of computational complexity is handled once in
- *              a static initializer.
+ * @performance Critical operations like {@link #click(short)} and state checks are {@code O(1)} due
+ *              to extensive pre-computation. The majority of computational complexity is handled
+ *              once in a static initializer.
  * @threading Not thread-safe. Instances of {@code Grid} must not be shared between threads without
  *            external synchronization.
  * @algorithm Uses a bitmask ({@code long[2]}) to represent the grid state. Clicks are performed
@@ -131,7 +132,7 @@ public abstract class Grid {
     public enum ValueFormat {
         /**
          * A format where each cell is represented as a packed integer, with the row and column encoded as
-         * <code>row * 100 + col</code>. For example, the cell at row 3, column 5 would be represented as
+         * {@code row * 100 + col}. For example, the cell at row 3, column 5 would be represented as
          * 305.
          * 
          * <p>
@@ -142,8 +143,8 @@ public abstract class Grid {
          * 
          * <p>
          * It's worth noting that, as of July 24th, 2025, most of our codebase has been updated to use
-         * <code>short</code>s instead of <code>int</code>s for cell values, due to the grid's size fitting
-         * comfortably within the range of a <code>short</code>. However, the naming has persisted for
+         * {@code short}s instead of {@code int}s for cell values, due to the grid's size fitting
+         * comfortably within the range of a {@code short}. However, the naming has persisted for
          * clarity and consistency, as the format's structure remains unchanged. "PackedShort" would be more
          * accurate, but it would require modifying a significant portion of the codebase, which may not be
          * worth the effort at this time.
@@ -173,9 +174,9 @@ public abstract class Grid {
          */
         PackedInt,
         /**
-         * A format where each cell is represented as a zero-based index, ranging from 0 to 108 for our
-         * 109-cell grid. The index is calculated based on the cell's position in a flattened array
-         * representation of the grid.
+         * A format where each cell is represented as a zero-based index, ranging from {@code 0} to
+         * {@code 108} for our {@value Grid#NUM_CELLS}-cell grid. The index is calculated based on the
+         * cell's position in a flattened array representation of the grid.
          * 
          * <p>
          * This format is more memory-efficient than {@link #PackedInt PackedInt}, as it uses the minimum
@@ -187,10 +188,10 @@ public abstract class Grid {
          * 
          * <h3>Performance Considerations</h3>
          * <p>
-         * In comparison with the {@link #PackedInt PackedInt} format, this format is more efficient in
-         * terms of storage, as it uses fewer bits to represent the cell values. However, operations that
-         * require multiple cell accesses and/or modifications may benefit from using the {@link #Bitmask
-         * Bitmask} format instead, as it can allow for operations in parallel.
+         * In comparison with the {@code PackedInt} format, this format is more efficient in terms of
+         * storage, as it uses fewer bits to represent the cell values. However, operations that require
+         * multiple cell accesses and/or modifications may benefit from using the {@link #Bitmask Bitmask}
+         * format instead, as it can allow for operations in parallel.
          * </p>
          * 
          * @see #indexToPacked(short)
@@ -198,14 +199,14 @@ public abstract class Grid {
          * @since 2025.07 - ValueFormat Enum Introduction
          * @performance {@code O(1)} access time.
          * @threading This enum value is an immutable constant and is thread-safe.
-         * @optimization This format provides a compact, efficient representation for iterating through cells,
-         *               making it ideal for generator tasks.
+         * @optimization This format provides a compact, efficient representation for iterating through
+         *               cells, making it ideal for generator tasks.
          */
         Index,
         /**
          * A format where the entire grid state is represented as a bitmask, with each bit corresponding to
-         * a cell in the grid. A bit value of 1 indicates that the cell is "on" (true), while a bit value of
-         * 0 indicates that the cell is "off" (false).
+         * a cell in the grid. A bit value of 1 indicates that the cell is "on" ({@code true}), while a bit
+         * value of 0 indicates that the cell is "off" ({@code false}).
          * 
          * <p>
          * This format allows for compact storage and fast operations using bitwise logic, as multiple cell
@@ -220,16 +221,16 @@ public abstract class Grid {
          * While this format carries several efficiency advantages, it is rarely used in our current
          * codebase due to its trade-offs. Further complicating matters is Java's lack of a native 128-bit
          * primitive type, which would be ideal for representing our 109-cell grid in a single bitmask.
-         * Without such a type, we are forced to split the grid state across two 64-bit longs, which adds
-         * complexity and slightly diminishes the performance benefits of using a bitmask.
+         * Without such a type, we are forced to split the grid state across two 64-bit {@code long}s, which
+         * adds complexity and slightly diminishes the performance benefits of using a bitmask.
          * </p>
          * 
          * <p>
-         * Despite this, we could still see some benefits from using this format in certain scenarios. Combinations
-         * of clicks could be represented as bitmasks, allowing for fast application to the grid state using two
-         * bitwise OR operations. Our current codebase hasn't explored this avenue yet, but it remains a potential
-         * optimization for the future to squeeze out additional performance, especially for operations involving
-         * very long click combinations.
+         * Despite this, we could still see some benefits from using this format in certain scenarios.
+         * Combinations of clicks could be represented as bitmasks, allowing for fast application to the
+         * grid state using two bitwise OR operations. Our current codebase hasn't explored this avenue yet,
+         * but it remains a potential optimization for the future to squeeze out additional performance,
+         * especially for operations involving very long click combinations.
          * </p>
          * 
          * @see #gridState
@@ -240,15 +241,16 @@ public abstract class Grid {
          * @since 2025.07 - ValueFormat Enum Introduction
          * @performance {@code O(1)} access time.
          * @threading This enum value is an immutable constant and is thread-safe.
-         * @optimization This format is primarily for internal grid state representation and is not exposed in
-         *               most public methods due to its complexity and Java's lack of a native 128-bit
+         * @optimization This format is primarily for internal grid state representation and is not exposed
+         *               in most public methods due to its complexity and Java's lack of a native 128-bit
          *               primitive type.
          */
         Bitmask
     }
     
     /**
-     * The number of rows in the grid. This is a constant value of 7, as the grid is defined to have 7 rows.
+     * The number of rows in the grid. This is a constant value of {@value #NUM_ROWS}, as the grid is
+     * defined to have {@value #NUM_ROWS} rows.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
@@ -268,8 +270,8 @@ public abstract class Grid {
      */
     public static final int NUM_ROWS = 7;
     /**
-     * The number of columns in odd-indexed rows of the grid. This is a constant value of 15, as defined
-     * by the grid's structure.
+     * The number of columns in odd-indexed rows of the grid. This is a constant value of
+     * {@value #ODD_NUM_COLS}, as defined by the grid's structure.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
@@ -289,8 +291,8 @@ public abstract class Grid {
      */
     public static final int ODD_NUM_COLS = 15;
     /**
-     * The number of columns in even-indexed rows of the grid. This is a constant value of 16, as
-     * defined by the grid's structure.
+     * The number of columns in even-indexed rows of the grid. This is a constant value of
+     * {@value #EVEN_NUM_COLS}, as defined by the grid's structure.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
@@ -314,17 +316,18 @@ public abstract class Grid {
      * and {@link ValueFormat#Index Index} formats.
      * 
      * <p>
-     * PackedInt format is human-readable and easy to work with for adjacency calculations, but it isn't
-     * the most efficient for storage. Index format is more memory-efficient and is easier for
-     * generators to work with, but it isn't as easily understood by humans. The offsets bridge the gap
-     * between these two formats, allowing us to convert between them without losing information.
+     * {@code PackedInt} format is human-readable and easy to work with for adjacency calculations, but
+     * it isn't the most efficient for storage. {@code Index} format is more memory-efficient and is
+     * easier for generators to work with, but it isn't as easily understood by humans. The offsets
+     * bridge the gap between these two formats, allowing us to convert between them without losing
+     * information.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Lookup time for the offsets is O(1) since they are stored in a static array. Testing has shown
-     * that using a static array is more efficient than calculating the offsets at runtime, at least for
-     * Packed -> Index conversions.
+     * Lookup time for the offsets is {@code O(1)} since they are stored in a static array. Testing has
+     * shown that using a static array is more efficient than calculating the offsets at runtime, at
+     * least for {@code PackedInt} -> {@code Index} conversions.
      * </p>
      * 
      * @see #EVEN_NUM_COLS
@@ -339,13 +342,15 @@ public abstract class Grid {
      */
     public static final short[] ROW_OFFSETS = {0, 16, 31, 47, 62, 78, 93};
     /**
-     * The total number of cells in the grid. This is a constant value of 109, derived from the grid's
-     * structure of 7 rows with alternating counts of 16 and 15 columns.
+     * The total number of cells in the grid. This is a constant value of {@value #NUM_CELLS}, derived
+     * from the grid's structure of {@value #NUM_ROWS} rows with alternating counts of
+     * {@value #EVEN_NUM_COLS} and {@value #ODD_NUM_COLS} columns.
      * 
      * <p>
-     * The grid consists of 7 rows, where even-indexed rows (0, 2, 4, 6) contain 16 columns each, and
-     * odd-indexed rows (1, 3, 5) contain 15 columns each. This results in a total of 4 * 16 + 3 * 15 =
-     * 109 cells.
+     * The grid consists of {@value #NUM_ROWS} rows, where even-indexed rows (0, 2, 4, 6) contain
+     * {@value #EVEN_NUM_COLS} columns each, and odd-indexed rows (1, 3, 5) contain
+     * {@value #EVEN_NUM_COLS} columns each. This results in a total of 4 * {@value #EVEN_NUM_COLS} + 3
+     * * {@value #ODD_NUM_COLS} = {@value NUM_CELLS} cells.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -369,8 +374,8 @@ public abstract class Grid {
     public static final int NUM_CELLS = 109;
 
     /**
-     * The current state of the grid as an array of two longs. Each long contains a bitmask,
-     * with the first representing the first 64 cells and the second representing the last 45 cells.
+     * The current state of the grid as an array of two{@code long}s. Each long contains a bitmask, with
+     * the first representing the first 64 cells and the second representing the last 45 cells.
      * 
      * <p>
      * The core part of the grid state is, well, the grid state. We need something that can efficiently
@@ -382,31 +387,31 @@ public abstract class Grid {
      * <h3>Performance Considerations</h3>
      * <p>
      * The fundamental rule of JVM optimization: <b>Don't allocate</b>. To achieve a throughput of tens
-     * of billions of <code>click</code>s per second, we need to avoid unnecessary allocations and use
+     * of billions of {@code click}s per second, we need to avoid unnecessary allocations and use
      * primitive types wherever possible. This takes most collections off the table.
      * </p>
      * 
      * <p>
-     * An array of booleans seems like a good fit, but a boolean takes up 1 byte at minimum in Java
-     * (with arrays using extra padding), which would require 109 bytes for the grid. In addition,
-     * clicks act on adjacent cells, meaning that each operation would require 6 lookups and 6 updates,
-     * which is suboptimal.
+     * An array of {@code boolean}s seems like a good fit, but a {@code boolean} takes up 1 byte at
+     * minimum in Java (with arrays using extra padding), which would require 109 bytes for the grid. In
+     * addition, clicks act on adjacent cells, meaning that each operation would require 6 lookups and 6
+     * updates, which is suboptimal.
      * </p>
      * 
      * <p>
-     * BitSets are a good fit, but they incur some overhead in terms of object headers and the need to
-     * perform up to 6 XOR operations per click. Their internals give way to the best implementation: a
-     * bitmask. We can make custom masks to represent click operations, turning clicks into a single
-     * operation (technically two because of size limitations) and storing our grid in an array that
-     * takes up just 128 bits (or 16 bytes).
+     * {@link java.util.BitSet BitSets} are a good fit, but they incur some overhead in terms of object
+     * headers and the need to perform up to 6 XOR operations per click. Their internals give way to the
+     * best implementation: a bitmask. We can make custom masks to represent click operations, turning
+     * clicks into a single operation (technically two because of size limitations) and storing our grid
+     * in an array that takes up just 128 bits (or 16 bytes).
      * </p>
      * 
      * <p>
      * There could be some further optimizations in the future, but we're running against the limits of
      * Java as a whole. There is no 128-bit primitive type, so we can't use that. LongVectors seemed
      * promising, but the Vector API allocates TERRIBLY (we're talking 4 allocations per lanewise
-     * operation, all from the internal non-overridable logic of the API). Until we can find something that
-     * can represent a 128-bit value without allocations, we will stick with this approach.
+     * operation, all from the internal non-overridable logic of the API). Until we can find something
+     * that can represent a 128-bit value without allocations, we will stick with this approach.
      * </p>
      * 
      * @see #clearBit(int)
@@ -417,14 +422,14 @@ public abstract class Grid {
      * @since 2025.07 - Bitmasked Grid State
      * @performance {@code O(1)} access and update time.
      * @threading Not thread-safe. Access must be synchronized externally.
-     * @optimization Uses a primitive {@code long[]} bitmask to avoid object allocation overhead, enabling
-     *               extremely fast, cache-friendly state manipulation via bitwise operations.
+     * @optimization Uses a primitive {@code long[]} bitmask to avoid object allocation overhead,
+     *               enabling extremely fast, cache-friendly state manipulation via bitwise operations.
      */
     protected final long[] gridState = new long[2];
     /**
-     * Cached value of the number of cells that are currently true (on) in the grid. Used for quick
-     * {@link #isSolved() solution checks} and to optimize certain operations. Updated whenever
-     * {@link #getTrueCount()} is called and {@link #recalculationNeeded} is <code>true</code>.
+     * Cached value of the number of cells that are currently {@code true} (on) in the grid. Used for
+     * quick {@link #isSolved() solution checks} and to optimize certain operations. Updated whenever
+     * {@link #getTrueCount()} is called and {@link #recalculationNeeded} is {@code true}.
      * 
      * @see #getTrueCount()
      * @see #isSolved()
@@ -432,15 +437,16 @@ public abstract class Grid {
      * @performance {@code O(1)} access. The value is updated lazily.
      * @threading Not thread-safe. This field is mutated by {@link #click(short)} and read by
      *            {@link #getTrueCount()}.
-     * @optimization Caches the number of "on" cells to make {@link #isSolved()} checks instantaneous. The
-     *               count is recalculated only when necessary, controlled by {@link #recalculationNeeded}.
+     * @optimization Caches the number of "on" cells to make {@link #isSolved()} checks instantaneous.
+     *               The count is recalculated only when necessary, controlled by
+     *               {@link #recalculationNeeded}.
      */
     protected int trueCellsCount = 0;
     /**
-     * A cached index of the first cell that is currently true (on) in the grid. Stored in
+     * A cached index of the first cell that is currently {@code true} (on) in the grid. Stored in
      * {@link ValueFormat#Index Index} format and used to optimize constraint satisfaction checks and
      * certain operations. Updated whenever {@link #findFirstTrueCell(ValueFormat)} is called and
-     * {@link #recalculationNeeded} is <code>true</code>.
+     * {@link #recalculationNeeded} is {@code true}.
      * 
      * @see #findFirstTrueCell()
      * @since 2025.07 - First True Cell Caching
@@ -454,8 +460,8 @@ public abstract class Grid {
     protected short firstTrueCell = -1;
     /**
      * A flag indicating whether a recalculation of {@link #trueCellsCount} and/or
-     * {@link #firstTrueCell} is needed. Set to <code>true</code> whenever the grid state is modified
-     * (e.g., via a click operation) and reset to <code>false</code> after the next call to
+     * {@link #firstTrueCell} is needed. Set to {@code true} whenever the grid state is modified
+     * (e.g., via a click operation) and reset to {@code false} after the next call to
      * {@link #getTrueCount()} or {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()}.
      * 
      * @see #firstTrueCell
@@ -470,108 +476,110 @@ public abstract class Grid {
     protected boolean recalculationNeeded = false;
 
     /**
-     * Adjacency masks for each cell in the grid. These are filled in during the static block of
+     * Adjacency masks for each cell in the grid. These are filled in during the {@code static} block of
      * {@link Grid this class} and are used to quickly determine the adjacent cells for a given cell in
      * the grid.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Pre-computing these masks allows for O(1) lookups when determining the adjacent cells for a given
-     * cell, avoiding the need to compute adjacencies on-the-fly. This is crucial, as
-     * {@link TestClickCombination monkeys} perform tens of billions of <code>click</code>s per second
-     * (as of writing this), and we need to ensure that adjacency checks are as fast as possible.
+     * Pre-computing these masks allows for {@code O(1)} lookups when determining the adjacent cells for
+     * a given cell, avoiding the need to compute adjacencies on-the-fly. This is crucial, as
+     * {@link TestClickCombination monkeys} perform tens of billions of {@code click}s per second (as of
+     * writing this), and we need to ensure that adjacency checks are as fast as possible.
      * </p>
      * 
      * <p>
-     * We standardize the masks to use 2 longs for each cell since we have 109 cells, which fits
-     * comfortably within 128 bits. Though a click could only affect cells in the range of one of these
-     * longs, we use two for simplicity and to avoid additional complexity in the hot path. The indices
-     * are standardized to follow the {@link ValueFormat#Index Index} format, consistent with other
-     * fields in this class.
+     * We standardize the masks to use 2 {@code long}s for each cell since we have {@value #NUM_CELLS}
+     * cells, which fits comfortably within 128 bits. Though a click could only affect cells in the
+     * range of one of these {@code long}s, we use two for simplicity and to avoid additional complexity
+     * in the hot path. The indices are standardized to follow the {@link ValueFormat#Index Index}
+     * format, consistent with other fields in this class.
      * </p>
      * 
      * @see #NUM_CELLS
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.04 - Static Block Initialization
      * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after static initialization and is thread-safe.
-     * @optimization Pre-computing adjacency masks is the core optimization that makes {@link #click(short)} an
-     *               {@code O(1)} operation. Each mask represents the bitwise change required to toggle all
-     *               cells adjacent to a given cell.
+     * @threading This array is immutable after {@code static} initialization and is thread-safe.
+     * @optimization Pre-computing adjacency masks is the core optimization that makes
+     *               {@link #click(short)} an {@code O(1)} operation. Each mask represents the bitwise
+     *               change required to toggle all cells adjacent to a given cell.
      */
     private static final long[][] ADJACENCY_MASKS = new long[NUM_CELLS][2];
     
     // Legacy support for existing code that expects adjacency arrays
     /**
-     * Adjacency array for each cell in the grid. Each entry contains a <code>short[]</code> of the
-     * indices of adjacent cells. These are filled in during the static block of Grid's initialization,
-     * and are used to quickly retrieve results with the
+     * Adjacency array for each cell in the grid. Each entry contains a {@code short[]} of the indices
+     * of adjacent cells. These are filled in during the {@code static} block of {@code Grid}'s
+     * initialization, and are used to quickly retrieve results with the
      * {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Pre-computing these arrays allows for O(1) lookups when determining the adjacent cells for a
-     * given cell, avoiding the need to compute adjacencies on-the-fly. Previously, we used this array
-     * in the {@link #click(short, ValueFormat) click()} method, but we have since moved to using the
-     * {@link #ADJACENCY_MASKS adjacency masks} for better performance. The array is retained for use in
-     * the {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
+     * Pre-computing these arrays allows for {@code O(1)} lookups when determining the adjacent cells
+     * for a given cell, avoiding the need to compute adjacencies on-the-fly. Previously, we used this
+     * array in the {@link #click(short, ValueFormat) click()} method, but we have since moved to using
+     * the {@link #ADJACENCY_MASKS adjacency masks} for better performance. The array is retained for
+     * use in the {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} method.
      * </p>
      * 
      * @see #NUM_CELLS
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.05 - Adjacency Storage Optimization
      * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after static initialization and is thread-safe.
-     * @optimization Pre-computing adjacency lists in this array allows the {@link #findAdjacents} methods to
+     * @threading This array is immutable after {@code static} initialization and is thread-safe.
+     * @optimization Pre-computing adjacency lists in this array allows the
+     *               {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} methods to
      *               be fast lookups rather than expensive computations.
      */
     private static final short[][] adjacencyArray = new short[NUM_CELLS][]; // Index format
     /**
-     * A 2D boolean array representing adjacency between cells in the grid. This is a legacy structure,
-     * primarily used for quick adjacency checks between two cells in
+     * A 2D {@code boolean} array representing adjacency between cells in the grid. This is a legacy
+     * structure, primarily used for quick adjacency checks between two cells in
      * {@link #areAdjacent(short, short, ValueFormat) areAdjacent()}. It is filled in during the static
      * block of Grid's initialization and is not used in performance-critical paths.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This structure allows for O(1) adjacency checks between two cells, which is useful for certain
-     * operations. However, it is not used in the hot path of the application, as most operations use
-     * the {@link #ADJACENCY_MASKS adjacency masks} or the {@link #adjacencyArray adjacency array} for
-     * better performance. The 2D array is retained for legacy support and for use in specialized
-     * operations.
+     * This structure allows for {@code O(1)} adjacency checks between two cells, which is useful for
+     * certain operations. However, it is not used in the hot path of the application, as most
+     * operations use the {@link #ADJACENCY_MASKS adjacency masks} or the {@link #adjacencyArray
+     * adjacency array} for better performance. The 2D array is retained for legacy support and for use
+     * in specialized operations.
      * </p>
      * 
      * @see #NUM_CELLS
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
-     * @since 2025.06 - O(1) Adjacency Check
+     * @since 2025.06 - {@code O(1)} Adjacency Check
      * @performance {@code O(1)} lookup time.
      * @threading This array is immutable after static initialization and is thread-safe.
-     * @optimization A pre-computed boolean matrix that provides a near-instantaneous way to check if two
-     *               cells are adjacent, used by {@link #areAdjacent(short, short)}.
+     * @optimization A pre-computed {@code boolean} matrix that provides a near-instantaneous way to
+     *               check if two cells are adjacent, used by {@link #areAdjacent(short, short)}.
      */
     private static final boolean[][] ADJACENCY_CACHE = new boolean[NUM_CELLS][NUM_CELLS]; // Index format
     /**
-     * A cache for converting {@link ValueFormat#PackedInt PackedInt} values to
-     * {@link ValueFormat#Index Index} values. This is filled in during the static block of Grid's
-     * initialization and is used to quickly convert between these two formats without needing to
-     * compute the conversion on-the-fly.
+     * A cache for converting {@link ValueFormat#PackedInt PackedInt} values to {@link ValueFormat#Index
+     * Index} values. This is filled in during the {@code static} block of {@code Grid}'s initialization
+     * and is used to quickly convert between these two formats without needing to compute the
+     * conversion on-the-fly.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Pre-computing this cache allows for O(1) lookups when converting from PackedInt to Index format,
-     * avoiding the need to compute the conversion on-the-fly. This is useful for operations that need
-     * to work with both formats, as it allows for quick conversions without incurring the cost of
-     * calculations.
+     * Pre-computing this cache allows for {@code O(1)} lookups when converting from {@code PackedInt}
+     * to {@code Index} format, avoiding the need to compute the conversion on-the-fly. This is useful
+     * for operations that need to work with both formats, as it allows for quick conversions without
+     * incurring the cost of calculations.
      * </p>
      * 
      * @see #NUM_CELLS
      * @see #computePackedToIndex(short)
      * @see ValueFormat
-     * @since 2025.06 - PackedInt to Index Precomputation
+     * @since 2025.06 - {@code PackedInt} to {@code Index} Precomputation
      * @performance {@code O(1)} lookup time.
-     * @threading This array is immutable after static initialization and is thread-safe.
-     * @optimization A cache to accelerate the conversion from the human-readable {@link ValueFormat#PackedInt}
-     *               format to the performance-oriented {@link ValueFormat#Index} format.
+     * @threading This array is immutable after {@code static} initialization and is thread-safe.
+     * @optimization A cache to accelerate the conversion from the human-readable
+     *               {@link ValueFormat#PackedInt PackedInt} format to the performance-oriented
+     *               {@link ValueFormat#Index Index} format.
      */
     private static final short[] PACKED_TO_INDEX_CACHE = new short[(NUM_ROWS - 1) * 100 + EVEN_NUM_COLS];
 
@@ -615,46 +623,46 @@ public abstract class Grid {
      * adjacent to a given cell aren't just based on the row and column, but also on the row's parity
      * (even or odd), making calculations much more complex than a simple rectangular grid. This problem
      * is exacerbated by the fact that the Grid is represented in a flattened, bitmask format, doing
-     * away with the concept of rows and columns entirely for memory efficiency. Since
-     * <code>click</code> operations affect the adjacent cells, we need some way to determine which
-     * cells are adjacent to a given cell. This method provides that functionality.
+     * away with the concept of rows and columns entirely for memory efficiency. Since {@code click}
+     * operations affect the adjacent cells, we need some way to determine which cells are adjacent to a
+     * given cell. This method provides that functionality.
      * </p>
      * 
-     * <h3>Algorithm Details</h3> For a given cell n (in packed int format) in an even row, the adjacent
-     * cells include:
+     * <h3>Algorithm Details</h3> For a given cell {@code n} (in {@link ValueFormat#PackedInt} format)
+     * in an even row, the adjacent cells include:
      * <ul>
-     * <li>n - 101 (row - 1, col - 1)</li>
-     * <li>n - 100 (row - 1, col)</li>
-     * <li>n - 1 (row, col - 1)</li>
-     * <li>n + 1 (row, col + 1)</li>
-     * <li>n + 99 (row + 1, col - 1)</li>
-     * <li>n + 100 (row + 1, col)</li>
+     * <li>{@code n - 101} (row - 1, col - 1)</li>
+     * <li>{@code n - 100} (row - 1, col)</li>
+     * <li>{@code n - 1} (row, col - 1)</li>
+     * <li>{@code n + 1} (row, col + 1)</li>
+     * <li>{@code n + 99} (row + 1, col - 1)</li>
+     * <li>{@code n + 100} (row + 1, col)</li>
      * </ul>
      * 
      * For a cell in an odd row, the adjacent cells include:
      * <ul>
-     * <li>n - 100 (row - 1, col)</li>
-     * <li>n - 99 (row - 1, col + 1)</li>
-     * <li>n - 1 (row, col - 1)</li>
-     * <li>n + 1 (row, col + 1)</li>
-     * <li>n + 100 (row + 1, col)</li>
-     * <li>n + 101 (row + 1, col + 1)</li>
+     * <li>{@code n - 100} (row - 1, col)</li>
+     * <li>{@code n - 99} (row - 1, col + 1)</li>
+     * <li>{@code n - 1} (row, col - 1)</li>
+     * <li>{@code n + 1} (row, col + 1)</li>
+     * <li>{@code n + 100} (row + 1, col)</li>
+     * <li>{@code n + 101} (row + 1, col + 1)</li>
      * </ul>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Internal computations are performed in <code>PackedInt</code> format for efficiency, as it allows
-     * for straightforward arithmetic operations to determine adjacency. The method has to convert
-     * between formats as needed, which adds some overhead, but this is offset by our use of the method
-     * in the static block to pre-compute an {@link #adjacencyArray adjacency table}. Future calls to
-     * find adjacents can then use this pre-computed table for O(1) lookups.
+     * Internal computations are performed in {@code PackedInt} format for efficiency, as it allows for
+     * straightforward arithmetic operations to determine adjacency. The method has to convert between
+     * formats as needed, which adds some overhead, but this is offset by our use of the method in the
+     * {@code static} block to pre-compute an {@link #adjacencyArray adjacency table}. Future calls to
+     * find adjacents can then use this pre-computed table for {@code O(1)} lookups.
      * </p>
      * <p>
      * Since cells in different grid positions can have a different number of valid adjacent cells (due
-     * to edges and corners), we use a dynamic list (<code>ShortList</code>) to store the results,
-     * letting the calling method handle conversion to a fixed-size array if needed. Fastutil's
-     * primitive collections are used to avoid boxing overhead and allow for efficient storage and
-     * retrieval of short values.
+     * to edges and corners), we use a dynamic list ({@code ShortList}) to store the results, letting
+     * the calling method handle conversion to a fixed-size array if needed. Fastutil's primitive
+     * collections are used to avoid boxing overhead and allow for efficient storage and retrieval of
+     * short values.
      * </p>
      * 
      * @param cell         A short representing the cell in the grid, expected to be in the same format
@@ -663,10 +671,10 @@ public abstract class Grid {
      *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
      * @param outputFormat The {@link ValueFormat} of the output cell, which can either be
      *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return affectedPieces A <code>ShortList</code> of adjacent cells in the specified output format, containing
-     *         up to 6 items.
-     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
-     *                                  represent a single cell in that format.
+     * @return affectedPieces A {@code ShortList} of adjacent cells in the specified output format,
+     *         containing up to 6 items.
+     * @throws IllegalArgumentException if the input or output format is {@link ValueFormat#Bitmask},
+     *                                  since we cannot represent a single cell in that format.
      * @see #findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
      * @see ShortList
      * @since 2025.07 - Format Support
@@ -741,11 +749,11 @@ public abstract class Grid {
      * assumes the input and output formats are the same. This exists purely for convenience, as it
      * simply calls the main method with the same format for both parameters.
      * 
-     * @param cell   a <code>short</code> representing the cell in the grid, expected to be in the same
-     *               format as <code>format</code>.
+     * @param cell   a {@code short} representing the cell in the grid, expected to be in the same
+     *               format as {@code format}.
      * @param format the {@link ValueFormat} of both the input and output cell, which can either be
      *               {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return A <code>ShortList</code> of adjacent cells in the specified format, containing up to 6
+     * @return A {@code ShortList} of adjacent cells in the specified format, containing up to 6
      *         items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
@@ -764,11 +772,11 @@ public abstract class Grid {
     /**
      * Overload of {@link #computeAdjacents(short, ValueFormat) computeAdjacents()} that assumes that
      * the format is {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply
-     * calls the main method with <code>Index</code> for both parameters.
+     * calls the main method with {@code Index} for both parameters.
      * 
-     * @param cell a <code>short</code> representing the cell in the grid, expected to be in
+     * @param cell a {@code short} representing the cell in the grid, expected to be in
      *             {@link ValueFormat#Index Index} format.
-     * @return A <code>ShortList</code> of adjacent cells in {@link ValueFormat#Index Index} format,
+     * @return A {@code ShortList} of adjacent cells in {@link ValueFormat#Index Index} format,
      *         containing up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
@@ -796,11 +804,11 @@ public abstract class Grid {
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * While this method does pull from a {@link #adjacencyArray pre-computed adjacency array} for O(1)
-     * lookups, it is forced to convert each of the results to the requested output format, which adds
-     * some overhead and makes the method O(n) in complexity (where n is the number of adjacent cells,
-     * which is at most 6). In addition, the large switch statements for format handling limit this
-     * method's ability to be inlined by the JVM.
+     * While this method does pull from a {@link #adjacencyArray pre-computed adjacency array} for
+     * {@code O(1)} lookups, it is forced to convert each of the results to the requested output format,
+     * which adds some overhead and makes the method {@code O(adjacencyArray[cell].length)} in
+     * complexity (with the length being 6 at most). In addition, the large {@code switch} statements
+     * for format handling limit this method's ability to be inlined by the JVM.
      * </p>
      * 
      * <p>
@@ -809,14 +817,14 @@ public abstract class Grid {
      * lifetime of the program, so the added complexity and memory usage may not be worth it.
      * </p>
      * 
-     * @param cell         A <code>short</code> representing the cell in the grid, expected to be in the
-     *                     same format as <code>inputFormat</code>.
+     * @param cell         A {@code short} representing the cell in the grid, expected to be in the same
+     *                     format as {@code inputFormat}.
      * @param inputFormat  The {@link ValueFormat} of the input cell, which can either be
      *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
      * @param outputFormat The {@link ValueFormat} of the output cell, which can either be
      *                     {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return A <code>short[]</code> of adjacent cells in the specified output format, containing up to
-     *         6 items.
+     * @return A {@code short[]} of adjacent cells in the specified output format, containing up to 6
+     *         items.
      * @throws IllegalArgumentException       if the input or output format is
      *                                        {@link ValueFormat#Bitmask Bitmask}, since we cannot
      *                                        represent a single cell in that format.
@@ -826,12 +834,13 @@ public abstract class Grid {
      * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
      * @see ValueFormat
      * @since 2025.07 - Format Support
-     * @performance {@code O(1)} for {@link ValueFormat#Index} output, {@code O(k)} for other formats due to
-     *              conversion, where {@code k} is the number of adjacent cells (max 6).
-     * @threading This method is thread-safe, as it relies only on immutable, pre-computed static data.
+     * @performance {@code O(1)} for {@link ValueFormat#Index} output,
+     *              {@code O(adjacencyArray[cell].length)} for other formats due to conversion.
+     * @threading This method is thread-safe, as it relies only on immutable, pre-computed
+     *            {@code static} data.
      * @memory Allocates a new {@code short[]} for the result only if format conversion is necessary.
-     * @optimization The primary lookup from {@link #adjacencyArray} is an {@code O(1)} operation. The main
-     *               performance consideration is the potential overhead of format conversion.
+     * @optimization The primary lookup from {@link #adjacencyArray} is an {@code O(1)} operation. The
+     *               main performance consideration is the potential overhead of format conversion.
      */
     public static short[] findAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] result;
@@ -876,12 +885,11 @@ public abstract class Grid {
      * the input and output formats are the same. This exists purely for convenience, as it simply calls
      * the main method with the same format for both parameters.
      * 
-     * @param cell   a <code>short</code> representing the cell in the grid, expected to be in the same
-     *               format as <code>format</code>.
+     * @param cell   a {@code short} representing the cell in the grid, expected to be in the same
+     *               format as {@code format}.
      * @param format the {@link ValueFormat} of both the input and output cell, which can either be
      *               {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
-     * @return A <code>short[]</code> of adjacent cells in the specified format, containing up to 6
-     *         items.
+     * @return A {@code short[]} of adjacent cells in the specified format, containing up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
      * @see #findAdjacents(short)
@@ -898,12 +906,12 @@ public abstract class Grid {
     /**
      * Overload of {@link #findAdjacents(short, ValueFormat) findAdjacents()} that assumes that the
      * format is {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls
-     * the main method with <code>Index</code> for both parameters.
+     * the main method with {@code Index} for both parameters.
      * 
-     * @param cell a <code>short</code> representing the cell in the grid, expected to be in
+     * @param cell a {@code short} representing the cell in the grid, expected to be in
      *             {@link ValueFormat#Index Index} format.
-     * @return A <code>short[]</code> of adjacent cells in {@link ValueFormat#Index Index} format,
-     *         containing up to 6 items.
+     * @return A {@code short[]} of adjacent cells in {@link ValueFormat#Index Index} format, containing
+     *         up to 6 items.
      * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
      *                                  represent a single cell in that format.
      * @see #findAdjacents(short, ValueFormat)
@@ -921,38 +929,39 @@ public abstract class Grid {
     /**
      * Computes the conversion from {@link ValueFormat#PackedInt PackedInt} format to
      * {@link ValueFormat#Index Index} format. This method performs the necessary arithmetic to
-     * determine the correct index for a given packed int value.
+     * determine the correct {@code Index} for a given {@code PackedInt} value.
      * 
      * <h3>Algorithm Details</h3>
      * <p>
      * The conversion is based on the structure of the grid, which has rows of varying lengths. The
-     * first row has 16 columns, the second row has 15 columns, and this pattern continues to alternate.
-     * To convert a packed int value (which encodes the row and column) to an index value (which is a
-     * single integer representing the cell's position in a flattened array), we need to account for the
-     * varying row lengths.
+     * first row has {@value #EVEN_NUM_COLS} columns, the second row has {@value #ODD_NUM_COLS} columns,
+     * and this pattern continues to alternate. To convert a {@code PackedInt} value (which encodes the
+     * row and column) to an {@code Index} value (which is a single {@code short} representing the
+     * cell's position in a flattened array), we need to account for the varying row lengths.
      * </p>
      * 
      * <p>
-     * After obtaining the row and column from the packed int value, we use a {@link #ROW_OFFSETS
+     * After obtaining the row and column from the {@code PackedInt} value, we use a {@link #ROW_OFFSETS
      * pre-defined array of row offsets} to determine the starting index of the row in the flattened
      * array. We then add the column to this offset to get the final index.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be used by the static block of the Grid class to pre-compute a
-     * {@link #PACKED_TO_INDEX_CACHE cache} for fast lookups. While the method itself is O(1) in
-     * complexity, it is not intended to be called frequently during the program's execution. Instead,
-     * it serves as a utility for initializing the cache, which can then be used for O(1) lookups in
-     * performance-critical paths. The method does not perform any bounds checking on the input packed
-     * value, as it is assumed that the static block will only call it with valid values.
+     * This method is designed to be used by the {@code static} block of the {@code Grid} class to
+     * pre-compute a {@link #PACKED_TO_INDEX_CACHE cache} for fast lookups. While the method itself is
+     * {@code O(1)} in complexity, it is not intended to be called frequently during the program's
+     * execution. Instead, it serves as a utility for initializing the cache, which can then be used for
+     * {@code O(1)} lookups in performance-critical paths. The method does not perform any bounds
+     * checking on the input packed value, as it is assumed that the static block will only call it with
+     * valid values.
      * </p>
      * 
-     * @param packed the <code>short</code> representing the cell in {@link ValueFormat#PackedInt
-     *               PackedInt} format.
-     * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
+     * @param packed the {@code short} representing the cell in {@link ValueFormat#PackedInt PackedInt}
+     *               format.
+     * @return A {@code short} representing the cell in {@link ValueFormat#Index Index} format.
      * @throws ArrayIndexOutOfBoundsException (implicitly) if the input packed value is out of bounds
-     *                                   (less than 0 or greater than 615).
+     *                                        (less than 0 or greater than 615).
      * @since 2025.06 - PackedInt to Index Precomputation
      * @performance {@code O(1)} complexity due to direct arithmetic and a single array lookup.
      * @threading This method is thread-safe as it is a pure function.
@@ -978,19 +987,19 @@ public abstract class Grid {
      * </p>
      * 
      * <p>
-     * A potential area for optimization would be to explicitly compute the entire cache in the static
-     * block to avoid the need for on-the-fly calculations. Doing this would increase the startup time
-     * slightly, but would eliminate the need for any calculations during runtime, allowing us to remove
-     * the check for uncached values and make this method smaller, improving its chances of being
-     * inlined by the JVM. We've chosen not to do this for now, since conversions from the
-     * human-friendly <code>PackedInt</code> format to the memory efficient <code>Index</code> format
-     * are not a common operation in performance-critical paths (we try to use <code>Index</code>
-     * internally as much as possible), but the option remains open for the future.
+     * A potential area for optimization would be to explicitly compute the entire cache in the
+     * {@code static} block to avoid the need for on-the-fly calculations. Doing this would increase the
+     * startup time slightly, but would eliminate the need for any calculations during runtime, allowing
+     * us to remove the check for uncached values and make this method smaller, improving its chances of
+     * being inlined by the JVM. We've chosen not to do this for now, since conversions from the
+     * human-friendly {@code PackedInt} format to the memory efficient {@code Index} format are not a
+     * common operation in performance-critical paths (we try to use {@code Index} internally as much as
+     * possible), but the option remains open for the future.
      * </p>
      * 
-     * @param packed A <code>short</code> representing the cell in {@link ValueFormat#PackedInt
-     *               PackedInt} format.
-     * @return A <code>short</code> representing the cell in {@link ValueFormat#Index Index} format.
+     * @param packed A {@code short} representing the cell in {@link ValueFormat#PackedInt PackedInt}
+     *               format.
+     * @return A {@code short} representing the cell in {@link ValueFormat#Index Index} format.
      * @throws IllegalArgumentException if the input packed value is out of bounds (less than 0 or
      *                                  greater than 615).
      * @see #PACKED_TO_INDEX_CACHE
@@ -1017,11 +1026,12 @@ public abstract class Grid {
     /**
      * Converts a cell from {@link ValueFormat#Index Index} format to {@link ValueFormat#PackedInt
      * PackedInt} format. This method uses a series of conditional checks to determine the correct row
-     * and column for the given index.
+     * and column for the given {@code Index}.
      * 
      * <p>
-     * Note that this method does not explicitly check if the input index is greater than 0 for
-     * performance. Negative indices may return a value, but they are not valid packed int values.
+     * Note that this method does not explicitly check if the input {@code Index} is greater than
+     * {@code 0} for performance. Negative indices may return a value, but they are not valid packed int
+     * values.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -1033,10 +1043,8 @@ public abstract class Grid {
      * performance-critical paths, the added complexity and memory usage may not be worth it.
      * </p>
      * 
-     * @param index A <code>short</code> representing the cell in {@link ValueFormat#Index Index}
-     *              format.
-     * @return A <code>short</code> representing the cell in {@link ValueFormat#PackedInt PackedInt}
-     *         format.
+     * @param index A {@code short} representing the cell in {@link ValueFormat#Index Index} format.
+     * @return A {@code short} representing the cell in {@link ValueFormat#PackedInt PackedInt} format.
      * @throws IllegalArgumentException if the input index is out of bounds (less than 0 or greater than
      *                                  108).
      * @see #packedToIndex(short)
@@ -1059,7 +1067,7 @@ public abstract class Grid {
     }
 
     /**
-     * Constructs a new {@link Grid} instance and initializes it to a specific starting state by calling
+     * Constructs a new {@code Grid} instance and initializes it to a specific starting state by calling
      * the {@link #initialize()} method.
      * 
      * <p>
@@ -1069,7 +1077,7 @@ public abstract class Grid {
      * </p>
      * 
      * @see #initialize()
-     * @since 2025.03 - Abstract Grid Introduction
+     * @since 2025.03 - Abstract {@code Grid} Introduction
      * @threading The constructor is thread-safe as it operates on a new instance.
      */
     public Grid() {
@@ -1077,19 +1085,19 @@ public abstract class Grid {
     }
 
     /**
-     * Initializes the grid to a specific starting state. This method is abstract and must be implemented
-     * by subclasses to define their own initial configurations.
+     * Initializes the {@code Grid} to a specific starting state. This method is abstract and must be
+     * implemented by subclasses to define their own initial configurations.
      * 
      * <p>
-     * This method is called in the {@link #Grid() constructor} of the {@link Grid} class, ensuring that any subclass
-     * will have its grid state properly initialized upon instantiation. The specific implementation of
-     * this method will depend on the requirements of the subclass.
+     * This method is called in the {@link #Grid() constructor} of the {@link Grid} class, ensuring that
+     * any subclass will have its {@link #gridState grid state} properly initialized upon instantiation.
+     * The specific implementation of this method will depend on the requirements of the subclass.
      * </p>
      * 
      * @see Grid13
      * @see Grid22
      * @see Grid35
-     * @since 2025.03 - Abstract Grid Introduction
+     * @since 2025.03 - Abstract {@code Grid} Introduction
      * @threading Not thread-safe. This method modifies the instance's state.
      */
     abstract void initialize();
@@ -1098,18 +1106,20 @@ public abstract class Grid {
 
     /**
      * Sets the bit at the specified index in the {@link #gridState grid state}. We assume that the
-     * index is in {@link ValueFormat#Index Index} format (0-108) to save time on format checks.
+     * index is in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}) to save time on format
+     * checks.
      * 
      * <p>
-     * While this method can be used to toggle a cell in the grid, we pre-compute {@link #ADJACENCY_MASKS 
-     * adjacency masks} for each cell to perform clicks more efficiently. As such, this method is not 
-     * used in any method of the codebase.
+     * While this method can be used to toggle a cell in the grid, we pre-compute
+     * {@link #ADJACENCY_MASKS adjacency masks} for each cell to perform clicks more efficiently. As
+     * such, this method is not used in any method of the codebase.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * For performance reasons, this method does not perform bounds checking on the index. It is the
-     * caller's responsibility to ensure that the index is within the valid range (0-108).
+     * caller's responsibility to ensure that the index is within the valid range
+     * ({@code 0}-{@code 108}).
      * </p>
      * <p>
      * This method checks internally if the bit is already set before setting it, but this move is not
@@ -1117,11 +1127,11 @@ public abstract class Grid {
      * method for any performance-critical paths.
      * </p>
      * 
-     * @param index The index of the bit to set (0-108).
-     * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
+     * @param index The index of the bit to set ({@code 0}-{@code 108}).
+     * @throws IndexOutOfBoundsException if the index is out of bounds ({@code 0}-{@code 127}).
      * @see #clearBit(int)
      * @see #getBit(int)
-     * @since 2025.07 - Bitmasked Grid State
+     * @since 2025.07 - Bitmasked {@code Grid} State
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
      * @optimization This is a low-level helper. For performance reasons, it does not perform bounds
@@ -1138,7 +1148,8 @@ public abstract class Grid {
 
     /**
      * Clears the bit at the specified index in the {@link #gridState grid state}. We assume that the
-     * index is in {@link ValueFormat#Index Index} format (0-108) to save time on format checks.
+     * index is in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}) to save time on format
+     * checks.
      * 
      * <p>
      * While this method can be used to clear a cell in the grid, we pre-compute {@link #ADJACENCY_MASKS
@@ -1149,14 +1160,15 @@ public abstract class Grid {
      * <h3>Performance Considerations</h3>
      * <p>
      * For performance reasons, this method does not perform bounds checking on the index. It is the
-     * caller's responsibility to ensure that the index is within the valid range (0-108).
+     * caller's responsibility to ensure that the index is within the valid range
+     * ({@code 0}-{@code 108}).
      * </p>
      * 
-     * @param index The index of the bit to clear (0-108).
+     * @param index The index of the bit to clear ({@code 0}-{@code 108}).
      * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
      * @see #getBit(int)
      * @see #setBit(int)
-     * @since 2025.07 - Bitmasked Grid State
+     * @since 2025.07 - Bitmasked {@code Grid} State
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
      * @optimization Low-level helper. The caller is responsible for providing a valid index.
@@ -1173,27 +1185,29 @@ public abstract class Grid {
 
     /**
      * Extracts the bit at the specified index from the {@link #gridState grid state}. We assume that
-     * the index is in {@link ValueFormat#Index Index} format (0-108) to save time on format checks.
+     * the index is in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}) to save time on
+     * format checks.
      * 
      * <p>
-     * This method is used to check if a specific cell in the grid is "true" (active) or "false"
-     * (inactive). We internally use this method for finding true cells in the grid, which is crucial
-     * for {@link #findTrueCells() outputting a list of true cells} or {@link #printGrid() printing the
-     * grid state.}
+     * This method is used to check if a specific cell in the grid is {@code true} (active) or
+     * {@code false} (inactive). We internally use this method for finding {@code true} cells in the
+     * grid, which is crucial for {@link #findTrueCells() outputting a list of true cells} or
+     * {@link #printGrid() printing the grid state.}
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * For performance reasons, this method does not perform bounds checking on the index. It is the
-     * caller's responsibility to ensure that the index is within the valid range (0-108).
+     * caller's responsibility to ensure that the index is within the valid range
+     * ({@code 0}-{@code 108}).
      * </p>
      * 
-     * @param index The index of the bit to check (0-108).
+     * @param index The index of the bit to check ({@code 0}-{@code 108}).
      * @return true if the bit is set, false otherwise.
      * @throws IndexOutOfBoundsException if the index is out of bounds (0-127).
      * @see #clearBit(int)
      * @see #setBit(int)
-     * @since 2025.07 - Bitmasked Grid State
+     * @since 2025.07 - Bitmasked {@code Grid} State
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe, as it reads potentially mutable state.
      * @optimization Low-level helper. The caller is responsible for providing a valid index.
@@ -1205,60 +1219,62 @@ public abstract class Grid {
     }
 
     /**
-     * Scans the {@link #gridState grid bitmask} and returns an array of all true cells. Converts the
-     * result to the requested format ({@link ValueFormat#Index} or {@link ValueFormat#PackedInt}).
+     * Scans the {@link #gridState grid bitmask} and returns an array of all {@code true} cells.
+     * Converts the result to the requested format ({@link ValueFormat#Index} or
+     * {@link ValueFormat#PackedInt}).
      * 
      * <p>
      * For {@link CombinationGeneratorTask generator} and {@link TestClickCombination monkey}
      * efficiency, we perform several checks to prune combinations early. Many of these checks involve
-     * the initial state of the grid, so we need a way to conveniently extract the true bits from the
-     * bitmask and return them in a format that can be used for processing. This method provides that
-     * functionality, allowing for the efficient scanning of the grid state.
+     * the initial state of the grid, so we need a way to conveniently extract the {@code true} bits
+     * from the bitmask and return them in a format that can be used for processing. This method
+     * provides that functionality, allowing for the efficient scanning of the grid state.
      * </p>
      * 
      * <h3>Algorithm Details</h3>
      * <p>
      * We use the {@link #getBit(int index)} method to check each bit in the grid state, iterating
      * across the values in the range 0-108 (inclusive). For each bit that is set, we add its index to
-     * an array that is pre-sized to the number of true cells in the grid. To avoid scanning the entire
-     * grid after finding the requisite number of true cells, we use a counter to track the index in the
-     * array and exit the for loop early when the array is full.
+     * an array that is pre-sized to the number of {@code true} cells in the grid. To avoid scanning the
+     * entire grid after finding the requisite number of {@code true} cells, we use a counter to track
+     * the index in the array and exit the for loop early when the array is full.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * This method isn't expected to be called frequently, as it is primarily used for obtaining the
      * initial grid state. For this reason, we avoid {@link #recalculationNeeded checking for
-     * recalculation} or {@link #getTrueCount() recalculating the true cells count}, assuming the true
-     * count is correctly maintained by the {@link #setBit(int index)} and {@link #clearBit(int index)}
-     * methods. This avoids overhead, though it does allow for the possibility of an incorrectly sized
-     * array or missing true cells. A future update could target this.
+     * recalculation} or {@link #getTrueCount() recalculating the true cells count}, assuming the
+     * {@code true} count is correctly maintained by the {@link #setBit(int index)} and
+     * {@link #clearBit(int index)} methods. This avoids overhead, though it does allow for the
+     * possibility of an incorrectly sized array or missing {@code true} cells. A future update could
+     * target this.
      * </p>
      * 
      * <p>
-     * Another area for potential optimization is in the extraction of true cells. We could create two
-     * temporary longs to store the grid state, use the {@link Long#numberOfTrailingZeros(long)} method
-     * to find the first 1 in our bitmask, add the index to the array and turn off the bit (by ANDing
-     * with 0) and repeat until we have found all true cells. This would allow us to avoid the overhead
-     * of iterating over the entire grid state, but it would require additional complexity in the code
-     * that is unneeded at the moment.
+     * Another area for potential optimization is in the extraction of {@code true} cells. We could
+     * create two temporary {@code long}s to store the grid state, use the
+     * {@link Long#numberOfTrailingZeros(long)} method to find the first 1 in our bitmask, add the index
+     * to the array and turn off the bit (by ANDing with 0) and repeat until we have found all true
+     * cells. This would allow us to avoid the overhead of iterating over the entire grid state, but it
+     * would require additional complexity in the code that is unneeded at the moment.
      * </p>
      * 
-     * @param format The desired output format (Index or PackedInt).
-     * @return An array of true cells in the specified format.
-     * @throws IllegalArgumentException if the format is Bitmask, (since that would just be the Grid
-     *                                  itself). Use {@link #getGridState()} instead to fulfill that
-     *                                  purpose.
+     * @param format the desired output format (Index or PackedInt).
+     * @return a {@code short[]} of {@code true} cells in the specified format.
+     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask}, (since
+     *                                  that would just be the Grid itself). Use {@link #getGridState()}
+     *                                  instead to fulfill that purpose.
      * @see #findFirstTrueCell(ValueFormat)
      * @see #findTrueCells()
      * @since 2025.07 - Format Support
-     * @performance {@code O(N)} where N is the {@link #NUM_CELLS}. A more optimized version could use
+     * @performance <code>O({@value #NUM_CELLS})</code>. A more optimized version could use
      *              {@link Long#numberOfTrailingZeros(long)} to find set bits directly, but this method
      *              is not on a critical performance path.
      * @threading Not thread-safe, as it reads the mutable {@link #gridState}.
      * @memory Allocates a new {@code short[]} for the results.
-     * @optimization Creates a perfectly sized array based on the cached {@link #trueCellsCount} to avoid
-     *               resizing. It also stops iterating as soon as all true cells have been found.
+     * @optimization Creates a perfectly sized array based on the cached {@link #trueCellsCount} to
+     *               avoid resizing. Stops iterating as soon as all {@code true} cells have been found.
      */
     public short[] findTrueCells(ValueFormat format) {
         short[] trueCellsArray = new short[trueCellsCount];
@@ -1292,20 +1308,20 @@ public abstract class Grid {
     }
 
     /**
-     * Scans the {@link #gridState grid bitmask} and returns an array of all true cells in
-     * {@link ValueFormat#Index} format (0-108).
+     * Scans the {@link #gridState grid bitmask} and returns an array of all {@code true} cells in
+     * {@link ValueFormat#Index Index} format (0-108).
      * 
      * <p>
      * This method is a convenience overload of {@link #findTrueCells(ValueFormat format)} that defaults
-     * to the Index format, allowing for better inlining and performance if this method is on the hot
-     * path.
+     * to the {@code Index} format, allowing for better inlining and performance if this method is on
+     * the hot path.
      * </p>
      * 
-     * @return An array of true cells in the specified format.
+     * @return An array of {@code true} cells in the specified format.
      * @see #findFirstTrueCell(ValueFormat)
      * @see #findTrueCells(ValueFormat)
      * @since 2025.04 - Adjacency Optimizations
-     * @performance {@code O(N)} where N is the {@link #NUM_CELLS}.
+     * @performance <code>O({@value #NUM_CELLS})</code>.
      * @threading Not thread-safe.
      * @memory Allocates a new {@code short[]} for the results.
      * @optimization A {@code final} convenience overload that defaults to the most common format.
@@ -1324,47 +1340,50 @@ public abstract class Grid {
     }
 
     /**
-     * Scans the {@link #gridState grid} and returns the first true cell. Converts the result to the
-     * requested format ({@link ValueFormat#Index} or {@link ValueFormat#PackedInt}). If no true cell is
-     * found, returns -1.
+     * Scans the {@link #gridState grid} and returns the first {@code true} cell. Converts the result to
+     * the requested format ({@link ValueFormat#Index} or {@link ValueFormat#PackedInt}). If no
+     * {@code true} cell is found, returns -1.
      * 
      * <p>
-     * Since <code>click</code>s are limited in scope to the adjacents of one cell, we can derive an
-     * important property of the solution: It must toggle the first true cell in the initial grid state.
-     * We can therefore optimize the search for the solution by pruning combinations that violate this
-     * condition, making it important to have a fast way to find the first true cell in the grid. While
-     * one could use the <code>findTrueCells()</code> method to find the first true cell, this method is
-     * optimized for that purpose.
+     * Since {@code click}s are limited in scope to the adjacents of one cell, we can derive an
+     * important property of the solution: It must toggle the first {@code true} cell in the initial
+     * grid state. We can therefore optimize the search for the solution by pruning combinations that
+     * violate this condition, making it important to have a fast way to find the first {@code true}
+     * cell in the grid. While one could use the {@code findTrueCells()} method to find the first
+     * {@code true} cell, this method is optimized for that purpose.
      * </p>
      * 
      * <h3>Algorithm Details</h3>
      * <p>
-     * Java contains a built-in method for finding the first set bit in a long, called
-     * {@link Long#numberOfTrailingZeros(long)}. We can use this method to grab the first true cell and
-     * update the {@link #firstTrueCell} field. We also update {@link #trueCellsCount} field with
-     * another method, {@link Long#bitCount(long)}, which counts the number of set bits in a long.
+     * Java contains a built-in method for finding the first set bit in a {@code long}, called
+     * {@link Long#numberOfTrailingZeros(long)}. We can use this method to grab the first {@code true}
+     * cell and update the {@link #firstTrueCell} field. We also update {@link #trueCellsCount} field
+     * with another method, {@link Long#bitCount(long)}, which counts the number of set bits in a
+     * {@code long}.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * If no changes have been made to the grid state since the last call to this method, we'd want to
-     * save on recalculating the value of the first true cell and the count of true cells. We can do
-     * this by checking the {@link #recalculationNeeded recalculationNeeded} flag and updating the
-     * values if it is true. In the case where the flag is false and the count of true cells is 0, we
-     * can short-circuit the method to avoid unnecessary calculations, returning -1 immediately.
+     * save on recalculating the value of the first true cell and the count of {@code true} cells. We
+     * can do this by checking the {@link #recalculationNeeded recalculationNeeded} flag and updating
+     * the values if it is {@code true}. In the case where the flag is {@code false} and the count of
+     * true cells is {@code 0}, we can short-circuit the method to avoid unnecessary calculations,
+     * returning {@code -1} immediately.
      * </p>
      * 
      * <p>
-     * The methods used to find the first true cell and count the number of true cells are O(1) due to
-     * some clever programming on the Java developers' part. Reinventing the wheel would be a waste of
-     * time (and likely less efficient), so we avoid that effort.
+     * The methods used to find the first {@code true} cell and count the number of true cells are
+     * {@code O(1)} due to some clever programming on the Java developers' part. Reinventing the wheel
+     * would be a waste of time (and likely less efficient), so we avoid that effort.
      * </p>
      * 
-     * @param format The desired output format ({@link ValueFormat#Index Index} or
+     * @param format the desired output format ({@link ValueFormat#Index Index} or
      *               {@link ValueFormat#PackedInt PackedInt}).
-     * @return The first true cell in the specified format, or -1 if no true cell is found.
-     * @throws IllegalArgumentException if the format is Bitmask (since bitmasks aren't supported for
-     *                                  single values).
+     * @return the first {@code true} cell in the specified format, or -1 if no {@code true} cell is
+     *         found.
+     * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask} (since
+     *                                  bitmasks aren't supported for single values).
      * @see #click(short[])
      * @see #click(short, ValueFormat)
      * @see #findFirstTrueCell()
@@ -1373,7 +1392,7 @@ public abstract class Grid {
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe due to lazy evaluation of cached fields.
      * @algorithm Uses the highly optimized {@link Long#numberOfTrailingZeros(long)} and
-     *              {@link Long#bitCount(long)} intrinsics for recalculation.
+     *            {@link Long#bitCount(long)} intrinsics for recalculation.
      * @optimization Implements lazy recalculation. The cached {@link #firstTrueCell} and
      *               {@link #trueCellsCount} are only recomputed if the {@link #recalculationNeeded}
      *               flag is set.
@@ -1422,16 +1441,18 @@ public abstract class Grid {
     }
 
     /**
-     * Scans the {@link #gridState grid} and returns the first true cell in {@link ValueFormat#Index}
-     * format (0-108). If no true cell is found, returns -1.
+     * Scans the {@link #gridState grid} and returns the first {@code true} cell in
+     * {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}). If no {@code true} cell is found,
+     * returns -1.
      * 
      * <p>
      * This method is a convenience overload of {@link #findFirstTrueCell(ValueFormat format)} that
-     * defaults to the Index format, allowing for better inlining and performance if this method is on
-     * the hot path.
+     * defaults to the {@code Index} format, allowing for better inlining and performance if this method
+     * is on the hot path.
      * </p>
      * 
-     * @return The first true cell in Index format, or -1 if no true cell is found.
+     * @return The first {@code true} cell in {@code Index} format, or -1 if no {@code true} cell is
+     *         found.
      * @see #click(short[])
      * @see #click(short, ValueFormat)
      * @see #findFirstTrueCell(ValueFormat)
@@ -1471,9 +1492,9 @@ public abstract class Grid {
     }
 
     /**
-     * Simulates a click on the <code>Grid</code> at the specified cell, which can be in any of the
-     * supported {@link ValueFormat formats} ({@link ValueFormat#Index Index} or
-     * {@link ValueFormat#PackedInt PackedInt}).
+     * Simulates a click on the {@code Grid} at the specified cell, which can be in any of the supported
+     * {@link ValueFormat formats} ({@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt
+     * PackedInt}).
      * 
      * <p>
      * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
@@ -1482,24 +1503,24 @@ public abstract class Grid {
      * </p>
      * 
      * <p>
-     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to <code>true</code> ensures
-     * that the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will
-     * recalculate the {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of
-     * true cells}. This avoids unnecessary recalculations on every click, which is crucial for
-     * performance in high-frequency scenarios.
+     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to {@code true} ensures that
+     * the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will recalculate the
+     * {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of true cells}. This
+     * avoids unnecessary recalculations on every click, which is crucial for performance in
+     * high-frequency scenarios.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit <code>long</code>
-     * for the grid state, meaning that we have to use two <code>long</code>s, and thus two adjacency
-     * masks per cell. Though we could strategically use a single long as a bitmask if the adjacent
-     * cells are localized to the same long, we choose to use two longs for simplicity and to avoid
-     * branching.
+     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit {@code long} for
+     * the grid state, meaning that we have to use two {@code long}s, and thus two adjacency masks per
+     * cell. Though we could strategically use a single {@code long} as a bitmask if the adjacent cells
+     * are localized to the same {@code long}, we choose to use two{@code long}s for simplicity and to
+     * avoid branching.
      * </p>
      * 
      * @param cell   the cell to click, in the specified format.
-     * @param format the format of the cell (<code>Index</code> or <code>PackedInt</code>).
+     * @param format the format of the cell ({@code Index} or {@code PackedInt}).
      * @throws IllegalArgumentException       if the format is {@link ValueFormat#Bitmask Bitmask}
      *                                        (since bitmasks aren't supported for single values) or
      *                                        another unsupported format.
@@ -1511,8 +1532,8 @@ public abstract class Grid {
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
      * @optimization The core of this operation is two bitwise XORs against the pre-computed
-     *               {@link #ADJACENCY_MASKS}, which is extremely fast. It also lazily marks the state for
-     *               recalculation.
+     *               {@link #ADJACENCY_MASKS}, which is extremely fast. It also lazily marks the state
+     *               for recalculation.
      */
     public void click(short cell, ValueFormat format) {
         switch (format) 
@@ -1537,8 +1558,9 @@ public abstract class Grid {
     }
 
     /**
-     * Simulates a click on the <code>Grid</code> at the specified cell. We assume that the cell is in
-     * {@link ValueFormat#Index <code>Index</code>} format (0-108) to save time on format checks.
+     * Simulates a click on the {@code Grid} at the specified cell. We assume that the cell is in
+     * {@link ValueFormat#Index {@code Index}} format ({@code 0}-{@code 108}) to save time on format
+     * checks.
      * 
      * <p>
      * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
@@ -1547,23 +1569,23 @@ public abstract class Grid {
      * </p>
      * 
      * <p>
-     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to <code>true</code> ensures
-     * that the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will
-     * recalculate the {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of
-     * true cells}. This avoids unnecessary recalculations on every click, which is crucial for
-     * performance in high-frequency scenarios.
+     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to {@code true} ensures that
+     * the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will recalculate the
+     * {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of true cells}. This
+     * avoids unnecessary recalculations on every click, which is crucial for performance in
+     * high-frequency scenarios.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit <code>long</code>
-     * for the grid state, meaning that we have to use two <code>long</code>s, and thus two adjacency
-     * masks per cell. Though we could strategically use a single long as a bitmask if the adjacent
-     * cells are localized to the same long, we choose to use two longs for simplicity and to avoid
-     * branching.
+     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit {@code long} for
+     * the grid state, meaning that we have to use two {@code long}s, and thus two adjacency masks per
+     * cell. Though we could strategically use a single {@code long} as a bitmask if the adjacent cells
+     * are localized to the same {@code long}, we choose to use two{@code long}s for simplicity and to
+     * avoid branching.
      * </p>
      * 
-     * @param cell The cell to click, in Index format (0-108).
+     * @param cell The cell to click, in {@link ValueFormat#Index Index} format ({@code 0}-{@code 108}).
      * @throws ArrayIndexOutOfBoundsException if the cell is out of bounds (implicitly checked by the
      *                                        array accesses).
      * @see #areAdjacent(short, short, ValueFormat)
@@ -1589,8 +1611,8 @@ public abstract class Grid {
     }
 
     /**
-     * Specialized click method for the {@link ValueFormat#PackedInt PackedInt} format. Made final to
-     * encourage inlining.
+     * Specialized click method for the {@link ValueFormat#PackedInt PackedInt} format. Made
+     * {@code final} to encourage inlining.
      * 
      * @param row The row of the cell to click.
      * @param col The column of the cell to click.
@@ -1600,8 +1622,8 @@ public abstract class Grid {
      * @since 2025.03 - Initial Creation
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization A {@code final} convenience overload that handles {@link ValueFormat#PackedInt} conversion
-     *               before performing the click. Designed to be inlined.
+     * @optimization A {@code final} convenience overload that handles {@link ValueFormat#PackedInt}
+     *               conversion before performing the click. Designed to be inlined.
      */
     public final void click(short row, short col) {
         // Convert packed int to index format first
@@ -1619,22 +1641,24 @@ public abstract class Grid {
      * Specialized click method for the {@link ValueFormat#Bitmask Bitmask} format.
      * 
      * <p>
-     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
-     * by XORing the {@link #gridState grid state} with the provided bitmask.
+     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click by
+     * XORing the {@link #gridState grid state} with the provided bitmask.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is built for scenarios where the caller has pre-computed the adjacency bitmask for a cell
-     * and wants to apply it directly, avoiding the overhead of format conversions or lookups. While our code
-     * does not currently leverage this method, it is provided for completeness and potential future use cases.
+     * This method is built for scenarios where the caller has pre-computed the adjacency bitmask for a
+     * cell and wants to apply it directly, avoiding the overhead of format conversions or lookups.
+     * While our code does not currently leverage this method, it is provided for completeness and
+     * potential future use cases.
      * </p>
      * 
      * <p>
-     * To optimize performance further, we could make the method final to encourage inlining, but we leave it as-is for now
-     * to allow for potential overrides in subclasses.
+     * To optimize performance further, we could make the method {@code final} to encourage inlining,
+     * but we leave it as-is for now to allow for potential overrides in subclasses.
      * </p>
-     * @param bitmask The bitmask representing the adjacents to toggle, as a long array of length 2.
+     * 
+     * @param bitmask The bitmask representing the adjacents to toggle, as a {@code long[]} of length 2.
      * @throws IllegalArgumentException if the bitmask is not of length 2.
      * @see #click(short)
      * @see #click(short, ValueFormat)
@@ -1655,9 +1679,9 @@ public abstract class Grid {
     }
 
     /**
-     * Simulates a click on multiple cells in the <code>Grid</code>. We assume that the cells are in the
-     * {@link ValueFormat#Index <code>Index</code>} format (0-108) and the array is non-null to save on
-     * format checks.
+     * Simulates a click on multiple cells in the {@code Grid}. We assume that the cells are in the
+     * {@link ValueFormat#Index {@code Index}} format ({@code 0}-{@code 108}) and the array is
+     * non-{@code null} to save on format checks.
      * 
      * <p>
      * A click simply toggles the state of its adjacent cells (excluding itself), so we can perform a
@@ -1668,20 +1692,20 @@ public abstract class Grid {
      * </p>
      * 
      * <p>
-     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to <code>true</code> ensures
-     * that the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will
-     * recalculate the {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of
-     * true cells}. This avoids unnecessary recalculations on every click, which is crucial for
-     * performance in high-frequency scenarios.
+     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to {@code true} ensures that
+     * the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will recalculate the
+     * {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of true cells}. This
+     * avoids unnecessary recalculations on every click, which is crucial for performance in
+     * high-frequency scenarios.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit <code>long</code>
-     * for the grid state, meaning that we have to use two <code>long</code>s, and thus two adjacency
-     * masks per cell. Though we could strategically use a single long as a bitmask if the adjacent
-     * cells are localized to the same long, we choose to use two longs for simplicity and to avoid
-     * branching.
+     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit {@code long} for
+     * the grid state, meaning that we have to use two {@code long}s, and thus two adjacency masks per
+     * cell. Though we could strategically use a single {@code long} as a bitmask if the adjacent cells
+     * are localized to the same {@code long}, we choose to use two {@code long}s for simplicity and to
+     * avoid branching.
      * </p>
      * <p>
      * We avoid unrolling the loop here, since the JVM can handle that for us and it would deliver
@@ -1689,19 +1713,18 @@ public abstract class Grid {
      * array accesses in a non-predictable manner.
      * </p>
      * 
-     * @param cells The array of cells to click, in Index format (0-108).
+     * @param cells The array of cells to click, in Index format ({@code 0}-{@code 108}).
      * @throws IllegalArgumentException if the clicks are out of bounds (implicitly checked by the array
      *                                  accesses).
-     * @throws NullPointerException     if the cells array is null (implicitly thrown by the for-each
+     * @throws NullPointerException     if the cells array is {@code null} (implicitly thrown by the for-each
      *                                  loop).
      * @see #areAdjacent(short, short, ValueFormat)
      * @see #computeAdjacents(short, ValueFormat, ValueFormat)
      * @since 2025.07 - Bulk Clicks
-     * @performance {@code O(N)} where N is the number of cells in the input array. This is a hot-path
-     *              method for worker threads.
+     * @performance {@code O(cells.length)}. This is a hot-path method for worker threads.
      * @threading Not thread-safe. Modifies the instance's {@link #gridState}.
-     * @optimization This method is the primary replacement for single-cell clicks. It processes an array
-     *               of clicks in a tight loop. It is {@code final} to encourage JIT inlining and
+     * @optimization This method is the primary replacement for single-cell clicks. It processes an
+     *               array of clicks in a tight loop. It is {@code final} to encourage JIT inlining and
      *               assumes valid input to avoid branching and checks inside the loop.
      */
     public final void click(short[] cells) {
@@ -1717,53 +1740,54 @@ public abstract class Grid {
 
     /**
      * Returns an array of adjacents of the {@link #findFirstTrueCell() first true cell} in the
-     * requested {@link ValueFormat format}. If no true cell exists, returns <code>null</code>.
+     * requested {@link ValueFormat format}. If no {@code true} cell exists, returns {@code null}.
      * 
      * <p>
      * Since clicks are limited in scope to the adjacents of one cell (excluding itself), we can derive
      * an important property of the solution: It must contain at least one click on the adjacents of the
-     * first true cell in the initial grid state. This may seem obvious, but it allows us to establish
-     * bounds for generation, limiting the maximum cell that needs to be considered for the first click
-     * to the last adjacent of the first true cell. This method gives us an easy way to extract and test
-     * those adjacents.
+     * first {@code true} cell in the initial grid state. This may seem obvious, but it allows us to
+     * establish bounds for generation, limiting the maximum cell that needs to be considered for the
+     * first click to the last adjacent of the first {@code true} cell. This method gives us an easy way
+     * to extract and test those adjacents.
      * </p>
      * 
      * <p>
      * As a note, we currently prevent the use of {@link ValueFormat#Bitmask Bitmask} formats here,
      * since bitmasks aren't well-suited for representing small sets of values. If we were to support
-     * them, we would either need to create a <code>long[]</code> of length 2 (to match the internal
-     * grid size) or a <code>short[]</code> with a length of 7 to cover 116 bits (the closest multiple
-     * of 16 above 109). The former would likely require a new method due to the incompatible return
-     * type (unless we made the return type <code>Object</code>, which would be messy), while the latter
-     * would waste space and require additional conversions. Given the limited utility of bitmasks in
-     * this context, we opt to exclude them for now.
+     * them, we would either need to create a {@code long[]} of length 2 (to match the internal grid
+     * size) or a {@code short[]} with a length of 7 to cover 116 bits (the closest multiple of 16 above
+     * 109). The former would likely require a new method due to the incompatible return type (unless we
+     * made the return type {@code Object}, which would be messy), while the latter would waste space
+     * and require additional conversions. Given the limited utility of bitmasks in this context, we opt
+     * to exclude them for now.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is designed to be efficient, performing a simple lookup of the first true cell and
-     * then retrieving its adjacents. The operation is O(1) due to the fixed size of the adjacency list
-     * (up to 6 elements).
+     * This method is designed to be efficient, performing a simple lookup of the first {@code true}
+     * cell and then retrieving its adjacents. The operation is {@code O(1)} due to the fixed size of
+     * the adjacency list (up to 6 elements).
      * </p>
      * 
      * <p>
      * To optimize performance further, we could consider caching the result of the operation if the
      * state has not changed since the last call, but given the simplicity of the operation and the
-     * small size of the adjacency list, the current implementation is sufficient. If the first true
-     * cell were to change, we would need to invalidate the cache anyway, requiring an allocation of a
-     * new array; we would also need to clone the array before returning it to avoid external
-     * modifications, which would negate the performance benefits of caching in the first place.
+     * small size of the adjacency list, the current implementation is sufficient. If the first
+     * {@code true} cell were to change, we would need to invalidate the cache anyway, requiring an
+     * allocation of a new array; we would also need to clone the array before returning it to avoid
+     * external modifications, which would negate the performance benefits of caching in the first
+     * place.
      * </p>
      * 
      * @param format The desired output format ({@link ValueFormat#Index Index} or
      *               {@link ValueFormat#PackedInt PackedInt}).
-     * @return An array of adjacent cells in the requested format, or <code>null</code> if no true cell
-     *         exists.
+     * @return A {@code short[]} of adjacent cells in the requested format, or {@code null} if no true
+     *         cell exists.
      * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask}.
      * @see #findAdjacents(short, ValueFormat)
      * @since 2025.04 - First True Adjacents Method Creation
-     * @performance {@code O(1)} for {@link ValueFormat#Index}, {@code O(k)} for others, where {@code k} is the
-     *              number of adjacent cells (max 6).
+     * @performance {@code O(1)} for {@link ValueFormat#Index},
+     *              <code>O({@link #adjacencyArray}[cell].length)</code> for others.
      * @threading Not thread-safe, as it depends on the result of non-thread-safe methods.
      * @memory Allocates a new {@code short[]} for the result.
      * @optimization Leverages the lazy evaluation of {@link #findFirstTrueCell()} and the pre-computed
@@ -1786,10 +1810,10 @@ public abstract class Grid {
     /**
      * Overload of {@link #findFirstTrueAdjacents(ValueFormat)} that assumes the output format is
      * {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls the main
-     * method with the <code>Index</code> format.
+     * method with the {@code Index} format.
      * 
-     * @return An array of adjacent cells in {@link ValueFormat#Index Index} format, or
-     *         <code>null</code> if no true cell exists.
+     * @return A {@code short[]} of adjacent cells in {@link ValueFormat#Index Index} format, or
+     *         {@code null} if no {@code true} cell exists.
      * @since 2025.07 - Format Support
      * @performance {@code O(1)} complexity.
      * @threading Not thread-safe.
@@ -1802,27 +1826,27 @@ public abstract class Grid {
 
     /**
      * Returns an array of adjacents of the {@link #findFirstTrueCell() first true cell} that come after
-     * the specified cell, in the requested {@link ValueFormat format}. If no true cell exists, or if no
-     * true adjacents after the specified cell exist, returns <code>null</code>.
+     * the specified cell, in the requested {@link ValueFormat format}. If no {@code true} cell exists,
+     * or if no {@code true} adjacents after the specified cell exist, returns {@code null}.
      * 
      * <p>
      * Since clicks are limited in scope to the adjacents of one cell (excluding itself), we can derive
      * an important property of the solution: It must contain at least one click on the adjacents of the
-     * first true cell in the initial grid state. This may seem obvious, but it allows us to establish
-     * bounds for generation, limiting the maximum cell that needs to be considered for the first click
-     * to the last adjacent of the first true cell. This method gives us an easy way to extract and test
-     * those adjacents.
+     * first {@code true} cell in the initial grid state. This may seem obvious, but it allows us to
+     * establish bounds for generation, limiting the maximum cell that needs to be considered for the
+     * first click to the last adjacent of the first {@code true} cell. This method gives us an easy way
+     * to extract and test those adjacents.
      * </p>
      * 
      * <h3>Algorithm Details</h3>
      * <p>
      * We first {@link #findFirstTrueAdjacents(ValueFormat) find the adjacents of the first true cell}
-     * in the specified input format. If no true cell exists, we return <code>null</code>. We then
+     * in the specified input format. If no {@code true} cell exists, we return {@code null}. We then
      * convert the input cell to {@link ValueFormat#Index index} format if necessary, using the
      * {@link #packedToIndex(short)} method for {@link ValueFormat#PackedInt packed int} format. We then
      * perform a binary search on the array of adjacents to find the first adjacent cell that is greater
-     * than the specified cell. If no such adjacent exists, we return <code>null</code>. If we find such
-     * an adjacent, we create a new array containing all adjacents from that point onward. Finally, we
+     * than the specified cell. If no such adjacent exists, we return {@code null}. If we find such an
+     * adjacent, we create a new array containing all adjacents from that point onward. Finally, we
      * convert the result to the desired output format if necessary and return it.
      * </p>
      * 
@@ -1841,22 +1865,21 @@ public abstract class Grid {
      * @param outputFormat the {@link ValueFormat format} of the output array ({@link ValueFormat#Index
      *                     Index} or {@link ValueFormat#PackedInt PackedInt}).
      * @return An array of adjacent cells after the specified cell, in the requested output format, or
-     *         <code>null</code> if no true cell exists or if no adjacents after the specified cell
-     *         exist.
+     *         {@code null} if no true cell exists or if no adjacents after the specified cell exist.
      * @throws IllegalArgumentException if either format is {@link ValueFormat#Bitmask Bitmask} (since
      *                                  bitmasks aren't supported for single values) or anything else.
      * @see #findAdjacents(short)
      * @see #findFirstTrueAdjacents(ValueFormat)
      * @see #findFirstTrueCell()
      * @since 2025.07 - Format Support
-     * @performance {@code O(log k + m)} where {@code k} is the number of adjacents (max 6) and {@code m} is
+     * @performance <code>O(log({@link #adjacencyArray}[cell].length) + m)}</code> where {@code m} is
      *              the number of remaining adjacents to copy. Effectively constant time.
      * @threading Not thread-safe.
-     * @algorithm Performs a binary search on the sorted adjacency list of the first true cell to find
-     *            the subset of neighbors that appear after the given cell.
+     * @algorithm Performs a binary search on the sorted adjacency list of the first {@code true} cell
+     *            to find the subset of neighbors that appear after the given cell.
      * @memory Allocates a new {@code short[]} for the result.
-     * @optimization A specialized method for the generator to efficiently prune the search space by only
-     *               considering relevant subsequent clicks.
+     * @optimization A specialized method for the generator to efficiently prune the search space by
+     *               only considering relevant subsequent clicks.
      */
     public short[] findFirstTrueAdjacentsAfter(short cell, ValueFormat inputFormat, ValueFormat outputFormat) {
         short[] firstTrueAdjacents = findFirstTrueAdjacents(inputFormat);
@@ -1922,13 +1945,13 @@ public abstract class Grid {
     }
 
     /**
-     * Checks if the grid is completely solved (i.e., all cells are false). We use the
+     * Checks if the grid is completely solved (i.e., all cells are {@code false}). We use the
      * {@link #getTrueCount()} method to determine if there are any true cells remaining rather than
      * directly checking the {@link #gridState grid state} or the {@link #trueCellsCount true cells
      * count} to ensure that any necessary recalculations are performed before making the check while
      * avoiding code duplication.
      * 
-     * @return <code>true</code> if the grid is solved (no true cells), <code>false</code> otherwise.
+     * @return {@code true} if the grid is solved (no {@code true} cells), {@code false} otherwise.
      * @see #recalculationNeeded
      * @since 2025.03 - Initial Creation
      * @performance {@code O(1)} complexity.
@@ -1939,7 +1962,7 @@ public abstract class Grid {
     }
 
     /**
-     * Returns the count of true cells in the grid. If the grid state has changed since the last
+     * Returns the count of {@code true} cells in the grid. If the grid state has changed since the last
      * calculation, it recalculates the count using {@link Long#bitCount(long) bitwise operations}.
      * 
      * @return the number of true cells in the grid.
@@ -1959,7 +1982,7 @@ public abstract class Grid {
     }
 
     /**
-     * Creates and returns a deep copy of this <code>Grid</code> instance.
+     * Creates and returns a deep copy of this {@code Grid} instance.
      * 
      * <p>
      * The cloned instance has its own copy of the grid state, ensuring that modifications to
@@ -1968,7 +1991,7 @@ public abstract class Grid {
      * needing to create overrides for each subclass.
      * </p>
      * 
-     * @return A deep copy of this <code>Grid</code> instance.
+     * @return A deep copy of this {@code Grid} instance.
      * @throws RuntimeException if the cloning process fails due to reflection issues.
      * @see #firstTrueCell
      * @see #gridState
@@ -1997,32 +2020,36 @@ public abstract class Grid {
     }
 
     /**
-     * Determines if a click on a specified cell can affect or create a new first true cell in the grid.
+     * Determines if a click on a specified cell can affect or create a new first {@code true} cell in
+     * the grid.
      * 
      * <p>
-     * Since the solution must toggle the first true cell in the initial grid state, we can optimize our
-     * search for the solution by pruning combinations whose first click cannot affect or create a new
-     * first true cell. This method provides the logic to determine that.
+     * Since the solution must toggle the first {@code true} cell in the initial grid state, we can
+     * optimize our search for the solution by pruning combinations whose first click cannot affect or
+     * create a new first {@code true} cell. This method provides the logic to determine that.
      * </p>
      * 
      * <p>
      * There are several scenarios that this program considers:
      * <ul>
-     * <li>If there are no true cells, any click can create one. In the context of our solver, we
-     * shouldn't see this case happen too often, but it's included for short-circuiting purposes.</li>
-     * <li>If the first true cell is the top-left cell (0,0), only its adjacents can affect it.</li>
-     * <li>If the click is before or equal to the first true cell, it can create a new one.</li>
-     * <li>If the click is adjacent to the first true cell, it can affect it.</li>
+     * <li>If there are no {@code true} cells, any click can create one. In the context of our solver,
+     * we shouldn't see this case happen too often, but it's included for short-circuiting
+     * purposes.</li>
+     * <li>If the first {@code true} cell is the top-left cell (0,0), only its adjacents can affect
+     * it.</li>
+     * <li>If the click is before or equal to the first {@code true} cell, it can create a new one.</li>
+     * <li>If the click is adjacent to the first {@code true} cell, it can affect it.</li>
      * </ul>
-     * If none of these conditions are met, the click cannot affect or create a new first true cell.
+     * If none of these conditions are met, the click cannot affect or create a new first {@code true}
+     * cell.
      * </p>
      * 
-     * @param firstTrueCell the first true cell in the specified format.
+     * @param firstTrueCell the first {@code true} cell in the specified format.
      * @param clickCell     the cell to be clicked, in the specified format.
      * @param format        the {@link ValueFormat format} of both cells ({@link ValueFormat#Index
      *                      Index} or {@link ValueFormat#PackedInt PackedInt}).
-     * @return <code>true</code> if the click can affect or create a new first true cell,
-     *         <code>false</code> otherwise.
+     * @return {@code true} if the click can affect or create a new first {@code true} cell,
+     *         {@code false} otherwise.
      * @throws IllegalArgumentException if the format is {@link ValueFormat#Bitmask Bitmask} (since
      *                                  bitmasks aren't supported for single values) or another
      *                                  unsupported format.
@@ -2030,11 +2057,11 @@ public abstract class Grid {
      * @see #findAdjacents(short, ValueFormat)
      * @see #findFirstTrueCell(ValueFormat)
      * @since 2025.07 - Format and Adjacency Optimizations
-     * @performance {@code O(log k)} where k is the number of adjacent cells (max 6). Effectively constant
-     *              time.
+     * @performance <code>O(log({@link #adjacencyArray}[firstTrueCell].length))</code>. Effectively
+     *              constant time.
      * @threading This method is thread-safe as it is a pure function.
-     * @optimization A specialized pruning helper for the generator. Uses an efficient binary search on the
-     *               pre-sorted adjacency list.
+     * @optimization A specialized pruning helper for the generator. Uses an efficient binary search on
+     *               the pre-sorted adjacency list.
      */
     public static boolean canAffectFirstTrueCell(short firstTrueCell, short clickCell, ValueFormat format) {
         if (firstTrueCell == -1) return true; // No true cells, any click can create one
@@ -2105,30 +2132,30 @@ public abstract class Grid {
 
     /**
      * Determines if two cells are adjacent to each other in the grid. Leverages the pre-computed
-     * {@link #ADJACENCY_CACHE adjacency cache} for O(1) lookups.
+     * {@link #ADJACENCY_CACHE adjacency cache} for {@code O(1)} lookups.
      * 
      * <p>
      * Two cells are considered adjacent if they share a common edge or vertex. In a hexagonal grid,
      * each cell can have up to 6 adjacent cells, depending on its position in the grid. Since clicks
      * only affect adjacent cells, we rely on adjacency calculations to optimize our search for the
      * solution to a state, factoring these calculations into much of our logic. Therefore, we need a
-     * public facing method to quickly determine adjacency between any two cells. This method fills that
-     * role.
+     * {@code public} facing method to quickly determine adjacency between any two cells. This method
+     * fills that role.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method performs O(1) lookups in a pre-computed adjacency cache, making it extremely fast.
-     * The overhead of converting between formats is likely larger than the lookup itself, so this
-     * method should be used judiciously in performance-critical paths compared to something like
-     * {@link #areAdjacent(short, short)}.
+     * This method performs {@code O(1)} lookups in a pre-computed adjacency cache, making it extremely
+     * fast. The overhead of converting between formats is likely larger than the lookup itself, so this
+     * method should be used judiciously in performance-critical paths, or redesigned to assume a single
+     * format if necessary.
      * </p>
      * 
      * @param cellA  the first cell to check, in the specified format.
      * @param cellB  the second cell to check, in the specified format.
      * @param format the {@link ValueFormat format} of both cells ({@link ValueFormat#Index Index} or
      *               {@link ValueFormat#PackedInt PackedInt}).
-     * @return <code>true</code> if the cells are adjacent, <code>false</code> otherwise.
+     * @return {@code true} if the cells are adjacent, {@code false} otherwise.
      * @throws IllegalArgumentException       if the format is {@link ValueFormat#Bitmask Bitmask}
      *                                        (since bitmasks aren't supported for single values) or
      *                                        another unsupported format.
@@ -2140,8 +2167,8 @@ public abstract class Grid {
      * @since 2025.07 - Index Format Usage
      * @performance {@code O(1)} complexity.
      * @threading Thread-safe, as it only reads from immutable static data.
-     * @optimization Directly uses the {@link #ADJACENCY_CACHE} for an instantaneous lookup after handling
-     *               any necessary format conversion.
+     * @optimization Directly uses the {@link #ADJACENCY_CACHE} for an instantaneous lookup after
+     *               handling any necessary format conversion.
      */
     public static boolean areAdjacent(short cellA, short cellB, ValueFormat format) {
         // Convert both cells to index format if necessary
@@ -2164,11 +2191,11 @@ public abstract class Grid {
     /**
      * Overload of {@link #areAdjacent(short, short, ValueFormat)} that assumes the input format is
      * {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls the main
-     * method with the <code>Index</code> format.
+     * method with the {@code Index} format.
      * 
      * @param cellA the first cell to check, in {@link ValueFormat#Index Index} format (0-108).
      * @param cellB the second cell to check, in {@link ValueFormat#Index Index} format (0-108).
-     * @return <code>true</code> if the cells are adjacent, <code>false</code> otherwise.
+     * @return {@code true} if the cells are adjacent, {@code false} otherwise.
      * @throws ArrayIndexOutOfBoundsException if either cell is out of bounds (implicitly checked by the
      *                                        array access).
      * @since 2025.06 - Odd Adjacency Pruning
@@ -2181,7 +2208,8 @@ public abstract class Grid {
     }
 
     /**
-     * Returns a copy of the current {@link #gridState grid state} as a bitmask (array of two longs).
+     * Returns a copy of the current {@link #gridState grid state} as a bitmask (array of two
+     * {@code long}s).
      * 
      * <p>
      * This method exists to provide direct access to the grid's internal state. While no current code
@@ -2190,12 +2218,12 @@ public abstract class Grid {
      * state.
      * </p>
      * 
-     * @return A copy of the current grid state as a bitmask (array of two longs).
+     * @return A copy of the current grid state as a bitmask (array of two {@code long}s).
      * @see #click(long[])
      * @see ValueFormat#Bitmask
      * @since 2025.07 - Bitmasked Grid State
      * @performance {@code O(1)} complexity.
-     * @threading This method is thread-safe because it returns a defensive copy of the state.
+     * @threading The output is thread-safe, since it is a copy of the internal state.
      * @memory Allocates a new {@code long[2]} array to prevent external modification of the instance's
      *         internal state.
      */
@@ -2205,8 +2233,8 @@ public abstract class Grid {
 
     /**
      * Prints the current grid state to the {@link LogManager#getLogger() logger} in a human-readable
-     * format, with '1' representing true cells and '0' representing false cells. Rows are indented to
-     * reflect the hexagonal layout, matching the format used in the PDC puzzle code.
+     * format, with '1' representing {@code true} cells and '0' representing {@code false} cells. Rows
+     * are indented to reflect the hexagonal layout, matching the format used in the PDC puzzle code.
      * 
      * @see #EVEN_NUM_COLS
      * @see #NUM_ROWS
@@ -2220,7 +2248,7 @@ public abstract class Grid {
      * @see org.apache.logging.log4j.Logger
      * @see org.apache.logging.log4j.LogManager
      * @since 2025.03 - Grid Printing Method Creation
-     * @performance {@code O(N)} where N is the number of cells. This is a debugging method and is not
+     * @performance <code>O({@value Grid#NUM_CELLS})</code>. This is a debugging method and is not
      *              performance-critical.
      * @threading Not thread-safe, as it iterates over the mutable grid state.
      * @memory Allocates a new {@link StringBuilder} for each row.

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -92,7 +92,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * avoiding synchronization and locks allows for faster operations in the hot path.
  * </p>
  * 
- * <h3>31/52 - ~59.6% of documentation completed</h3>
+ * <h3>44/52 - ~84.6% of documentation completed</h3>
  * 
  * @since 2025.03.20 - Initial creation
  * @performance Core operations like clicking a cell and checking for the solved state are designed
@@ -108,17 +108,153 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * @see TestClickCombination
  */
 public abstract class Grid {
-    public enum ValueFormat
-    {
-        PackedInt, // row * 100 + col [Technically, we use shorts, but let's ignore that]
-        Index, // 0-108
-        Bitmask // Unused for the moment, but we could directly store combinations as an array of two bitmasks
+    /**
+     * Format specification for cell values in the grid.
+     * 
+     * <p>
+     * The grid can represent cell values in three different formats, each with its own advantages and
+     * disadvantages. The {@link #PackedInt PackedInt} format is human-readable and easy to work with
+     * for adjacency calculations, but it isn't the most efficient for storage. The {@link #Index Index}
+     * format is more memory-efficient and is easier for generators to work with, but it isn't as easily
+     * understood by humans. The {@link #Bitmask Bitmask} format allows for compact storage and fast
+     * operations using bitwise logic, but it is the least human-readable and requires more complex
+     * logic to work with.
+     * </p>
+     * 
+     * <p>
+     * To streamline the codebase and clarify the operations used, we defined these formats as an enum,
+     * letting us switch between them easily and avoid magic numbers. This also facilitates future
+     * expansions or modifications to the formats, as we can simply add new enum values and update the
+     * relevant methods accordingly, improving maintainability.
+     * </p>
+     * 
+     * @since 2025.07.16 - ValueFormat Enum Introduction
+     * @threading This enum is immutable and safe to use across threads.
+     * @performance O(1) access time, as enum values are constants.
+     * @optimization Using an enum to avoid magic numbers and improve code clarity and maintainability.
+     */
+    public enum ValueFormat {
+        /**
+         * A format where each cell is represented as a packed integer, with the row and column encoded as
+         * <code>row * 100 + col</code>. For example, the cell at row 3, column 5 would be represented as
+         * 305.
+         * 
+         * <p>
+         * This format is human-readable and easy to work with for adjacency calculations, as the row and
+         * column can be easily extracted using simple arithmetic. However, it isn't the most efficient for
+         * storage, as it uses more bits than necessary to represent the cell values.
+         * </p>
+         * 
+         * <p>
+         * It's worth noting that, as of July 24th, 2025, most of our codebase has been updated to use
+         * <code>short</code>s instead of <code>int</code>s for cell values, due to the grid's size fitting
+         * comfortably within the range of a <code>short</code>. However, the naming has persisted for
+         * clarity and consistency, as the format's structure remains unchanged. "PackedShort" would be more
+         * accurate, but it would require modifying a significant portion of the codebase, which may not be
+         * worth the effort at this time.
+         * </p>
+         * 
+         * <h3>Performance Considerations</h3>
+         * <p>
+         * While this format is easy to understand and work with, it does incur some overhead in terms of
+         * storage and computation. Each packed integer requires more bits than necessary, and operations
+         * like adjacency checks require additional arithmetic to extract the row and column.
+         * </p>
+         * 
+         * <p>
+         * Our codebase uses this format primarily for human-readable outputs and for operations that
+         * benefit from the clarity of row and column representation (e.g., adjacency calculations).
+         * However, we avoid using it in performance-critical paths where efficiency is paramount.
+         * </p>
+         * 
+         * @since 2025.07.16 - ValueFormat Enum Introduction
+         * @threading This enum value is immutable and safe to use across threads.
+         * @performance O(1) access time, as enum values are constants.
+         * @optimization The codebase adopts this format for human-readable outputs and clarity in certain
+         *               operations, while avoiding it in performance-critical paths.
+         * @see #packedToIndex(short)
+         * @see #indexToPacked(short)
+         */
+        PackedInt,
+        /**
+         * A format where each cell is represented as a zero-based index, ranging from 0 to 108 for our
+         * 109-cell grid. The index is calculated based on the cell's position in a flattened array
+         * representation of the grid.
+         * 
+         * <p>
+         * This format is more memory-efficient than {@link #PackedInt PackedInt}, as it uses the minimum
+         * number of bits necessary to represent the cell values. It is also easier for generators to work
+         * with, as they can simply iterate over the indices to generate combinations. However, it isn't as
+         * easily understood by humans, as the row and column information is not directly encoded in the
+         * index.
+         * </p>
+         * 
+         * <h3>Performance Considerations</h3>
+         * <p>
+         * In comparison with the {@link #PackedInt PackedInt} format, this format is more efficient in
+         * terms of storage, as it uses fewer bits to represent the cell values. However, operations that
+         * require multiple cell accesses and/or modifications may benefit from using the {@link #Bitmask
+         * Bitmask} format instead, as it can allow for operations in parallel.
+         * </p>
+         * 
+         * @since 2025.07.16 - ValueFormat Enum Introduction
+         * @threading This enum value is immutable and safe to use across threads.
+         * @performance O(1) access time, as enum values are constants.
+         * @optimization The codebase adopts this format for memory efficiency and ease of use in
+         *               generators, while avoiding it in operations that benefit from parallelism.
+         * @see #packedToIndex(short)
+         * @see #indexToPacked(short)
+         */
+        Index,
+        /**
+         * A format where the entire grid state is represented as a bitmask, with each bit corresponding to
+         * a cell in the grid. A bit value of 1 indicates that the cell is "on" (true), while a bit value of
+         * 0 indicates that the cell is "off" (false).
+         * 
+         * <p>
+         * This format allows for compact storage and fast operations using bitwise logic, as multiple cell
+         * states can be manipulated in parallel. However, it is the least human-readable of the three
+         * formats, as the individual cell states are not directly visible. It also requires more complex
+         * logic to work with, as operations like adjacency checks and cell clicks need to be implemented
+         * using bitwise operations.
+         * </p>
+         * 
+         * <h3>Performance Considerations</h3>
+         * <p>
+         * While this format carries several efficiency advantages, it is rarely used in our current
+         * codebase due to its trade-offs. Further complicating matters is Java's lack of a native 128-bit
+         * primitive type, which would be ideal for representing our 109-cell grid in a single bitmask.
+         * Without such a type, we are forced to split the grid state across two 64-bit longs, which adds
+         * complexity and slightly diminishes the performance benefits of using a bitmask.
+         * </p>
+         * 
+         * <p>
+         * Despite this, we could still see some benefits from using this format in certain scenarios. Combinations
+         * of clicks could be represented as bitmasks, allowing for fast application to the grid state using two
+         * bitwise OR operations. Our current codebase hasn't explored this avenue yet, but it remains a potential
+         * optimization for the future to squeeze out additional performance, especially for operations involving
+         * very long click combinations.
+         * </p>
+         * 
+         * @since 2025.07.16 - Bitmask Enum Introduction
+         * @threading This enum value is immutable and safe to use across threads.
+         * @performance O(1) access time, as enum values are constants.
+         * @optimization The codebase avoids using this format frequently due to its complexity and the lack
+         *               of a native 128-bit primitive type in Java, which would be ideal for our grid
+         *               representation.
+         * @see #gridState
+         * @see #click(long[])
+         * @see #getBit(int)
+         * @see #setBit(int)
+         * @see #clearBit(int)
+         */
+        Bitmask
     }
     
     /**
      * The number of rows in the grid. This is a constant value of 7, as the grid is defined to have 7 rows.
      * 
-     * <h3>Performance Characteristics</h3>
+     * <h3>Performance Considerations</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -140,7 +276,7 @@ public abstract class Grid {
      * The number of columns in odd-indexed rows of the grid. This is a constant value of 15, as defined
      * by the grid's structure.
      * 
-     * <h3>Performance Characteristics</h3>
+     * <h3>Performance Considerations</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -162,7 +298,7 @@ public abstract class Grid {
      * The number of columns in even-indexed rows of the grid. This is a constant value of 16, as
      * defined by the grid's structure.
      * 
-     * <h3>Performance Characteristics</h3>
+     * <h3>Performance Considerations</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -191,7 +327,7 @@ public abstract class Grid {
      * between these two formats, allowing us to convert between them without losing information.
      * </p>
      * 
-     * <h3>Performance Characteristics</h3>
+     * <h3>Performance Considerations</h3>
      * <p>
      * Lookup time for the offsets is O(1) since they are stored in a static array. Testing has shown
      * that using a static array is more efficient than calculating the offsets at runtime, at least for
@@ -219,7 +355,7 @@ public abstract class Grid {
      * 109 cells.
      * </p>
      * 
-     * <h3>Performance Characteristics</h3>
+     * <h3>Performance Considerations</h3>
      * <p>
      * This constant is used throughout the class to define array sizes and loop bounds, ensuring
      * consistency and preventing magic numbers in the code. It is crucial for maintaining the integrity
@@ -426,7 +562,31 @@ public abstract class Grid {
      * @see #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)
      */
     private static final boolean[][] ADJACENCY_CACHE = new boolean[NUM_CELLS][NUM_CELLS]; // Index format
-    private static final short[] PACKED_TO_INDEX_CACHE = new short[(NUM_ROWS - 1) * 100 + EVEN_NUM_COLS]; // Cache for packed to index conversion
+    /**
+     * A cache for converting {@link ValueFormat#PackedInt PackedInt} values to
+     * {@link ValueFormat#Index Index} values. This is filled in during the static block of Grid's
+     * initialization and is used to quickly convert between these two formats without needing to
+     * compute the conversion on-the-fly.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Pre-computing this cache allows for O(1) lookups when converting from PackedInt to Index format,
+     * avoiding the need to compute the conversion on-the-fly. This is useful for operations that need
+     * to work with both formats, as it allows for quick conversions without incurring the cost of
+     * calculations.
+     * </p>
+     * 
+     * @since 2025.06.15 - PackedInt -> Index Precomputation
+     * @threading This array is initialized in a static block and is immutable after that point.
+     * @performance O(1) lookup time for PackedInt to Index conversions, as it is a pre-computed
+     *              array.
+     * @optimization Uses a static array to avoid the overhead of runtime calculations. Standardized to
+     *               use the {@link ValueFormat#Index Index} format for consistency.
+     * @see #NUM_CELLS
+     * @see #computePackedToIndex(short)
+     * @see ValueFormat
+     */
+    private static final short[] PACKED_TO_INDEX_CACHE = new short[(NUM_ROWS - 1) * 100 + EVEN_NUM_COLS];
 
     // We don't necessarily need to worry too much about how optimized this block
     // is, since it's only run once at startup.
@@ -526,8 +686,7 @@ public abstract class Grid {
      * @performance If outputFormat is <code>Index</code>, O(1) input conversion (if necessary) + 6 *
      *              O(1) adjacency computation + O(6) output filtering + O(n) conversion to index format
      *              (where n is fixed as 6 or less) = O(1) complexity.
-     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
-     *            or with proper synchronization.
+     * @threading This method is thread-safe, as it does not modify any instance or static state.
      * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
      *         required for <code>ArrayList</code>s and allowing for easy conversion to a properly-sized
      *         short array.
@@ -595,13 +754,61 @@ public abstract class Grid {
         return affectedPieces;
     }
 
-    public static ShortList computeAdjacents(short cell, ValueFormat format) 
-    {
+    /**
+     * Overload of {@link #computeAdjacents(short, ValueFormat, ValueFormat) computeAdjacents()} that
+     * assumes the input and output formats are the same. This exists purely for convenience, as it
+     * simply calls the main method with the same format for both parameters.
+     * 
+     * @param cell   a <code>short</code> representing the cell in the grid, expected to be in the same
+     *               format as <code>format</code>.
+     * @param format the {@link ValueFormat} of both the input and output cell, which can either be
+     *               {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
+     * @return A <code>ShortList</code> of adjacent cells in the specified format, containing up to 6
+     *         items.
+     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
+     *                                  represent a single cell in that format.
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) input conversion (if necessary) + 6 * O(1) adjacency computation + O(6) output
+     *              filtering = O(1) complexity.
+     * @threading This method is thread-safe, as it does not modify any instance or static state.
+     * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
+     *         required for <code>ArrayList</code>s and allowing for efficient storage and retrieval of
+     *         short values.
+     * @optimization Using a <code>ShortList</code> avoids the need for counting the number of valid
+     *               adjacent cells before initializing a presized array and avoids the boxing overhead
+     *               associated with <code>ArrayList</code>s.
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @see ShortList
+     */
+    public static ShortList computeAdjacents(short cell, ValueFormat format) {
         return computeAdjacents(cell, format, format);
     }
 
-    public static ShortList computeAdjacents(short cell) 
-    {
+    /**
+     * Overload of {@link #computeAdjacents(short, ValueFormat) computeAdjacents()} that assumes that
+     * the format is {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply
+     * calls the main method with <code>Index</code> for both parameters.
+     * 
+     * @param cell a <code>short</code> representing the cell in the grid, expected to be in
+     *             {@link ValueFormat#Index Index} format.
+     * @return A <code>ShortList</code> of adjacent cells in {@link ValueFormat#Index Index} format,
+     *         containing up to 6 items.
+     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
+     *                                  represent a single cell in that format.
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) input conversion (if necessary) + 6 * O(1) adjacency computation + O(6) output
+     *              filtering = O(1) complexity.
+     * @threading This method is thread-safe, as it does not modify any instance or static state.
+     * @memory We use a <code>ShortList</code> to store the affected pieces, avoiding the boxing
+     *         required for <code>ArrayList</code>s and allowing for efficient storage and retrieval of
+     *         short values.
+     * @optimization Using a <code>ShortList</code> avoids the need for counting the number of valid
+     *               adjacent cells before initializing a presized array and avoids the boxing overhead
+     *               associated with <code>ArrayList</code>s.
+     * @see #computeAdjacents(short, ValueFormat, ValueFormat)
+     * @see ShortList
+     */
+    public static ShortList computeAdjacents(short cell) {
         return computeAdjacents(cell, ValueFormat.Index);
     }
 
@@ -694,13 +901,55 @@ public abstract class Grid {
         return result;
     }
 
-    public static short[] findAdjacents(short cell, ValueFormat format) 
-    {
+    /**
+     * Overload of {@link #findAdjacents(short, ValueFormat, ValueFormat) findAdjacents()} that assumes
+     * the input and output formats are the same. This exists purely for convenience, as it simply calls
+     * the main method with the same format for both parameters.
+     * 
+     * @param cell   a <code>short</code> representing the cell in the grid, expected to be in the same
+     *               format as <code>format</code>.
+     * @param format the {@link ValueFormat} of both the input and output cell, which can either be
+     *               {@link ValueFormat#Index Index} or {@link ValueFormat#PackedInt PackedInt}.
+     * @return A <code>short[]</code> of adjacent cells in the specified format, containing up to 6
+     *         items.
+     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
+     *                                  represent a single cell in that format.
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) input conversion (if necessary) + O(1) adjacency lookup {+ O(n) output
+     *              conversion (where n is fixed as 6 or less)} = O(1) for simplest case, O(n) worst
+     *              case complexity.
+     * @threading This method is thread-safe, since it only reads from static, immutable data.
+     * @memory Uses a fixed-size array to store the results, avoiding dynamic memory allocation and
+     *         temporary object creation.
+     * @optimization Uses a pre-computed adjacency array for fast lookups and minimizes memory usage by
+     *               using fixed-size arrays.
+     * @see #findAdjacents(short)
+     */
+    public static short[] findAdjacents(short cell, ValueFormat format) {
         return findAdjacents(cell, format, format);
     }
 
-    public static short[] findAdjacents(short cell) 
-    {
+    /**
+     * Overload of {@link #findAdjacents(short, ValueFormat) findAdjacents()} that assumes that the
+     * format is {@link ValueFormat#Index Index}. This exists purely for convenience, as it simply calls
+     * the main method with <code>Index</code> for both parameters.
+     * 
+     * @param cell a <code>short</code> representing the cell in the grid, expected to be in
+     *             {@link ValueFormat#Index Index} format.
+     * @return A <code>short[]</code> of adjacent cells in {@link ValueFormat#Index Index} format,
+     *         containing up to 6 items.
+     * @throws IllegalArgumentException if the input or output format is Bitmask, since we cannot
+     *                                  represent a single cell in that format.
+     * @since 2025.07.16 - Format Support
+     * @performance O(1) adjacency lookup
+     * @threading This method is thread-safe, since it only reads from static, immutable data.
+     * @memory Uses a fixed-size array to store the results, avoiding dynamic memory allocation and
+     *         temporary object creation.
+     * @optimization Uses a pre-computed adjacency array for fast lookups and minimizes memory usage by
+     *               using fixed-size arrays.
+     * @see #findAdjacents(short, ValueFormat)
+     */
+    public static short[] findAdjacents(short cell) {
         return findAdjacents(cell, ValueFormat.Index);
     }
 
@@ -787,11 +1036,41 @@ public abstract class Grid {
         throw new IllegalArgumentException("Invalid index: " + index);
     }
 
-    public Grid()
-    {
+    /**
+     * Constructs a new {@link Grid} instance and initializes it to a specific starting state by calling
+     * the {@link #initialize()} method.
+     * 
+     * <p>
+     * Since {@link Grid} is an abstract class, this constructor is called implicitly via a subclass's
+     * constructor. The {@link #initialize()} method is abstract and must be implemented by subclasses
+     * to define their own initial configurations.
+     * </p>
+     * 
+     * @since 2025.03.29 - Abstract Grid Introduction
+     * @threading Thread-safe since each call operates on a new instance.
+     * @see #initialize()
+     */
+    public Grid() {
         initialize();
     }
 
+    /**
+     * Initializes the grid to a specific starting state. This method is abstract and must be implemented
+     * by subclasses to define their own initial configurations.
+     * 
+     * <p>
+     * This method is called in the {@link #Grid() constructor} of the {@link Grid} class, ensuring that any subclass
+     * will have its grid state properly initialized upon instantiation. The specific implementation of
+     * this method will depend on the requirements of the subclass.
+     * </p>
+     * 
+     * @since 2025.03.29 - Abstract Grid Introduction
+     * @threading This method is <b>not</b> thread-safe. It should only be called from a single thread
+     *            or with proper synchronization.
+     * @see Grid13
+     * @see Grid22
+     * @see Grid35
+     */
     abstract void initialize();
 
     // Core bitmask operations
@@ -1335,10 +1614,37 @@ public abstract class Grid {
         recalculationNeeded = true;
     }
 
-    public void click(long[] bitmask) 
-    {
-        if (bitmask.length != 2) 
-        {
+    /**
+     * Specialized click method for the {@link ValueFormat#Bitmask Bitmask} format.
+     * 
+     * <p>
+     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
+     * by XORing the {@link #gridState grid state} with the provided bitmask.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is built for scenarios where the caller has pre-computed the adjacency bitmask for a cell
+     * and wants to apply it directly, avoiding the overhead of format conversions or lookups. While our code
+     * does not currently leverage this method, it is provided for completeness and potential future use cases.
+     * </p>
+     * 
+     * <p>
+     * To optimize performance further, we could make the method final to encourage inlining, but we leave it as-is for now
+     * to allow for potential overrides in subclasses.
+     * </p>
+     * @param bitmask The bitmask representing the adjacents to toggle, as a long array of length 2.
+     * @throws IllegalArgumentException if the bitmask is not of length 2.
+     * @since 2025.07.17 - Click Format Support
+     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
+     *            instances of Grid or synchronize access to this method.
+     * @performance O(1) bitwise operations on the grid state = O(1) complexity.
+     * @optimization Assumes the bitmask is of length 2 to avoid format checks.
+     * @see #click(short cell, ValueFormat format)
+     * @see #click(short cell)
+     */
+    public void click(long[] bitmask) {
+        if (bitmask.length != 2) {
             throw new IllegalArgumentException("Bitmask must be of length 2.");
         }
         gridState[0] ^= bitmask[0];
@@ -1576,10 +1882,30 @@ public abstract class Grid {
         return trueCellsCount;
     }
 
-    public Grid clone() 
-    {
-        try 
-        {
+    /**
+     * Creates and returns a deep copy of this <code>Grid</code> instance.
+     * 
+     * <p>
+     * The cloned instance has its own copy of the grid state, ensuring that modifications to
+     * the clone do not affect the original instance and vice versa. The method uses reflection to
+     * create a new instance of the same class, allowing for proper cloning of subclasses without
+     * needing to create overrides for each subclass.
+     * </p>
+     * 
+     * @return A deep copy of this <code>Grid</code> instance.
+     * @throws RuntimeException if the cloning process fails due to reflection issues.
+     * @since 2025.03.26 - Cloning Introduction
+     * @performance O(1) for creating a new instance + O(1) for copying the grid state and fields = O(1) complexity.
+     * @threading Thread-safe, as it creates a new instance and does not modify any shared state.
+     * @see #firstTrueCell
+     * @see #gridState
+     * @see #recalculationNeeded
+     * @see #trueCellsCount
+     * @see java.lang.Cloneable
+     * @see java.lang.Object#clone()
+     */
+    public Grid clone() {
+        try {
             Grid newGrid = this.getClass().getDeclaredConstructor().newInstance();
             // Copy bitmask state
             newGrid.gridState[0] = this.gridState[0];
@@ -1588,8 +1914,7 @@ public abstract class Grid {
             newGrid.firstTrueCell = this.firstTrueCell;
             newGrid.recalculationNeeded = this.recalculationNeeded;
             return newGrid;
-        } catch (Exception e) 
-        {
+        } catch (Exception e) {
             throw new RuntimeException("Failed to clone Grid", e);
         }
     }

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -749,7 +749,6 @@ public abstract class Grid
      * path.
      * </p>
      * 
-     * @param format The desired output format (Index or PackedInt).
      * @return An array of true cells in the specified format.
      * @since 2025.04.08 - Adjacency Optimizations
      * @performance O(n) loop through the grid state (where n is the index of the last true cell, up to

--- a/src/main/java/com/github/mrgarbagegamer/Grid.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid.java
@@ -24,7 +24,7 @@ import it.unimi.dsi.fastutil.shorts.ShortList;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>0/50 - 0% of documentation completed</h3>
+ * <h3>2/50 - 4% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]
@@ -453,12 +453,50 @@ public abstract class Grid
     }
 
     /**
-     * Specialized click method for Index format. Made final to encourage inlining.
-     * This is the hottest path for worker threads.
+     * Simulates a click on the <code>Grid</code> at the specified cell. We assume that the cell is in
+     * {@link #ValueFormat.Index <code>Index</code>} format (0-108) to save time on format checks.
+     * 
+     * <p>
+     * A click toggles the state of its adjacent cells (excluding itself), so we can perform a click
+     * simply by XORing the {@link #gridState grid state} with a pre-computed {@link #ADJACENCY_MASKS
+     * adjacency mask.}
+     * </p>
+     * 
+     * <p>
+     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to <code>true</code> ensures
+     * that the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will
+     * recalculate the {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of
+     * true cells}. This avoids unnecessary recalculations on every click, which is crucial for
+     * performance in high-frequency scenarios.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit <code>long</code>
+     * for the grid state, meaning that we have to use two <code>long</code>s, and thus two adjacency
+     * masks per cell. Though we could strategically use a single long as a bitmask if the adjacent
+     * cells are localized to the same long, we choose to use two longs for simplicity and to avoid
+     * branching.
+     * </p>
+     * 
      * @param cell The cell to click, in Index format (0-108).
+     * @throws IllegalArgumentException if the cell is out of bounds (implicitly checked by the array accesses.
+     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
+     *            instances of Grid or synchronize access to this method.
+     * @performance Two O(1) click operations using pre-computed adjacency bitmasks = O(1) complexity.
+     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
+     *               Declared as final to encourage JIT inlining. Assumes the cell is in
+     *               <code>Index</code> format (0-108) to avoid format checks.
+     * @see {@link #click(short cell, ValueFormat format)} - Method overload for different formats.
+     * @see {@link #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)} -
+     *      Computes the adjacent cells for a given cell, overloaded for different input and output
+     *      formats. Used internally to generate the masks used in this method.
+     * @see {@link #areAdjacent(short cellA, short cellB, ValueFormat format)} - Checks if two cells are adjacent in the
+     *      grid.
+     * @deprecated As of 2025.07.28, replaced by {@link #click(short[] cells)} for bulk operations on
+     *             combinations in {@link TestClickCombination monkeys}.
      */
-    public final void click(short cell) 
-    {
+    public final void click(short cell) {
         // XOR the grid state with the pre-computed adjacency mask
         gridState[0] ^= ADJACENCY_MASKS[cell][0];
         gridState[1] ^= ADJACENCY_MASKS[cell][1];
@@ -498,14 +536,61 @@ public abstract class Grid
         recalculationNeeded = true;
     }
 
-    /** 
-     * Performs a bulk click operation on multiple cells in the grid. Saves the overhead of multiple method calls.
-     * @param cells An array of cells to click, in Index format (0-108).
-    */
-    public final void click(short[] cells)
-    {
-        for (short cell : cells) 
-        {
+    /**
+     * Simulates a click on multiple cells in the <code>Grid</code>. We assume that the cells are in the
+     * {@link #ValueFormat.Index <code>Index</code>} format (0-108) and the array is non-null to save on
+     * format checks.
+     * 
+     * <p>
+     * A click simply toggles the state of its adjacent cells (excluding itself), so we can perform a
+     * click by XORing the {@link #gridState grid state} with the pre-computed {@link #ADJACENCY_MASKS
+     * adjacency masks}. As opposed to the single cell {@link #click(short cell)} method, this method
+     * allows for bulk operations on combinations of cells, saving on the overhead of multiple method
+     * calls.
+     * </p>
+     * 
+     * <p>
+     * Setting the {@link #recalculationNeeded recalculationNeeded} flag to <code>true</code> ensures
+     * that the next call to {@link #findFirstTrueCell(ValueFormat) findFirstTrueCell()} will
+     * recalculate the {@link #firstTrueCell first true cell} and the {@link #trueCellsCount count of
+     * true cells}. This avoids unnecessary recalculations on every click, which is crucial for
+     * performance in high-frequency scenarios.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since the Grid has {@link #NUM_CELLS 109 cells}, we can't use a single 64-bit <code>long</code>
+     * for the grid state, meaning that we have to use two <code>long</code>s, and thus two adjacency
+     * masks per cell. Though we could strategically use a single long as a bitmask if the adjacent
+     * cells are localized to the same long, we choose to use two longs for simplicity and to avoid
+     * branching.
+     * </p>
+     * <p>
+     * We avoid unrolling the loop here, since the JVM can handle that for us and it would deliver
+     * mediocre performance gains at best. Vectorization is also not applicable here, since we perform
+     * array accesses in a non-predictable manner.
+     * </p>
+     * 
+     * @param cells The array of cells to click, in Index format (0-108).
+     * @throws IllegalArgumentException if the clicks are out of bounds (implicitly checked by the array
+     *                                  accesses).
+     * @throws NullPointerException     if the cells array is null (implicitly thrown by the for-each
+     *                                  loop).
+     * @threading This method is <b>not</b> thread-safe. Multiple threads should have their own
+     *            instances of Grid or synchronize access to this method.
+     * @performance O(n) loop * (2 O(1) bitwise operations per cell) = O(n) complexity, where n is the
+     *              number of cells clicked.
+     * @optimization Using precomputed adjacency masks for fast bitwise operations on the grid state.
+     *               Declared as final to encourage JIT inlining. Assumes the cells are in Index format
+     *               and the array is non-null to avoid format checks.
+     * @see {@link #computeAdjacents(short cell, ValueFormat inputFormat, ValueFormat outputFormat)} -
+     *      Computes the adjacent cells for a given cell, overloaded for different input and output
+     *      formats and used internally to generate the masks used in this method.
+     * @see {@link #areAdjacent(short cellA, short cellB, ValueFormat format)} - Checks if two cells are
+     *      adjacent in the grid.
+     */
+    public final void click(short[] cells) {
+        for (short cell : cells) {
             // XOR the grid state with the pre-computed adjacency mask
             gridState[0] ^= ADJACENCY_MASKS[cell][0];
             gridState[1] ^= ADJACENCY_MASKS[cell][1];

--- a/src/main/java/com/github/mrgarbagegamer/Grid13.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid13.java
@@ -1,7 +1,7 @@
 package com.github.mrgarbagegamer;
 
 /**
- * Grid13 - Concrete Grid Implementation for Q13/Kermit
+ * A concrete {@code Grid} implementation for Q13/Kermit.
  * 
  * <p>
  * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q13
@@ -11,11 +11,11 @@ package com.github.mrgarbagegamer;
  * 
  * <h2>Configuration Details</h2>
  * <p>
- * In this configuration, the grid is initialized with a total of 30 true cells, with the first true
- * cell located at bit index 32 (row 2, column 1). The grid's state is represented using two long
- * values in the {@link #gridState} array, where each bit corresponds to a cell in the hexagonal
- * grid. The specific bit pattern for this configuration is pre-computed and directly assigned in
- * the {@link #initialize()} method.
+ * In this configuration, the grid is initialized with a total of 30 {@code true} cells, with the
+ * first {@code true} cell located at bit index 32 (row 2, column 1). The grid's state is
+ * represented using two {@code long} values in the {@link #gridState} array, where each bit
+ * corresponds to a cell in the hexagonal grid. The specific bit pattern for this configuration is
+ * pre-computed and directly assigned in the {@link #initialize()} method.
  * </p>
  * 
  * <h2>Initialization Strategy</h2>
@@ -24,8 +24,8 @@ package com.github.mrgarbagegamer;
  * pre-computed values to the {@link #gridState} array. This approach avoids the need for
  * recalculating the grid state during initialization, which can be computationally expensive. The
  * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
- * initial configuration, and marks the {@link #recalculationNeeded} flag as false, indicating that
- * no further recalculation is necessary at this point.
+ * initial configuration, and marks the {@link #recalculationNeeded} flag as {@code false},
+ * indicating that no further recalculation is necessary at this point.
  * </p>
  * 
  * <p>
@@ -37,8 +37,8 @@ package com.github.mrgarbagegamer;
  * @see Grid22
  * @see Grid35
  * @since 2025.04.15 - Adjacent Skipping Optimization
- * @performance O(1) for initialization, as it involves direct assignments without loops or complex
- *              calculations.
+ * @performance {@code O(1)} for initialization, as it involves direct assignments without loops or
+ *              complex calculations.
  * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
  *            Grid13 to avoid concurrency issues.
  * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
@@ -48,17 +48,17 @@ public class Grid13 extends Grid {
      * Initializes the grid to the specific configuration for Q13/Kermit.
      * 
      * <p>
-     * This method sets the initial state of the grid, directly assigning pre-computed
-     * values to the {@link #gridState} array. The proper values for {@link #firstTrueCell}
-     * and {@link #trueCellsCount} are also set to reflect the initial configuration, and
-     * the {@link #recalculationNeeded} flag is set to false, indicating that no further
+     * This method sets the initial state of the grid, directly assigning pre-computed values to the
+     * {@link #gridState} array. The proper values for {@link #firstTrueCell} and
+     * {@link #trueCellsCount} are also set to reflect the initial configuration, and the
+     * {@link #recalculationNeeded} flag is set to {@code false}, indicating that no further
      * recalculation is necessary at this point.
      * </p>
      * 
      * <p>
-     * Commented out are the clicks that make up the solution to the Q13 puzzle, which
-     * can be uncommented to test lower click counts. These clicks are pre-computed to
-     * avoid unnecessary recalculations during initialization.
+     * Commented out are the clicks that make up the solution to the Q13 puzzle, which can be
+     * uncommented to test lower click counts. These clicks are pre-computed to avoid unnecessary
+     * recalculations during initialization.
      * </p>
      * 
      * @see #getGridState()

--- a/src/main/java/com/github/mrgarbagegamer/Grid13.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid13.java
@@ -1,68 +1,57 @@
 package com.github.mrgarbagegamer;
 
 /**
- * A concrete {@code Grid} implementation for Q13/Kermit.
- * 
+ * A concrete {@link Grid} that provides the initial puzzle state for Q13 ("Kermit").
+ *
  * <p>
- * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q13
- * of 2018 (also known as "Kermit"). It extends the abstract {@link Grid} class, providing a
- * specific implementation for the puzzle's starting state.
+ * This class defines the starting configuration for the 2018 PDC Q13 puzzle. Its sole purpose is to
+ * load a pre-computed bitmask representing the initial layout of {@code true} cells into the
+ * {@link #gridState} array.
  * </p>
- * 
- * <h2>Configuration Details</h2>
+ *
+ * <h2>Architectural Role</h2>
  * <p>
- * In this configuration, the grid is initialized with a total of 30 {@code true} cells, with the
- * first {@code true} cell located at bit index 32 (row 2, column 1). The grid's state is
- * represented using two {@code long} values in the {@link #gridState} array, where each bit
- * corresponds to a cell in the hexagonal grid. The specific bit pattern for this configuration is
- * pre-computed and directly assigned in the {@link #initialize()} method.
+ * As a concrete implementation of the {@code abstract} {@link Grid}, this class represents one of
+ * the specific problems the solver is designed to tackle. The initial state is loaded via the
+ * {@link #initialize()} method, which uses a hardcoded bitmask for maximum performance, avoiding
+ * any computational overhead at runtime.
  * </p>
- * 
- * <h2>Initialization Strategy</h2>
+ *
+ * <h2>Puzzle Details</h2>
  * <p>
- * The {@link #initialize()} method sets up the grid's initial state by directly assigning
- * pre-computed values to the {@link #gridState} array. This approach avoids the need for
- * recalculating the grid state during initialization, which can be computationally expensive. The
- * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
- * initial configuration, and marks the {@link #recalculationNeeded} flag as {@code false},
- * indicating that no further recalculation is necessary at this point.
+ * The Q13 grid is initialized with 30 {@code true} cells. A known 7-click solution is included in
+ * the source code, which can be uncommented for validation or testing of the solver's logic.
  * </p>
- * 
- * <p>
- * Since this puzzle has a known solution in 7 clicks, the method includes the solution in commented
- * out form. These clicks can be uncommented to test lower click counts, and they are pre-computed
- * to avoid unnecessary recalculations during initialization.
- * </p>
- * 
+ *
  * @see Grid22
  * @see Grid35
- * @since 2025.04.15 - Adjacent Skipping Optimization
- * @performance {@code O(1)} for initialization, as it involves direct assignments without loops or
- *              complex calculations.
+ * @since 2025.04 - Adjacent Skipping Optimization
+ * @performance {@code O(1)} for initialization and most operations.
  * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
- *            Grid13 to avoid concurrency issues.
- * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
+ *            {@code Grid13} to avoid concurrency issues.
+ * @memory No allocations after initialization (except for methods that explicitly create new
+ *         objects).
  */
 public class Grid13 extends Grid {
     /**
-     * Initializes the grid to the specific configuration for Q13/Kermit.
-     * 
+     * Loads the pre-computed state for the Q13 puzzle.
+     *
      * <p>
-     * This method sets the initial state of the grid, directly assigning pre-computed values to the
-     * {@link #gridState} array. The proper values for {@link #firstTrueCell} and
-     * {@link #trueCellsCount} are also set to reflect the initial configuration, and the
-     * {@link #recalculationNeeded} flag is set to {@code false}, indicating that no further
-     * recalculation is necessary at this point.
+     * This method directly assigns the bitmask representing the puzzle's initial state to the
+     * {@link #gridState} array. It also sets cached values for the first {@code true} cell and the
+     * total count of {@code true} cells for efficient processing.
      * </p>
-     * 
+     *
      * <p>
-     * Commented out are the clicks that make up the solution to the Q13 puzzle, which can be
-     * uncommented to test lower click counts. These clicks are pre-computed to avoid unnecessary
-     * recalculations during initialization.
+     * The commented-out clicks represent the known 7-click solution and can be used for testing or
+     * validation purposes.
      * </p>
      * 
      * @see #getGridState()
-     * @since 2025.04.15 - Adjacent Skipping Optimization
+     * @since 2025.04 - Adjacent Skipping Optimization
+     * @performance {@code O(1)} - Direct assignment of pre-computed values.
+     * @threading Not thread-safe; mutates instance state.
+     * @memory Does not allocate.
      */
     void initialize() {
         // Initialize for Q13/Kermit

--- a/src/main/java/com/github/mrgarbagegamer/Grid13.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid13.java
@@ -34,14 +34,14 @@ package com.github.mrgarbagegamer;
  * to avoid unnecessary recalculations during initialization.
  * </p>
  * 
- * @since 2025.04.15 - Adjacent Skipping Optimization
- * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
- *            Grid13 to avoid concurrency issues.
- * @performance O(1) for initialization, as it involves direct assignments without loops or complex
- *              calculations.
- * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
  * @see Grid22
  * @see Grid35
+ * @since 2025.04.15 - Adjacent Skipping Optimization
+ * @performance O(1) for initialization, as it involves direct assignments without loops or complex
+ *              calculations.
+ * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
+ *            Grid13 to avoid concurrency issues.
+ * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
  */
 public class Grid13 extends Grid {
     /**
@@ -61,8 +61,8 @@ public class Grid13 extends Grid {
      * avoid unnecessary recalculations during initialization.
      * </p>
      * 
-     * @since 2025.04.15 - Adjacent Skipping Optimization
      * @see #getGridState()
+     * @since 2025.04.15 - Adjacent Skipping Optimization
      */
     void initialize() {
         // Initialize for Q13/Kermit

--- a/src/main/java/com/github/mrgarbagegamer/Grid13.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid13.java
@@ -1,5 +1,22 @@
 package com.github.mrgarbagegamer;
 
+/**
+ * Grid13 - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * 
+ * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * 
+ * <h2>Configuration Details</h2>
+ * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * 
+ * <h2>Initialization Strategy</h2>
+ * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * 
+ * <h3>0/2 - 0% of documentation completed</h3>
+ * 
+ * @algorithm [If complex initialization logic is involved]
+ * @since [When this configuration was introduced]
+ * @see [Related configuration classes]
+ */
 public class Grid13 extends Grid 
 {
     

--- a/src/main/java/com/github/mrgarbagegamer/Grid13.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid13.java
@@ -1,24 +1,49 @@
 package com.github.mrgarbagegamer;
 
 /**
- * Grid13 - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * Grid13 - Concrete Grid Implementation for Q13/Kermit
  * 
- * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * <p>
+ * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q13
+ * of 2018 (also known as "Kermit"). It extends the abstract {@link Grid} class, providing a
+ * specific implementation for the puzzle's starting state.
+ * </p>
  * 
  * <h2>Configuration Details</h2>
- * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * <p>
+ * In this configuration, the grid is initialized with a total of 30 true cells, with the first true
+ * cell located at bit index 32 (row 2, column 1). The grid's state is represented using two long
+ * values in the {@link #gridState} array, where each bit corresponds to a cell in the hexagonal
+ * grid. The specific bit pattern for this configuration is pre-computed and directly assigned in
+ * the {@link #initialize()} method.
+ * </p>
  * 
  * <h2>Initialization Strategy</h2>
- * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * <p>
+ * The {@link #initialize()} method sets up the grid's initial state by directly assigning
+ * pre-computed values to the {@link #gridState} array. This approach avoids the need for
+ * recalculating the grid state during initialization, which can be computationally expensive. The
+ * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
+ * initial configuration, and marks the {@link #recalculationNeeded} flag as false, indicating that
+ * no further recalculation is necessary at this point.
+ * </p>
  * 
- * <h3>1/2 - 50% of documentation completed</h3>
+ * <p>
+ * Since this puzzle has a known solution in 7 clicks, the method includes the solution in commented
+ * out form. These clicks can be uncommented to test lower click counts, and they are pre-computed
+ * to avoid unnecessary recalculations during initialization.
+ * </p>
  * 
- * @algorithm [If complex initialization logic is involved]
- * @since [When this configuration was introduced]
- * @see [Related configuration classes]
+ * @since 2025.04.15 - Adjacent Skipping Optimization
+ * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
+ *            Grid13 to avoid concurrency issues.
+ * @performance O(1) for initialization, as it involves direct assignments without loops or complex
+ *              calculations.
+ * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
+ * @see Grid22
+ * @see Grid35
  */
-public class Grid13 extends Grid 
-{
+public class Grid13 extends Grid {
     /**
      * Initializes the grid to the specific configuration for Q13/Kermit.
      * 

--- a/src/main/java/com/github/mrgarbagegamer/Grid13.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid13.java
@@ -11,7 +11,7 @@ package com.github.mrgarbagegamer;
  * <h2>Initialization Strategy</h2>
  * <p>[How values are computed/determined. Pre-computation rationale.]</p>
  * 
- * <h3>0/2 - 0% of documentation completed</h3>
+ * <h3>1/2 - 50% of documentation completed</h3>
  * 
  * @algorithm [If complex initialization logic is involved]
  * @since [When this configuration was introduced]
@@ -19,9 +19,27 @@ package com.github.mrgarbagegamer;
  */
 public class Grid13 extends Grid 
 {
-    
-    void initialize() 
-    {
+    /**
+     * Initializes the grid to the specific configuration for Q13/Kermit.
+     * 
+     * <p>
+     * This method sets the initial state of the grid, directly assigning pre-computed
+     * values to the {@link #gridState} array. The proper values for {@link #firstTrueCell}
+     * and {@link #trueCellsCount} are also set to reflect the initial configuration, and
+     * the {@link #recalculationNeeded} flag is set to false, indicating that no further
+     * recalculation is necessary at this point.
+     * </p>
+     * 
+     * <p>
+     * Commented out are the clicks that make up the solution to the Q13 puzzle, which
+     * can be uncommented to test lower click counts. These clicks are pre-computed to
+     * avoid unnecessary recalculations during initialization.
+     * </p>
+     * 
+     * @since 2025.04.15 - Adjacent Skipping Optimization
+     * @see #getGridState()
+     */
+    void initialize() {
         // Initialize for Q13/Kermit
         
         // set all cells to their initial state

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -1,20 +1,21 @@
 package com.github.mrgarbagegamer;
 
 /**
- * Grid22 - Concrete Grid Implementation for Q22/Shrek
+ * A concrete {@code Grid} implementation for Q22/Shrek.
  * 
  * <p>
  * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q22
- * of 2018 (also known as "Shrek"). It extends the abstract {@link Grid} class, providing a
- * specific implementation for the puzzle's starting state.
+ * of 2018 (also known as "Shrek"). It extends the abstract {@link Grid} class, providing a specific
+ * implementation for the puzzle's starting state.
  * </p>
  * 
  * <h2>Configuration Details</h2>
  * <p>
- * In this configuration, the grid is initialized with a total of 50 true cells, with the first true
- * cell located at bit index 1 (row 0, column 1). The grid's state is represented using two long
- * values in the {@link #gridState} array, where each bit corresponds to a cell in the hexagonal
- * grid. The specific bit pattern for this configuration is pre-computed and directly assigned in the {@link #initialize()} method.
+ * In this configuration, the grid is initialized with a total of 50 {@code true} cells, with the
+ * first {@code true} cell located at bit index 1 (row 0, column 1). The grid's state is represented
+ * using two {@code long} values in the {@link #gridState} array, where each bit corresponds to a
+ * cell in the hexagonal grid. The specific bit pattern for this configuration is pre-computed and
+ * directly assigned in the {@link #initialize()} method.
  * </p>
  * 
  * <h2>Initialization Strategy</h2>
@@ -23,21 +24,21 @@ package com.github.mrgarbagegamer;
  * pre-computed values to the {@link #gridState} array. This approach avoids the need for
  * recalculating the grid state during initialization, which can be computationally expensive. The
  * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
- * initial configuration, and marks the {@link #recalculationNeeded} flag as false, indicating that
- * no further recalculation is necessary at this point.
+ * initial configuration, and marks the {@link #recalculationNeeded} flag as {@code false},
+ * indicating that no further recalculation is necessary at this point.
  * </p>
  * 
  * <p>
- * Since this puzzle has a known solution in 15 clicks, the method includes the solution in commented
- * out form. These clicks can be uncommented to test lower click counts, and they are pre-computed
- * to avoid unnecessary recalculations during initialization.
+ * Since this puzzle has a known solution in 15 clicks, the method includes the solution in
+ * commented out form. These clicks can be uncommented to test lower click counts, and they are
+ * pre-computed to avoid unnecessary recalculations during initialization.
  * </p>
  * 
  * @see Grid13
  * @see Grid35
  * @since 2025.03.29 - Concrete Class Introduction
- * @performance O(1) for initialization, as it involves direct assignments without loops or complex
- *              calculations.
+ * @performance {@code O(1)} for initialization, as it involves direct assignments without loops or
+ *              complex calculations.
  * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
  *            Grid22 to avoid concurrency issues.
  * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
@@ -47,17 +48,17 @@ public class Grid22 extends Grid {
      * Initializes the grid to the specific configuration for Q22/Shrek.
      * 
      * <p>
-     * This method sets the initial state of the grid, directly assigning pre-computed
-     * values to the {@link #gridState} array. The proper values for {@link #firstTrueCell}
-     * and {@link #trueCellsCount} are also set to reflect the initial configuration, and
-     * the {@link #recalculationNeeded} flag is set to false, indicating that no further
+     * This method sets the initial state of the grid, directly assigning pre-computed values to the
+     * {@link #gridState} array. The proper values for {@link #firstTrueCell} and
+     * {@link #trueCellsCount} are also set to reflect the initial configuration, and the
+     * {@link #recalculationNeeded} flag is set to {@code false}, indicating that no further
      * recalculation is necessary at this point.
      * </p>
      * 
      * <p>
-     * Commented out are the clicks that make up the solution to the Q22 puzzle, which
-     * can be uncommented to test lower click counts. These clicks are pre-computed to
-     * avoid unnecessary recalculations during initialization.
+     * Commented out are the clicks that make up the solution to the Q22 puzzle, which can be
+     * uncommented to test lower click counts. These clicks are pre-computed to avoid unnecessary
+     * recalculations during initialization.
      * </p>
      * 
      * @see #getGridState()

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -1,5 +1,22 @@
 package com.github.mrgarbagegamer;
 
+/**
+ * Grid22 - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * 
+ * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * 
+ * <h2>Configuration Details</h2>
+ * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * 
+ * <h2>Initialization Strategy</h2>
+ * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * 
+ * <h3>0/2 - 0% of documentation completed</h3>
+ * 
+ * @algorithm [If complex initialization logic is involved]
+ * @since [When this configuration was introduced]
+ * @see [Related configuration classes]
+ */
 public class Grid22 extends Grid 
 {   
     void initialize() 

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -1,68 +1,57 @@
 package com.github.mrgarbagegamer;
 
 /**
- * A concrete {@code Grid} implementation for Q22/Shrek.
- * 
+ * A concrete {@link Grid} that provides the initial puzzle state for Q22 ("Shrek").
+ *
  * <p>
- * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q22
- * of 2018 (also known as "Shrek"). It extends the abstract {@link Grid} class, providing a specific
- * implementation for the puzzle's starting state.
+ * This class defines the starting configuration for the 2018 PDC Q22 puzzle. Its sole purpose is to
+ * load a pre-computed bitmask representing the initial layout of {@code true} cells into the
+ * {@link #gridState} array.
  * </p>
- * 
- * <h2>Configuration Details</h2>
+ *
+ * <h2>Architectural Role</h2>
  * <p>
- * In this configuration, the grid is initialized with a total of 50 {@code true} cells, with the
- * first {@code true} cell located at bit index 1 (row 0, column 1). The grid's state is represented
- * using two {@code long} values in the {@link #gridState} array, where each bit corresponds to a
- * cell in the hexagonal grid. The specific bit pattern for this configuration is pre-computed and
- * directly assigned in the {@link #initialize()} method.
+ * As a concrete implementation of the abstract {@link Grid}, this class represents one of the
+ * specific problems the solver is designed to tackle. The initial state is loaded via the
+ * {@link #initialize()} method, which uses a hardcoded bitmask for maximum performance, avoiding
+ * any computational overhead at runtime.
  * </p>
- * 
- * <h2>Initialization Strategy</h2>
+ *
+ * <h2>Puzzle Details</h2>
  * <p>
- * The {@link #initialize()} method sets up the grid's initial state by directly assigning
- * pre-computed values to the {@link #gridState} array. This approach avoids the need for
- * recalculating the grid state during initialization, which can be computationally expensive. The
- * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
- * initial configuration, and marks the {@link #recalculationNeeded} flag as {@code false},
- * indicating that no further recalculation is necessary at this point.
+ * The Q22 grid is initialized with 50 {@code true} cells. A known 15-click solution is included in
+ * the source code, which can be uncommented for validation or testing of the solver's logic.
  * </p>
- * 
- * <p>
- * Since this puzzle has a known solution in 15 clicks, the method includes the solution in
- * commented out form. These clicks can be uncommented to test lower click counts, and they are
- * pre-computed to avoid unnecessary recalculations during initialization.
- * </p>
- * 
+ *
  * @see Grid13
  * @see Grid35
- * @since 2025.03.29 - Concrete Class Introduction
- * @performance {@code O(1)} for initialization, as it involves direct assignments without loops or
- *              complex calculations.
+ * @since 2025.03 - Concrete Class Introduction
+ * @performance {@code O(1)} for initialization and most operations.
  * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
- *            Grid22 to avoid concurrency issues.
- * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
+ *            {@code Grid22} to avoid concurrency issues.
+ * @memory No allocations after initialization (except for methods that explicitly create new
+ *         objects).
  */
 public class Grid22 extends Grid {   
     /**
-     * Initializes the grid to the specific configuration for Q22/Shrek.
-     * 
+     * Loads the pre-computed state for the Q22 puzzle.
+     *
      * <p>
-     * This method sets the initial state of the grid, directly assigning pre-computed values to the
-     * {@link #gridState} array. The proper values for {@link #firstTrueCell} and
-     * {@link #trueCellsCount} are also set to reflect the initial configuration, and the
-     * {@link #recalculationNeeded} flag is set to {@code false}, indicating that no further
-     * recalculation is necessary at this point.
+     * This method directly assigns the bitmask representing the puzzle's initial state to the
+     * {@link #gridState} array. It also sets cached values for the first {@code true} cell and the
+     * total count of {@code true} cells for efficient processing.
      * </p>
-     * 
+     *
      * <p>
-     * Commented out are the clicks that make up the solution to the Q22 puzzle, which can be
-     * uncommented to test lower click counts. These clicks are pre-computed to avoid unnecessary
-     * recalculations during initialization.
+     * The commented-out clicks represent the known 15-click solution and can be used for testing or
+     * validation purposes.
      * </p>
-     * 
+     *
      * @see #getGridState()
-     * @since 2025.03.29 - Concrete Class Introduction
+     * @since 2025.03 - Concrete Class Introduction
+     * @performance {@code O(1)} - Direct assignment of pre-computed values.
+     * @threading Not thread-safe; mutates instance state.
+     * @memory Does not allocate.
      */
     void initialize() {
         // Initialize for Q22/Shrek

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -28,7 +28,7 @@ package com.github.mrgarbagegamer;
  * </p>
  * 
  * <p>
- * Since this puzzle has a known solution in 10 clicks, the method includes the solution in commented
+ * Since this puzzle has a known solution in 15 clicks, the method includes the solution in commented
  * out form. These clicks can be uncommented to test lower click counts, and they are pre-computed
  * to avoid unnecessary recalculations during initialization.
  * </p>

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -33,14 +33,14 @@ package com.github.mrgarbagegamer;
  * to avoid unnecessary recalculations during initialization.
  * </p>
  * 
- * @since 2025.03.29 - Concrete Class Introduction
- * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
- *            Grid22 to avoid concurrency issues.
- * @performance O(1) for initialization, as it involves direct assignments without loops or complex
- *              calculations.
- * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
  * @see Grid13
  * @see Grid35
+ * @since 2025.03.29 - Concrete Class Introduction
+ * @performance O(1) for initialization, as it involves direct assignments without loops or complex
+ *              calculations.
+ * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
+ *            Grid22 to avoid concurrency issues.
+ * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
  */
 public class Grid22 extends Grid {   
     /**
@@ -60,8 +60,8 @@ public class Grid22 extends Grid {
      * avoid unnecessary recalculations during initialization.
      * </p>
      * 
-     * @since 2025.03.29 - Concrete Class Introduction
      * @see #getGridState()
+     * @since 2025.03.29 - Concrete Class Introduction
      */
     void initialize() {
         // Initialize for Q22/Shrek

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -1,24 +1,48 @@
 package com.github.mrgarbagegamer;
 
 /**
- * Grid22 - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * Grid22 - Concrete Grid Implementation for Q22/Shrek
  * 
- * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * <p>
+ * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q22
+ * of 2018 (also known as "Shrek"). It extends the abstract {@link Grid} class, providing a
+ * specific implementation for the puzzle's starting state.
+ * </p>
  * 
  * <h2>Configuration Details</h2>
- * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * <p>
+ * In this configuration, the grid is initialized with a total of 50 true cells, with the first true
+ * cell located at bit index 1 (row 0, column 1). The grid's state is represented using two long
+ * values in the {@link #gridState} array, where each bit corresponds to a cell in the hexagonal
+ * grid. The specific bit pattern for this configuration is pre-computed and directly assigned in the {@link #initialize()} method.
+ * </p>
  * 
  * <h2>Initialization Strategy</h2>
- * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * <p>
+ * The {@link #initialize()} method sets up the grid's initial state by directly assigning
+ * pre-computed values to the {@link #gridState} array. This approach avoids the need for
+ * recalculating the grid state during initialization, which can be computationally expensive. The
+ * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
+ * initial configuration, and marks the {@link #recalculationNeeded} flag as false, indicating that
+ * no further recalculation is necessary at this point.
+ * </p>
  * 
- * <h3>1/2 - 50% of documentation completed</h3>
+ * <p>
+ * Since this puzzle has a known solution in 10 clicks, the method includes the solution in commented
+ * out form. These clicks can be uncommented to test lower click counts, and they are pre-computed
+ * to avoid unnecessary recalculations during initialization.
+ * </p>
  * 
- * @algorithm [If complex initialization logic is involved]
- * @since [When this configuration was introduced]
- * @see [Related configuration classes]
+ * @since 2025.03.29 - Concrete Class Introduction
+ * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
+ *            Grid22 to avoid concurrency issues.
+ * @performance O(1) for initialization, as it involves direct assignments without loops or complex
+ *              calculations.
+ * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
+ * @see Grid13
+ * @see Grid35
  */
-public class Grid22 extends Grid 
-{   
+public class Grid22 extends Grid {   
     /**
      * Initializes the grid to the specific configuration for Q22/Shrek.
      * 

--- a/src/main/java/com/github/mrgarbagegamer/Grid22.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid22.java
@@ -11,7 +11,7 @@ package com.github.mrgarbagegamer;
  * <h2>Initialization Strategy</h2>
  * <p>[How values are computed/determined. Pre-computation rationale.]</p>
  * 
- * <h3>0/2 - 0% of documentation completed</h3>
+ * <h3>1/2 - 50% of documentation completed</h3>
  * 
  * @algorithm [If complex initialization logic is involved]
  * @since [When this configuration was introduced]
@@ -19,8 +19,27 @@ package com.github.mrgarbagegamer;
  */
 public class Grid22 extends Grid 
 {   
-    void initialize() 
-    {
+    /**
+     * Initializes the grid to the specific configuration for Q22/Shrek.
+     * 
+     * <p>
+     * This method sets the initial state of the grid, directly assigning pre-computed
+     * values to the {@link #gridState} array. The proper values for {@link #firstTrueCell}
+     * and {@link #trueCellsCount} are also set to reflect the initial configuration, and
+     * the {@link #recalculationNeeded} flag is set to false, indicating that no further
+     * recalculation is necessary at this point.
+     * </p>
+     * 
+     * <p>
+     * Commented out are the clicks that make up the solution to the Q22 puzzle, which
+     * can be uncommented to test lower click counts. These clicks are pre-computed to
+     * avoid unnecessary recalculations during initialization.
+     * </p>
+     * 
+     * @since 2025.03.29 - Concrete Class Introduction
+     * @see #getGridState()
+     */
+    void initialize() {
         // Initialize for Q22/Shrek
 
         // set all cells to their initial state

--- a/src/main/java/com/github/mrgarbagegamer/Grid35.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid35.java
@@ -1,7 +1,7 @@
 package com.github.mrgarbagegamer;
 
 /**
- * Grid35 - Concrete Grid Implementation for Q35/Buttercup
+ * A concrete {@code Grid} implementation for Q35/Buttercup.
  * 
  * <p>
  * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q35
@@ -11,10 +11,11 @@ package com.github.mrgarbagegamer;
  * 
  * <h2>Configuration Details</h2>
  * <p>
- * In this configuration, the grid is initialized with a total of 4 true cells, with the first true
- * cell located at bit index 39 (row 2, column 8). The grid's state is represented using two long
- * values in the {@link #gridState} array, where each bit corresponds to a cell in the hexagonal
- * grid. The specific bit pattern for this configuration is pre-computed and directly assigned in the {@link #initialize()} method.
+ * In this configuration, the grid is initialized with a total of 4 {@code true} cells, with the
+ * first {@code true} cell located at bit index 39 (row 2, column 8). The grid's state is
+ * represented using two {@code long} values in the {@link #gridState} array, where each bit
+ * corresponds to a cell in the hexagonal grid. The specific bit pattern for this configuration is
+ * pre-computed and directly assigned in the {@link #initialize()} method.
  * </p>
  * 
  * <h2>Initialization Strategy</h2>
@@ -23,8 +24,8 @@ package com.github.mrgarbagegamer;
  * pre-computed values to the {@link #gridState} array. This approach avoids the need for
  * recalculating the grid state during initialization, which can be computationally expensive. The
  * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
- * initial configuration, and marks the {@link #recalculationNeeded} flag as false, indicating that
- * no further recalculation is necessary at this point.
+ * initial configuration, and marks the {@link #recalculationNeeded} flag as {@code false},
+ * indicating that no further recalculation is necessary at this point.
  * </p>
  * 
  * <p>
@@ -34,8 +35,8 @@ package com.github.mrgarbagegamer;
  * @see Grid13
  * @see Grid22
  * @since 2025.03.29 - Concrete Class Introduction
- * @performance O(1) for initialization, as it involves direct assignments without loops or complex
- *              calculations.
+ * @performance {@code O(1)} for initialization, as it involves direct assignments without loops or
+ *              complex calculations.
  * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
  *            Grid35 to avoid concurrency issues.
  * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
@@ -45,10 +46,10 @@ public class Grid35 extends Grid {
      * Initializes the grid to the specific configuration for Q35/Buttercup.
      * 
      * <p>
-     * This method sets the initial state of the grid, directly assigning pre-computed
-     * values to the {@link #gridState} array. The proper values for {@link #firstTrueCell}
-     * and {@link #trueCellsCount} are also set to reflect the initial configuration, and
-     * the {@link #recalculationNeeded} flag is set to false, indicating that no further
+     * This method sets the initial state of the grid, directly assigning pre-computed values to the
+     * {@link #gridState} array. The proper values for {@link #firstTrueCell} and
+     * {@link #trueCellsCount} are also set to reflect the initial configuration, and the
+     * {@link #recalculationNeeded} flag is set to {@code false}, indicating that no further
      * recalculation is necessary at this point.
      * </p>
      * 

--- a/src/main/java/com/github/mrgarbagegamer/Grid35.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid35.java
@@ -1,5 +1,22 @@
 package com.github.mrgarbagegamer;
 
+/**
+ * Grid35 - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * 
+ * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * 
+ * <h2>Configuration Details</h2>
+ * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * 
+ * <h2>Initialization Strategy</h2>
+ * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * 
+ * <h3>0/2 - 0% of documentation completed</h3>
+ * 
+ * @algorithm [If complex initialization logic is involved]
+ * @since [When this configuration was introduced]
+ * @see [Related configuration classes]
+ */
 public class Grid35 extends Grid 
 {   
     void initialize() 

--- a/src/main/java/com/github/mrgarbagegamer/Grid35.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid35.java
@@ -1,24 +1,46 @@
 package com.github.mrgarbagegamer;
 
 /**
- * Grid35 - [Configuration Purpose - e.g., "Q35 puzzle initial state"]
+ * Grid35 - Concrete Grid Implementation for Q35/Buttercup
  * 
- * <p>[What this configuration represents and why it exists as a separate class.]</p>
+ * <p>
+ * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q35
+ * of 2018 (also known as "Buttercup"). It extends the abstract {@link Grid} class, providing a
+ * specific implementation for the puzzle's starting state.
+ * </p>
  * 
  * <h2>Configuration Details</h2>
- * <p>[Specific configuration values and their meaning in the domain context.]</p>
+ * <p>
+ * In this configuration, the grid is initialized with a total of 4 true cells, with the first true
+ * cell located at bit index 39 (row 2, column 8). The grid's state is represented using two long
+ * values in the {@link #gridState} array, where each bit corresponds to a cell in the hexagonal
+ * grid. The specific bit pattern for this configuration is pre-computed and directly assigned in the {@link #initialize()} method.
+ * </p>
  * 
  * <h2>Initialization Strategy</h2>
- * <p>[How values are computed/determined. Pre-computation rationale.]</p>
+ * <p>
+ * The {@link #initialize()} method sets up the grid's initial state by directly assigning
+ * pre-computed values to the {@link #gridState} array. This approach avoids the need for
+ * recalculating the grid state during initialization, which can be computationally expensive. The
+ * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
+ * initial configuration, and marks the {@link #recalculationNeeded} flag as false, indicating that
+ * no further recalculation is necessary at this point.
+ * </p>
  * 
- * <h3>1/2 - 50% of documentation completed</h3>
+ * <p>
+ * Since the solution for Q35 is not known, there are no pre-computed solution clicks included.
+ * </p>
  * 
- * @algorithm [If complex initialization logic is involved]
- * @since [When this configuration was introduced]
- * @see [Related configuration classes]
+ * @since 2025.03.29 - Concrete Class Introduction
+ * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
+ *            Grid35 to avoid concurrency issues.
+ * @performance O(1) for initialization, as it involves direct assignments without loops or complex
+ *              calculations.
+ * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
+ * @see Grid13
+ * @see Grid22
  */
-public class Grid35 extends Grid 
-{   
+public class Grid35 extends Grid {   
     /**
      * Initializes the grid to the specific configuration for Q35/Buttercup.
      * 

--- a/src/main/java/com/github/mrgarbagegamer/Grid35.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid35.java
@@ -1,64 +1,56 @@
 package com.github.mrgarbagegamer;
 
 /**
- * A concrete {@code Grid} implementation for Q35/Buttercup.
- * 
+ * A concrete {@link Grid} that provides the initial puzzle state for Q35 ("Buttercup").
+ *
  * <p>
- * This class represents the initial configuration of the hexagonal Lights Out puzzle in PDC's Q35
- * of 2018 (also known as "Buttercup"). It extends the abstract {@link Grid} class, providing a
- * specific implementation for the puzzle's starting state.
+ * This class defines the starting configuration for the 2018 PDC Q35 puzzle. Its sole purpose is to
+ * load a pre-computed bitmask representing the initial layout of {@code true} cells into the
+ * {@link #gridState} array. This puzzle is notable as its solution is currently unknown.
  * </p>
- * 
- * <h2>Configuration Details</h2>
+ *
+ * <h2>Architectural Role</h2>
  * <p>
- * In this configuration, the grid is initialized with a total of 4 {@code true} cells, with the
- * first {@code true} cell located at bit index 39 (row 2, column 8). The grid's state is
- * represented using two {@code long} values in the {@link #gridState} array, where each bit
- * corresponds to a cell in the hexagonal grid. The specific bit pattern for this configuration is
- * pre-computed and directly assigned in the {@link #initialize()} method.
+ * As a concrete implementation of the abstract {@link Grid}, this class represents one of the
+ * specific problems the solver is designed to tackle. The initial state is loaded via the
+ * {@link #initialize()} method, which uses a hardcoded bitmask for maximum performance, avoiding
+ * any computational overhead at runtime.
  * </p>
- * 
- * <h2>Initialization Strategy</h2>
+ *
+ * <h2>Puzzle Details</h2>
  * <p>
- * The {@link #initialize()} method sets up the grid's initial state by directly assigning
- * pre-computed values to the {@link #gridState} array. This approach avoids the need for
- * recalculating the grid state during initialization, which can be computationally expensive. The
- * method also sets the {@link #firstTrueCell} and {@link #trueCellsCount} fields to reflect the
- * initial configuration, and marks the {@link #recalculationNeeded} flag as {@code false},
- * indicating that no further recalculation is necessary at this point.
+ * The Q35 grid is initialized with only 4 {@code true} cells. Unlike Q13 and Q22, no solution is
+ * known, making it the primary target for the brute-force solver.
  * </p>
- * 
- * <p>
- * Since the solution for Q35 is not known, there are no pre-computed solution clicks included.
- * </p>
- * 
+ *
  * @see Grid13
  * @see Grid22
- * @since 2025.03.29 - Concrete Class Introduction
- * @performance {@code O(1)} for initialization, as it involves direct assignments without loops or
- *              complex calculations.
+ * @since 2025.03 - Concrete Class Introduction
+ * @performance {@code O(1)} for initialization and most operations.
  * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
- *            Grid35 to avoid concurrency issues.
- * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
+ *            {@code Grid35} to avoid concurrency issues.
+ * @memory No allocations after initialization (except for methods that explicitly create new
+ *         objects).
  */
 public class Grid35 extends Grid {   
     /**
-     * Initializes the grid to the specific configuration for Q35/Buttercup.
-     * 
+     * Loads the pre-computed state for the Q35 puzzle.
+     *
      * <p>
-     * This method sets the initial state of the grid, directly assigning pre-computed values to the
-     * {@link #gridState} array. The proper values for {@link #firstTrueCell} and
-     * {@link #trueCellsCount} are also set to reflect the initial configuration, and the
-     * {@link #recalculationNeeded} flag is set to {@code false}, indicating that no further
-     * recalculation is necessary at this point.
+     * This method directly assigns the bitmask representing the puzzle's initial state to the
+     * {@link #gridState} array. It also sets cached values for the first {@code true} cell and the
+     * total count of {@code true} cells for efficient processing.
      * </p>
-     * 
+     *
      * <p>
-     * Since the solution for Q35 is not known, there are no pre-computed solution clicks included.
+     * As the solution for Q35 is not known, no solution clicks are included.
      * </p>
-     * 
+     *
      * @see #getGridState()
-     * @since 2025.03.29 - Concrete Class Introduction
+     * @since 2025.03 - Concrete Class Introduction
+     * @performance {@code O(1)} - Direct assignment of pre-computed values.
+     * @threading Not thread-safe; mutates instance state.
+     * @memory Does not allocate.
      */
     void initialize() {
         // Initialize for Q35

--- a/src/main/java/com/github/mrgarbagegamer/Grid35.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid35.java
@@ -31,14 +31,14 @@ package com.github.mrgarbagegamer;
  * Since the solution for Q35 is not known, there are no pre-computed solution clicks included.
  * </p>
  * 
- * @since 2025.03.29 - Concrete Class Introduction
- * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
- *            Grid35 to avoid concurrency issues.
- * @performance O(1) for initialization, as it involves direct assignments without loops or complex
- *              calculations.
- * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
  * @see Grid13
  * @see Grid22
+ * @since 2025.03.29 - Concrete Class Introduction
+ * @performance O(1) for initialization, as it involves direct assignments without loops or complex
+ *              calculations.
+ * @threading This class is <b>not</b> thread-safe. Each thread should use its own instance of
+ *            Grid35 to avoid concurrency issues.
+ * @memory Minimal additional memory usage, only storing the grid state and a few metadata fields.
  */
 public class Grid35 extends Grid {   
     /**
@@ -56,8 +56,8 @@ public class Grid35 extends Grid {
      * Since the solution for Q35 is not known, there are no pre-computed solution clicks included.
      * </p>
      * 
-     * @since 2025.03.29 - Concrete Class Introduction
      * @see #getGridState()
+     * @since 2025.03.29 - Concrete Class Introduction
      */
     void initialize() {
         // Initialize for Q35

--- a/src/main/java/com/github/mrgarbagegamer/Grid35.java
+++ b/src/main/java/com/github/mrgarbagegamer/Grid35.java
@@ -11,7 +11,7 @@ package com.github.mrgarbagegamer;
  * <h2>Initialization Strategy</h2>
  * <p>[How values are computed/determined. Pre-computation rationale.]</p>
  * 
- * <h3>0/2 - 0% of documentation completed</h3>
+ * <h3>1/2 - 50% of documentation completed</h3>
  * 
  * @algorithm [If complex initialization logic is involved]
  * @since [When this configuration was introduced]
@@ -19,8 +19,25 @@ package com.github.mrgarbagegamer;
  */
 public class Grid35 extends Grid 
 {   
-    void initialize() 
-    {
+    /**
+     * Initializes the grid to the specific configuration for Q35/Buttercup.
+     * 
+     * <p>
+     * This method sets the initial state of the grid, directly assigning pre-computed
+     * values to the {@link #gridState} array. The proper values for {@link #firstTrueCell}
+     * and {@link #trueCellsCount} are also set to reflect the initial configuration, and
+     * the {@link #recalculationNeeded} flag is set to false, indicating that no further
+     * recalculation is necessary at this point.
+     * </p>
+     * 
+     * <p>
+     * Since the solution for Q35 is not known, there are no pre-computed solution clicks included.
+     * </p>
+     * 
+     * @since 2025.03.29 - Concrete Class Introduction
+     * @see #getGridState()
+     */
+    void initialize() {
         // Initialize for Q35
 
         // set all cells to their initial state

--- a/src/main/java/com/github/mrgarbagegamer/GridType.java
+++ b/src/main/java/com/github/mrgarbagegamer/GridType.java
@@ -1,8 +1,0 @@
-package com.github.mrgarbagegamer;
-
-public enum GridType 
-{
-    GRID13,
-    GRID22,
-    GRID35
-}

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -6,260 +6,169 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * The main class to orchestrate the Lights Out puzzle solver.
- * 
+ * The main application entry point and orchestrator for the Lights Out puzzle solver.
+ *
  * <p>
- * Our architecture for solving this problem involves a producer-consumer model where we have
- * {@link TestClickCombination "monkeys"} (workers) that test combinations of clicks on a Lights Out
- * grid and {@link CombinationGeneratorTask generators} that produce these combinations. The main
- * class is responsible for initializing the {@link Grid grids}, starting the generators and
- * monkeys, and coordinating their activities.
+ * This class is responsible for initializing and coordinating the entire puzzle-solving process. It
+ * sets up a producer-consumer architecture where {@link CombinationGeneratorTask generators} act as
+ * producers, generating potential solutions, and {@link TestClickCombination "monkeys"} act as
+ * consumers, validating them.
  * </p>
- * 
+ *
  * <h2>Architecture Role</h2>
  * <p>
- * All of the main orchestration logic is contained within this class. It sets up the environment,
- * manages the lifecycle of threads, and handles the overall flow of the program. The
- * {@link #main(String[]) main method} serves as the entry point to the application and spawns the
- * {@link java.util.concurrent.ForkJoinPool ForkJoinPool} for the generators, starts the
- * {@link CombinationQueueArray queues} for inter-thread communication, and launches the monkeys,
- * blocking until all tasks are complete or the solution is found.
+ * The {@link #main(String[])} method serves as the central hub, performing the following key tasks:
  * </p>
- * 
- * <h2>Performance Characteristics</h2>
+ * <ul>
+ * <li>Parses command-line arguments for {@code numClicks}, {@code numThreads}, and
+ * {@code puzzleNumber}.</li>
+ * <li>Instantiates the correct {@link Grid} implementation (e.g., {@link Grid35}) for the selected
+ * puzzle.</li>
+ * <li>Initializes the {@link CombinationQueueArray}, the communication backbone for distributing
+ * work.</li>
+ * <li>Configures and starts a {@link ForkJoinPool} for the recursive generators.</li>
+ * <li>Launches a pool of monkeys.</li>
+ * <li>Manages the application lifecycle, from submitting the initial root task to gracefully
+ * shutting down and reporting results.</li>
+ * </ul>
+ *
+ * <h2>Performance and Threading</h2>
  * <p>
- * Since this class primarily handles orchestration and thread management, its performance impact is
- * minimal compared to the computational work done by the generators and monkeys. The main method
- * itself runs in approximately constant time complexity, as it involves a fixed number of
- * operations regardless of input size. The overall performance of the application is more
- * significantly influenced by the efficiency of the combination generation and testing algorithms
- * implemented in the other classes.
+ * The orchestration logic within this class has a minimal performance footprint (effectively
+ * {@code O(1)}), as the computational heavy lifting is delegated to the generator and worker
+ * threads. The main thread's primary role is setup, coordination, and shutdown.
  * </p>
- * 
- * <h2>Thread Safety</h2>
+ *
  * <p>
- * Since this class is primarily responsible for initialization and managing the lifecycle of other
- * threads, it is designed to be mostly single-threaded in its operations. After spawning the
- * monkeys and generators, it waits for their completion by
- * {@link java.util.concurrent.ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask) invoking} a
- * {@link CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask.GeneratorContext)
- * blocking root task}, and then {@link Thread#join() joining} each monkey thread, ensuring that the
- * main thread does not proceed until computation is complete (and ensuring that the runtime thread
- * count is at most the number of threads specified at startup).
+ * Orchestration is single-threaded. The main thread blocks after submitting the root generation
+ * task and subsequently {@link Thread#join() joins} all worker threads, ensuring a clean shutdown
+ * and accurate result reporting. This makes it the ideal location for initializing {@code static},
+ * shared resources before the concurrent phase begins.
  * </p>
- * 
- * <p>
- * Static methods meant for pre-computed values are best called in this class, as it is
- * single-threaded for most of its operations. Methods that set {@code static} values for other
- * classes are also safe to call here.
- * </p>
- * 
- * @see CombinationGeneratorTask
- * @see CombinationQueueArray
- * @see Grid
- * @see TestClickCombination
- * @since 2025.04.01 - Multi-threaded Refactor
- * @performance ~{@code O(1)} for orchestration tasks
- * @threading Thread-safe due to single-threaded orchestration.
- * @algorithm Parses the command-line arguments, initializes the grid, starts the generator and
- *            monkey threads, and coordinates their activities until a solution is found or all
- *            combinations are exhausted.
+ *
+ * @since 2025.04 - Multi-threaded Refactor
+ * @performance ~{@code O(1)} for orchestration tasks.
+ * @threading Thread-safe; single-threaded orchestration.
+ * @memory Pre-allocation of shared resources to minimize runtime overhead.
  */
 public class StartYourMonkeys {
     
     /**
-     * Logger for {@code StartYourMonkeys} class.
-     * 
+     * The primary logger for the application, configured for high-performance, asynchronous logging.
+     *
      * <p>
-     * Logging is used throughout the program to provide insights into the solver's progress,
-     * performance metrics, and any issues encountered during execution. By nature, though, logging is
-     * not thread-safe, and using {@link java.io.PrintStream#println(String) System.out.println()} in a
-     * multi-threaded environment can lead to interleaved output and/or blocked threads. We need an
-     * asynchronous logging framework that can handle concurrent writes without blocking, which is why
-     * we use Log4j2.
+     * In a highly concurrent application, standard synchronous logging (like
+     * {@link java.io.PrintStream#println(String) System.out.println}) can become a major bottleneck. To
+     * avoid this, we use Log4j2 with an asynchronous configuration. This allows application threads to
+     * offload log messages to a background thread with minimal blocking, preventing logging from
+     * impacting the performance of the core solving algorithm.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Log4j2 is designed for high performance and low latency, making it suitable for multi-threaded
-     * applications like this one. It supports asynchronous logging, which allows log messages to be
-     * processed in a separate thread, reducing the impact on the main application threads.
-     * </p>
-     * 
+     *
      * @see CombinationMessage
      * @see Logger
      * @see LogManager
      * @see LogManager#getLogger()
      * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous
      *      Logging</a>
-     * @since 2025.05.04 - Log4j2 Integration
-     * @performance {@code O(1)} for logging operations, as they are buffered and processed
-     *              asynchronously.
-     * @threading This is thread-safe due to Log4j2's asynchronous logging capabilities. None-the-less,
-     *            there is only one thread that runs this main method, so the logger for this class is
-     *            effectively single-threaded.
-     * @optimization Asynchronous logging is enabled to minimize the impact on application performance.
+     * @since 2025.05 - Log4j2 Integration
+     * @performance {@code O(1)} for logging operations.
+     * @threading Thread-safe; designed for concurrent use.
+     * @memory Fixed overhead for asynchronous logging buffers.
      */
     private static final Logger logger = LogManager.getLogger();
 
     /**
-     * Default number of clicks if not specified via command-line arguments.
-     * 
+     * The default number of clicks to test for a solution.
+     *
      * <p>
-     * The goal of this solver is to find a solution to the Lights Out puzzle (Q35) using a brute-force
-     * approach. After extensive testing and analysis, we've been able to rule out the possibility of a
-     * &le; 16-click solution for Q35. Therefore, the default number of clicks is set to
-     * {@value #DEFAULT_NUM_CLICKS}, which is the minimum number of clicks that could potentially yield
-     * a solution. This default value can be overridden by providing a different number of clicks as a
-     * command-line argument when starting the program.
+     * Based on prior analysis, no solution with 16 or fewer clicks exists for the primary target, Q35.
+     * This default is set to the next logical step in the brute-force search.
      * </p>
      * 
      * @see #main(String[])
-     * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @performance {@code O(1)} - This is a constant value used for configuration.
-     * @threading This is a constant value and is inherently thread-safe.
+     * @since 2025.08 - Enhanced Documentation of Codebase
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private static final int DEFAULT_NUM_CLICKS = 17;
     /**
-     * Default number of threads if not specified via command-line arguments.
-     * 
+     * The default number of threads to use for both generators and workers.
+     *
      * <p>
-     * For my system (an Intel Core i7-13700K with 16 cores), the optimal number of threads is
-     * {@value #DEFAULT_NUM_THREADS}. This allows for efficient CPU utilization without context
-     * switching overhead. Larger numbers of threads tend to lead to diminishing returns due to
-     * increased context switching overhead and resource contention. This default value can be
-     * overridden by providing a different value at startup.
+     * This value is tuned for a high-core-count development machine (16+ cores). The application
+     * allocates half of these threads to the {@link ForkJoinPool} for the
+     * {@link CombinationGeneratorTask generators} and the other half to the {@link TestClickCombination
+     * monkeys}.
      * </p>
      * 
      * @see #main(String[])
-     * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @performance {@code O(1)} - This is a constant value used for configuration.
-     * @threading This is a constant value and is inherently thread-safe.
+     * @since 2025.08 - Enhanced Documentation of Codebase
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private static final int DEFAULT_NUM_THREADS = 16;
     /**
-     * The default question number to solve if not specified via command-line arguments.
-     * 
-     * <p>
-     * Since our program is mainly concerned with solving Q35, we set this as the default question
-     * number for convenience.
-     * </p>
+     * The default puzzle to solve, corresponding to the hardest variant (Q35).
      * 
      * @see #main(String[])
-     * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @performance {@code O(1)} - This is a constant value used for configuration.
-     * @threading This is a constant value and is inherently thread-safe.
+     * @since 2025.08 - Enhanced Documentation of Codebase
+     * @performance {@code O(1)} access time.
+     * @threading Thread-safe as a {@code static final} constant.
      */
     private static final int DEFAULT_QUESTION_NUMBER = 35;
 
     /**
-     * Main orchestration method for the Lights Out solver.
-     * 
+     * The main entry point for the solver application.
+     *
      * <p>
-     * We need an entry point to the program that can initialize the necessary components, start the
-     * {@link CombinationGeneratorTask generation} of combinations, and manage the lifecycle of the
-     * {@link TestClickCombination monkeys}. This method fulfills that role. The main method is
-     * responsible for several duties:
+     * This method orchestrates the entire solving process, from initialization to shutdown. It follows
+     * a structured sequence:
      * </p>
-     * 
      * <ol>
-     * <li>
-     * <h3>Argument Parsing and Configuration</h3></li>
+     * <li><b>Argument Parsing:</b> Reads {@code numClicks}, {@code numThreads}, and
+     * {@code puzzleNumber} from command-line arguments, with sane defaults.</li>
+     * <li><b>Component Initialization:</b> Selects the appropriate {@link Grid} subclass and
+     * initializes the {@link CombinationQueueArray} and other shared resources.</li>
+     * <li><b>Monkey Creation:</b> Spawns a pool of {@link TestClickCombination} threads that
+     * immediately begin waiting for work.</li>
+     * <li><b>Generator Execution:</b> Creates a {@link ForkJoinPool} and submits a root
+     * {@link CombinationGeneratorTask}. The main thread blocks using
+     * {@link ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask)}, waiting for the entire generation
+     * process (including all forked subtasks) to complete or for a solution to be found.</li>
+     * <li><b>Graceful Shutdown:</b> Once generation finishes, it
+     * {@link CombinationGeneratorTask#flushAllPendingBatches(CombinationQueueArray, ForkJoinPool)
+     * flushes any remaining work} from generator-local batches,
+     * {@link CombinationQueueArray#generatorFinished() signals} to the workers that no more work is
+     * coming, and waits for them to terminate using {@link Thread#join()}.</li>
+     * <li><b>Result Reporting:</b> Reports the outcome (solution found or not found), verifies the
+     * solution if one exists, and {@link #formatElapsedTime(long) logs the total elapsed time} before
+     * shutting down the {@link #logger}.</li>
+     * </ol>
+     *
+     * <h3>ForkJoinPool Behavior</h3>
      * <p>
-     * The method parses command-line arguments to determine the number of clicks, the number of
-     * threads, and the question number to solve, providing default values if not specified. We also get
-     * the current time in milliseconds to measure the elapsed time for the entire execution of the
-     * program (stored as a {@code long}). Note that the number of threads passed to the program is the
-     * TOTAL; an equal number of generator threads and monkeys are created to balance the workload.
+     * A key decision was to use {@code invoke()} to block the main thread. Early prototypes using
+     * non-blocking approaches with
+     * {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)} proved unreliable, as
+     * {@code awaitQuiescence} did not consistently wait for dynamically forked subtasks to complete.
+     * The current blocking approach provides a robust and predictable mechanism for managing the
+     * generator lifecycle.
      * </p>
-     * 
-     * <li>
-     * <h3>Grid Selection and Initialization</h3></li>
-     * <p>
-     * We use the question number to select the appropriate concrete implementation of the {@link Grid}
-     * class, which represents the puzzle grid to be solved.
-     * </p>
-     * 
-     * <li>
-     * <h3>True Adjacents Calculation</h3></li>
-     * <p>
-     * The method calculates the first true adjacents in {@link Grid.ValueFormat#Index Index} format,
-     * which is used to determine the index of the first {@code true} adjacent cell. This is crucial for
-     * the combination generation process, as it defines the range of indices that the first click in a
-     * {@code prefix} can take.
-     * </p>
-     * 
-     * <li>
-     * <h3>Monkey Creation and Startup</h3></li>
-     * <p>
-     * The method creates and starts the specified number of {@link TestClickCombination monkeys}, each
-     * responsible for consuming click combinations from a shared queue and testing them against the
-     * puzzle {@link Grid grid}. Each monkey is assigned a unique thread name for identification and is
-     * given a {@link CombinationQueue queue}.
-     * </p>
-     * 
-     * <li>
-     * <h3>ForkJoinPool Setup and Coordination</h3></li>
-     * <p>
-     * The method sets up a {@link ForkJoinPool} to manage the generation of click combinations. It
-     * submits the root task of the {@link CombinationGeneratorTask} to the pool, which will recursively
-     * generate subtasks for each possible index that the first click can take on. Notably, we use the
-     * {@link ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask)} method to submit the root task,
-     * which blocks the main thread until all its subtasks are completed.
-     * </p>
-     * 
-     * <p>
-     * Due to some weird {@code ForkJoinPool} mechanics, the
-     * {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)} method only waits for
-     * completion of the root task to finish and does not wait for tasks that are forked from it. If the
-     * method behaved like it should, we would be able to avoid creating a separate path for the root
-     * task in generation, but that world is not reality (for some reason). This approach ends up being
-     * the best compromise for our program.
-     * </p>
-     * 
-     * <li>
-     * <h3>Batch Flushing Coordination</h3></li>
-     * <p>
-     * Since the {@link CombinationGeneratorTask generators} hold onto their {@link WorkBatch batches}
-     * until they are full before flushing them to the queue, we need to ensure that any remaining
-     * batches are flushed if the generators exit without a solution being found. This is done by
-     * calling the {@code static} method
-     * {@link CombinationGeneratorTask#flushAllPendingBatches(CombinationQueueArray, ForkJoinPool)}.
-     * Afterwards, we mark the generation as complete to signal to the monkeys that no more batches will
-     * be generated.
-     * </p>
-     * 
-     * <li>
-     * <h3>Thread Synchronization and Cleanup</h3></li>
-     * <p>
-     * After the generation is complete, the method waits for all monkey threads to finish by calling
-     * {@link Thread#join()} on each monkey. This ensures that all threads have completed their work and
-     * allows for the proper cleanup of resources. To be safe, we also explicitly shut down the
-     * generator pool to release any resources it holds.
-     * </p>
-     * 
-     * <li>
-     * <h3>Result Processing and Output</h3></li>
-     * <p>
-     * Finally, the method retrieves the {@link CombinationQueueArray#getWinningCombination() winning
-     * combination} from the queue (if it exists) and {@link #formatElapsedTime(long) formats the
-     * elapsed time} for display. It then logs the winning combination and the elapsed time using the
-     * logger. If no solution is found, it logs that information instead. We also verify the solution's
-     * correctness by applying the winning combination to a clone of the original grid and checking if
-     * it results in a solved state. The grid is printed to the console for visual verification.
-     * </p>
-     * 
+     *
      * @param args Command-line arguments:
      *             <ul>
-     *             <li>{@code args[0]} - Number of clicks (default: 17)</li>
-     *             <li>{@code args[1]} - Number of threads (default: 8)</li>
-     *             <li>{@code args[2]} - Question number (default: 35)</li>
+     *             <li>{@code args[0]}: Number of clicks to test (e.g., 17).</li>
+     *             <li>{@code args[1]}: Total number of threads to use (e.g., 16).</li>
+     *             <li>{@code args[2]}: The puzzle ID to solve (13, 22, or 35).</li>
      *             </ul>
-     * @throws IllegalArgumentException if the number of clicks is not between 1 and 109, the number of
-     *                                  threads is less than 1, or the question number is not one of the
-     *                                  valid options (13, 22, or 35).
+     * @throws IllegalArgumentException if any command-line arguments are invalid.
      * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask.GeneratorContext)
-     * @since 2025.04.01 - Multi-threaded Refactor
+     * @since 2025.04 - Multi-threaded Refactor
+     * @performance ~{@code O(1)} for most orchestration tasks.
+     * @threading Single-threaded for most of orchestration, coordinating multiple threads.
+     * @memory Pre-allocates several shared resources to minimize runtime overhead.
      */
     public static void main(String[] args) {
         long startTime = System.currentTimeMillis(); // Start timer
@@ -430,22 +339,19 @@ public class StartYourMonkeys {
     }
 
     /**
-     * Formats elapsed time in milliseconds to a human-readable {@link java.lang.String string} in the
-     * form "Xh Ym Zs Wms".
-     * 
-     * <p>
-     * This method takes a duration in milliseconds and converts it into a more human-readable format,
-     * breaking it down into hours, minutes, seconds, and milliseconds. This is useful for displaying
-     * the total time taken for the solver to find a solution or exhaust all possibilities at the end of
-     * the program's execution.
-     * </p>
-     * 
-     * @param millis Elapsed time in milliseconds.
-     * @return A {@link java.lang.String String} representing the formatted elapsed time.
+     * {@link String#format(String, Object...) Formats} a millisecond duration into a human-readable "Xh
+     * Ym Zs Wms" string.
+     *
+     * @param millis The elapsed time in milliseconds.
+     * @return A formatted {@link String} representing the duration.
      * @see System#currentTimeMillis()
-     * @since 2025.06.29 - Millisecond Precision to Elapsed Time Formatting
+     * @see StringBuilder
+     * @see StringBuilder#toString()
+     * @since 2025.06 - Millisecond Precision to Elapsed Time Formatting
      * @performance {@code O(1)} operations and string formatting.
-     * @threading This method is thread-safe as it does not modify any shared state.
+     * @threading Thread-safe; does not modify shared state.
+     * @memory Allocates a small, fixed-size {@link StringBuilder} for formatting and returns a new
+     *         {@link String}.
      */
     private static String formatElapsedTime(long millis) {
         long seconds = millis / 1000;

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -5,6 +5,32 @@ import java.util.concurrent.ForkJoinPool;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * StartYourMonkeys - [Primary Purpose in Algorithm]
+ * 
+ * <p>[Detailed description of role in the overall puzzle-solving architecture.
+ * Explain the "what" and "why" - what problem this class solves and why this 
+ * approach was chosen.]</p>
+ * 
+ * <h2>Architecture Role</h2>
+ * <p>[How this class fits into the overall system. What classes depend on it,
+ * what it depends on, and the data flow.]</p>
+ * 
+ * <h2>Performance Characteristics</h2>
+ * <p>[Key performance properties, bottlenecks, and optimization strategies.
+ * Include complexity analysis for critical methods.]</p>
+ * 
+ * <h2>Thread Safety</h2>
+ * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * 
+ * <h3>0/7 - 0% of documentation completed</h3>
+ * 
+ * @performance [Overall performance characteristics]
+ * @threading [Thread safety guarantees]  
+ * @algorithm [High-level algorithm description]
+ * @since [Version when introduced/major changes]
+ * @see [Related classes in the architecture]
+ */
 public class StartYourMonkeys 
 {
     // Add a logger at the top of the class

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -54,8 +54,6 @@ import org.apache.logging.log4j.Logger;
  * also safe to call here.
  * </p>
  * 
- * <h3>6/7 - ~85.7% of documentation completed</h3>
- * 
  * @threading Thread-safe due to single-threaded orchestration.
  * @performance ~O(1) for orchestration tasks
  * @algorithm Parses the command-line arguments, initializes the grid, starts the generator and
@@ -67,8 +65,7 @@ import org.apache.logging.log4j.Logger;
  * @see Grid
  * @see TestClickCombination
  */
-public class StartYourMonkeys 
-{
+public class StartYourMonkeys {
     
     /**
      * Logger for StartYourMonkeys class.
@@ -426,8 +423,25 @@ public class StartYourMonkeys
         LogManager.shutdown();
     }
 
-    private static String formatElapsedTime(long millis) 
-    {
+    /**
+     * Formats elapsed time in milliseconds to a human-readable {@link java.lang.String string} in the
+     * form "Xh Ym Zs Wms".
+     * 
+     * <p>
+     * This method takes a duration in milliseconds and converts it into a more human-readable format,
+     * breaking it down into hours, minutes, seconds, and milliseconds. This is useful for displaying
+     * the total time taken for the solver to find a solution or exhaust all possibilities at the end of
+     * the program's execution.
+     * </p>
+     * 
+     * @param millis Elapsed time in milliseconds.
+     * @return A {@link java.lang.String String} representing the formatted elapsed time.
+     * @since 2025.06.29 - Millisecond Precision to Elapsed Time Formatting
+     * @threading This method is thread-safe as it does not modify any shared state.
+     * @performance O(1) operations and string formatting.
+     * @see System#currentTimeMillis()
+     */
+    private static String formatElapsedTime(long millis) {
         long seconds = millis / 1000;
         long minutes = seconds / 60;
         long hours = minutes / 60;

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -6,30 +6,66 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * StartYourMonkeys - [Primary Purpose in Algorithm]
+ * StartYourMonkeys - Main class to orchestrate the Lights Out puzzle solver.
  * 
- * <p>[Detailed description of role in the overall puzzle-solving architecture.
- * Explain the "what" and "why" - what problem this class solves and why this 
- * approach was chosen.]</p>
+ * <p>
+ * Our architecture for solving this problem involves a producer-consumer model where we have
+ * {@link TestClickCombination "monkeys"} (workers) that test combinations of clicks on a Lights Out
+ * grid and {@link CombinationGeneratorTask generators} that produce these combinations. The main
+ * class is responsible for initializing the {@link Grid grids}, starting the generators and
+ * monkeys, and coordinating their activities.
+ * </p>
  * 
  * <h2>Architecture Role</h2>
- * <p>[How this class fits into the overall system. What classes depend on it,
- * what it depends on, and the data flow.]</p>
+ * <p>
+ * All of the main orchestration logic is contained within this class. It sets up the environment,
+ * manages the lifecycle of threads, and handles the overall flow of the program. The
+ * {@link #main(String[]) main method} serves as the entry point to the application and spawns the
+ * {@link java.util.concurrent.ForkJoinPool ForkJoinPool} for the generators, starts the
+ * {@link CombinationQueueArray queues} for inter-thread communication, and launches the monkeys,
+ * blocking until all tasks are complete or the solution is found.
+ * </p>
  * 
  * <h2>Performance Characteristics</h2>
- * <p>[Key performance properties, bottlenecks, and optimization strategies.
- * Include complexity analysis for critical methods.]</p>
+ * <p>
+ * Since this class primarily handles orchestration and thread management, its performance impact is
+ * minimal compared to the computational work done by the generators and monkeys. The main method
+ * itself runs in approximately constant time complexity, as it involves a fixed number of
+ * operations regardless of input size. The overall performance of the application is more
+ * significantly influenced by the efficiency of the combination generation and testing algorithms
+ * implemented in the other classes.
+ * </p>
  * 
  * <h2>Thread Safety</h2>
- * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
+ * <p>
+ * Since this class is primarily responsible for initialization and managing the lifecycle of other
+ * threads, it is designed to be mostly single-threaded in its operations. After spawning the
+ * monkeys and generators, it waits for their completion by
+ * {@link java.util.concurrent.ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask) invoking} a
+ * {@link CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask.GeneratorContext)
+ * blocking root task}, and then {@link Thread#join() joining} each monkey thread, ensuring that the
+ * main thread does not proceed until computation is complete (and ensuring that the runtime thread
+ * count is at most the number of threads specified at startup).
+ * </p>
  * 
- * <h3>2/7 - ~28.5% of documentation completed</h3>
+ * <p>
+ * Static methods meant for pre-computed values are best called in this class, as it is
+ * single-threaded for most of its operations. Methods that set static values for other classes are
+ * also safe to call here.
+ * </p>
  * 
- * @performance [Overall performance characteristics]
- * @threading [Thread safety guarantees]  
- * @algorithm [High-level algorithm description]
- * @since [Version when introduced/major changes]
- * @see [Related classes in the architecture]
+ * <h3>6/7 - ~85.7% of documentation completed</h3>
+ * 
+ * @threading Thread-safe due to single-threaded orchestration.
+ * @performance ~O(1) for orchestration tasks
+ * @algorithm Parses the command-line arguments, initializes the grid, starts the generator and
+ *            monkey threads, and coordinates their activities until a solution is found or all
+ *            combinations are exhausted.
+ * @since 2025.04.01 - Multi-threaded Refactor
+ * @see CombinationGeneratorTask
+ * @see CombinationQueueArray
+ * @see Grid
+ * @see TestClickCombination
  */
 public class StartYourMonkeys 
 {
@@ -65,8 +101,54 @@ public class StartYourMonkeys
      */
     private static final Logger logger = LogManager.getLogger();
 
+    /**
+     * Default number of clicks if not specified via command-line arguments.
+     * 
+     * <p>
+     * The goal of this solver is to find a solution to the Lights Out puzzle (Q35) using a brute-force
+     * approach. After extensive testing and analysis, we've been able to rule out the possibility of a
+     * &le; 16-click solution for Q35. Therefore, the default number of clicks is set to 17, which is the
+     * minimum number of clicks that could potentially yield a solution. This default value can be
+     * overridden by providing a different number of clicks as a command-line argument when starting the
+     * program.
+     * </p>
+     * 
+     * @since 2025.08.16 - Enhanced Documentation of Codebase
+     * @threading This is a constant value and is inherently thread-safe.
+     * @performance O(1) - This is a constant value used for configuration.
+     * @see #main(String[])
+     */
     private static final int DEFAULT_NUM_CLICKS = 17;
-    private static final int DEFAULT_NUM_THREADS = 8;
+    /**
+     * Default number of threads if not specified via command-line arguments.
+     * 
+     * <p>
+     * For my system (an Intel Core i7-13700K with 16 cores), the optimal number of threads is
+     * 16. This allows for efficient CPU utilization without context switching overhead. Larger
+     * numbers of threads tend to lead to diminishing returns due to increased context switching
+     * overhead and resource contention. This default value can be overridden by providing a different
+     * value at startup.
+     * </p>
+     * 
+     * @since 2025.08.16 - Enhanced Documentation of Codebase
+     * @threading This is a constant value and is inherently thread-safe.
+     * @performance O(1) - This is a constant value used for configuration.
+     * @see #main(String[])
+     */
+    private static final int DEFAULT_NUM_THREADS = 16;
+    /**
+     * The default question number to solve if not specified via command-line arguments.
+     * 
+     * <p>
+     * Since our program is mainly concerned with solving Q35, we set this as the default question
+     * number for convenience.
+     * </p>
+     * 
+     * @since 2025.08.16 - Enhanced Documentation of Codebase
+     * @threading This is a constant value and is inherently thread-safe.
+     * @performance O(1) - This is a constant value used for configuration.
+     * @see #main(String[])
+     */
     private static final int DEFAULT_QUESTION_NUMBER = 35;
 
     /**
@@ -174,7 +256,7 @@ public class StartYourMonkeys
      * @throws IllegalArgumentException if the number of clicks is not between 1 and 109, the number of
      *                                  threads is less than 1, or the question number is not one of the
      *                                  valid options (13, 22, or 35).
-     * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask#GeneratorContext)
+     * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask.GeneratorContext)
      */
     public static void main(String[] args) {
         long startTime = System.currentTimeMillis(); // Start timer

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * StartYourMonkeys - Main class to orchestrate the Lights Out puzzle solver.
+ * The main class to orchestrate the Lights Out puzzle solver.
  * 
  * <p>
  * Our architecture for solving this problem involves a producer-consumer model where we have
@@ -50,8 +50,8 @@ import org.apache.logging.log4j.Logger;
  * 
  * <p>
  * Static methods meant for pre-computed values are best called in this class, as it is
- * single-threaded for most of its operations. Methods that set static values for other classes are
- * also safe to call here.
+ * single-threaded for most of its operations. Methods that set {@code static} values for other
+ * classes are also safe to call here.
  * </p>
  * 
  * @see CombinationGeneratorTask
@@ -59,7 +59,7 @@ import org.apache.logging.log4j.Logger;
  * @see Grid
  * @see TestClickCombination
  * @since 2025.04.01 - Multi-threaded Refactor
- * @performance ~O(1) for orchestration tasks
+ * @performance ~{@code O(1)} for orchestration tasks
  * @threading Thread-safe due to single-threaded orchestration.
  * @algorithm Parses the command-line arguments, initializes the grid, starts the generator and
  *            monkey threads, and coordinates their activities until a solution is found or all
@@ -68,32 +68,36 @@ import org.apache.logging.log4j.Logger;
 public class StartYourMonkeys {
     
     /**
-     * Logger for StartYourMonkeys class.
+     * Logger for {@code StartYourMonkeys} class.
      * 
      * <p>
      * Logging is used throughout the program to provide insights into the solver's progress,
-     * performance metrics, and any issues encountered during execution. By nature, though, logging
-     * is not thread-safe, and using System.out.println() in a multi-threaded environment can lead to
-     * interleaved output and/or blocked threads. We need an asynchronous logging framework
-     * that can handle concurrent writes without blocking, which is why we use Log4j2.
+     * performance metrics, and any issues encountered during execution. By nature, though, logging is
+     * not thread-safe, and using {@link java.io.PrintStream#println(String) System.out.println()} in a
+     * multi-threaded environment can lead to interleaved output and/or blocked threads. We need an
+     * asynchronous logging framework that can handle concurrent writes without blocking, which is why
+     * we use Log4j2.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Log4j2 is designed for high performance and low latency, making it suitable for
-     * multi-threaded applications like this one. It supports asynchronous logging,
-     * which allows log messages to be processed in a separate thread, reducing the
-     * impact on the main application threads.
+     * Log4j2 is designed for high performance and low latency, making it suitable for multi-threaded
+     * applications like this one. It supports asynchronous logging, which allows log messages to be
+     * processed in a separate thread, reducing the impact on the main application threads.
      * </p>
      * 
      * @see CombinationMessage
      * @see Logger
      * @see LogManager
      * @see LogManager#getLogger()
-     * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous Logging</a>
+     * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous
+     *      Logging</a>
      * @since 2025.05.04 - Log4j2 Integration
-     * @performance O(1) for logging operations, as they are buffered and processed asynchronously.
-     * @threading This is thread-safe due to Log4j2's asynchronous logging capabilities. None-the-less, there is only one thread that runs this main method, so the logger for this class is effectively single-threaded.
+     * @performance {@code O(1)} for logging operations, as they are buffered and processed
+     *              asynchronously.
+     * @threading This is thread-safe due to Log4j2's asynchronous logging capabilities. None-the-less,
+     *            there is only one thread that runs this main method, so the logger for this class is
+     *            effectively single-threaded.
      * @optimization Asynchronous logging is enabled to minimize the impact on application performance.
      */
     private static final Logger logger = LogManager.getLogger();
@@ -104,15 +108,15 @@ public class StartYourMonkeys {
      * <p>
      * The goal of this solver is to find a solution to the Lights Out puzzle (Q35) using a brute-force
      * approach. After extensive testing and analysis, we've been able to rule out the possibility of a
-     * &le; 16-click solution for Q35. Therefore, the default number of clicks is set to 17, which is the
-     * minimum number of clicks that could potentially yield a solution. This default value can be
-     * overridden by providing a different number of clicks as a command-line argument when starting the
-     * program.
+     * &le; 16-click solution for Q35. Therefore, the default number of clicks is set to
+     * {@value #DEFAULT_NUM_CLICKS}, which is the minimum number of clicks that could potentially yield
+     * a solution. This default value can be overridden by providing a different number of clicks as a
+     * command-line argument when starting the program.
      * </p>
      * 
      * @see #main(String[])
      * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @performance O(1) - This is a constant value used for configuration.
+     * @performance {@code O(1)} - This is a constant value used for configuration.
      * @threading This is a constant value and is inherently thread-safe.
      */
     private static final int DEFAULT_NUM_CLICKS = 17;
@@ -121,15 +125,15 @@ public class StartYourMonkeys {
      * 
      * <p>
      * For my system (an Intel Core i7-13700K with 16 cores), the optimal number of threads is
-     * 16. This allows for efficient CPU utilization without context switching overhead. Larger
-     * numbers of threads tend to lead to diminishing returns due to increased context switching
-     * overhead and resource contention. This default value can be overridden by providing a different
-     * value at startup.
+     * {@value #DEFAULT_NUM_THREADS}. This allows for efficient CPU utilization without context
+     * switching overhead. Larger numbers of threads tend to lead to diminishing returns due to
+     * increased context switching overhead and resource contention. This default value can be
+     * overridden by providing a different value at startup.
      * </p>
      * 
      * @see #main(String[])
      * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @performance O(1) - This is a constant value used for configuration.
+     * @performance {@code O(1)} - This is a constant value used for configuration.
      * @threading This is a constant value and is inherently thread-safe.
      */
     private static final int DEFAULT_NUM_THREADS = 16;
@@ -143,7 +147,7 @@ public class StartYourMonkeys {
      * 
      * @see #main(String[])
      * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @performance O(1) - This is a constant value used for configuration.
+     * @performance {@code O(1)} - This is a constant value used for configuration.
      * @threading This is a constant value and is inherently thread-safe.
      */
     private static final int DEFAULT_QUESTION_NUMBER = 35;
@@ -165,8 +169,8 @@ public class StartYourMonkeys {
      * The method parses command-line arguments to determine the number of clicks, the number of
      * threads, and the question number to solve, providing default values if not specified. We also get
      * the current time in milliseconds to measure the elapsed time for the entire execution of the
-     * program (stored as a long). Note that the number of threads passed to the program is the TOTAL;
-     * an equal number of generator threads and monkeys are created to balance the workload.
+     * program (stored as a {@code long}). Note that the number of threads passed to the program is the
+     * TOTAL; an equal number of generator threads and monkeys are created to balance the workload.
      * </p>
      * 
      * <li>
@@ -179,9 +183,10 @@ public class StartYourMonkeys {
      * <li>
      * <h3>True Adjacents Calculation</h3></li>
      * <p>
-     * The method calculates the first true adjacents in index format, which is used to determine the
-     * index of the first true adjacent cell. This is crucial for the combination generation process, as
-     * it defines the range of indices that the first click in a prefix can take.
+     * The method calculates the first true adjacents in {@link Grid.ValueFormat#Index Index} format,
+     * which is used to determine the index of the first {@code true} adjacent cell. This is crucial for
+     * the combination generation process, as it defines the range of indices that the first click in a
+     * {@code prefix} can take.
      * </p>
      * 
      * <li>
@@ -189,8 +194,8 @@ public class StartYourMonkeys {
      * <p>
      * The method creates and starts the specified number of {@link TestClickCombination monkeys}, each
      * responsible for consuming click combinations from a shared queue and testing them against the
-     * puzzle grid. Each monkey is assigned a unique thread name for identification and is given a
-     * {@link CombinationQueue queue}.
+     * puzzle {@link Grid grid}. Each monkey is assigned a unique thread name for identification and is
+     * given a {@link CombinationQueue queue}.
      * </p>
      * 
      * <li>
@@ -204,7 +209,7 @@ public class StartYourMonkeys {
      * </p>
      * 
      * <p>
-     * Due to some weird ForkJoinPool mechanics, the
+     * Due to some weird {@code ForkJoinPool} mechanics, the
      * {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)} method only waits for
      * completion of the root task to finish and does not wait for tasks that are forked from it. If the
      * method behaved like it should, we would be able to avoid creating a separate path for the root
@@ -218,7 +223,7 @@ public class StartYourMonkeys {
      * Since the {@link CombinationGeneratorTask generators} hold onto their {@link WorkBatch batches}
      * until they are full before flushing them to the queue, we need to ensure that any remaining
      * batches are flushed if the generators exit without a solution being found. This is done by
-     * calling the static method
+     * calling the {@code static} method
      * {@link CombinationGeneratorTask#flushAllPendingBatches(CombinationQueueArray, ForkJoinPool)}.
      * Afterwards, we mark the generation as complete to signal to the monkeys that no more batches will
      * be generated.
@@ -236,8 +241,9 @@ public class StartYourMonkeys {
      * <li>
      * <h3>Result Processing and Output</h3></li>
      * <p>
-     * Finally, the method retrieves the winning combination from the queue (if it exists) and formats
-     * the elapsed time for display. It then logs the winning combination and the elapsed time using the
+     * Finally, the method retrieves the {@link CombinationQueueArray#getWinningCombination() winning
+     * combination} from the queue (if it exists) and {@link #formatElapsedTime(long) formats the
+     * elapsed time} for display. It then logs the winning combination and the elapsed time using the
      * logger. If no solution is found, it logs that information instead. We also verify the solution's
      * correctness by applying the winning combination to a clone of the original grid and checking if
      * it results in a solved state. The grid is printed to the console for visual verification.
@@ -245,15 +251,15 @@ public class StartYourMonkeys {
      * 
      * @param args Command-line arguments:
      *             <ul>
-     *             <li><code>args[0]</code> - Number of clicks (default: 17)</li>
-     *             <li><code>args[1]</code> - Number of threads (default: 8)</li>
-     *             <li><code>args[2]</code> - Question number (default: 35)</li>
+     *             <li>{@code args[0]} - Number of clicks (default: 17)</li>
+     *             <li>{@code args[1]} - Number of threads (default: 8)</li>
+     *             <li>{@code args[2]} - Question number (default: 35)</li>
      *             </ul>
      * @throws IllegalArgumentException if the number of clicks is not between 1 and 109, the number of
      *                                  threads is less than 1, or the question number is not one of the
      *                                  valid options (13, 22, or 35).
-     * @throws NumberFormatException    if the arguments cannot be parsed as integers.
      * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask.GeneratorContext)
+     * @since 2025.04.01 - Multi-threaded Refactor
      */
     public static void main(String[] args) {
         long startTime = System.currentTimeMillis(); // Start timer
@@ -438,7 +444,7 @@ public class StartYourMonkeys {
      * @return A {@link java.lang.String String} representing the formatted elapsed time.
      * @see System#currentTimeMillis()
      * @since 2025.06.29 - Millisecond Precision to Elapsed Time Formatting
-     * @performance O(1) operations and string formatting.
+     * @performance {@code O(1)} operations and string formatting.
      * @threading This method is thread-safe as it does not modify any shared state.
      */
     private static String formatElapsedTime(long millis) {

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>1/7 - 14% of documentation completed</h3>
+ * <h3>2/7 - ~28.5% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]  
@@ -69,8 +69,114 @@ public class StartYourMonkeys
     private static final int DEFAULT_NUM_THREADS = 8;
     private static final int DEFAULT_QUESTION_NUMBER = 35;
 
-    public static void main(String[] args) 
-    {
+    /**
+     * Main orchestration method for the Lights Out solver.
+     * 
+     * <p>
+     * We need an entry point to the program that can initialize the necessary components, start the
+     * {@link CombinationGeneratorTask generation} of combinations, and manage the lifecycle of the
+     * {@link TestClickCombination monkeys}. This method fulfills that role. The main method is
+     * responsible for several duties:
+     * </p>
+     * 
+     * <ol>
+     * <li>
+     * <h3>Argument Parsing and Configuration</h3></li>
+     * <p>
+     * The method parses command-line arguments to determine the number of clicks, the number of
+     * threads, and the question number to solve, providing default values if not specified. We also get
+     * the current time in milliseconds to measure the elapsed time for the entire execution of the
+     * program (stored as a long). Note that the number of threads passed to the program is the TOTAL;
+     * an equal number of generator threads and monkeys are created to balance the workload.
+     * </p>
+     * 
+     * <li>
+     * <h3>Grid Selection and Initialization</h3></li>
+     * <p>
+     * We use the question number to select the appropriate concrete implementation of the {@link Grid}
+     * class, which represents the puzzle grid to be solved.
+     * </p>
+     * 
+     * <li>
+     * <h3>True Adjacents Calculation</h3></li>
+     * <p>
+     * The method calculates the first true adjacents in index format, which is used to determine the
+     * index of the first true adjacent cell. This is crucial for the combination generation process, as
+     * it defines the range of indices that the first click in a prefix can take.
+     * </p>
+     * 
+     * <li>
+     * <h3>Monkey Creation and Startup</h3></li>
+     * <p>
+     * The method creates and starts the specified number of {@link TestClickCombination monkeys}, each
+     * responsible for consuming click combinations from a shared queue and testing them against the
+     * puzzle grid. Each monkey is assigned a unique thread name for identification and is given a
+     * {@link CombinationQueue queue}.
+     * </p>
+     * 
+     * <li>
+     * <h3>ForkJoinPool Setup and Coordination</h3></li>
+     * <p>
+     * The method sets up a {@link ForkJoinPool} to manage the generation of click combinations. It
+     * submits the root task of the {@link CombinationGeneratorTask} to the pool, which will recursively
+     * generate subtasks for each possible index that the first click can take on. Notably, we use the
+     * {@link ForkJoinPool#invoke(java.util.concurrent.ForkJoinTask)} method to submit the root task,
+     * which blocks the main thread until all its subtasks are completed.
+     * </p>
+     * 
+     * <p>
+     * Due to some weird ForkJoinPool mechanics, the
+     * {@link ForkJoinPool#awaitQuiescence(long, java.util.concurrent.TimeUnit)} method only waits for
+     * completion of the root task to finish and does not wait for tasks that are forked from it. If the
+     * method behaved like it should, we would be able to avoid creating a separate path for the root
+     * task in generation, but that world is not reality (for some reason). This approach ends up being
+     * the best compromise for our program.
+     * </p>
+     * 
+     * <li>
+     * <h3>Batch Flushing Coordination</h3></li>
+     * <p>
+     * Since the {@link CombinationGeneratorTask generators} hold onto their {@link WorkBatch batches}
+     * until they are full before flushing them to the queue, we need to ensure that any remaining
+     * batches are flushed if the generators exit without a solution being found. This is done by
+     * calling the static method
+     * {@link CombinationGeneratorTask#flushAllPendingBatches(CombinationQueueArray, ForkJoinPool)}.
+     * Afterwards, we mark the generation as complete to signal to the monkeys that no more batches will
+     * be generated.
+     * </p>
+     * 
+     * <li>
+     * <h3>Thread Synchronization and Cleanup</h3></li>
+     * <p>
+     * After the generation is complete, the method waits for all monkey threads to finish by calling
+     * {@link Thread#join()} on each monkey. This ensures that all threads have completed their work and
+     * allows for the proper cleanup of resources. To be safe, we also explicitly shut down the
+     * generator pool to release any resources it holds.
+     * </p>
+     * 
+     * <li>
+     * <h3>Result Processing and Output</h3></li>
+     * <p>
+     * Finally, the method retrieves the winning combination from the queue (if it exists) and formats
+     * the elapsed time for display. It then logs the winning combination and the elapsed time using the
+     * logger. If no solution is found, it logs that information instead. We also verify the solution's
+     * correctness by applying the winning combination to a clone of the original grid and checking if
+     * it results in a solved state. The grid is printed to the console for visual verification.
+     * </p>
+     * 
+     * @param args Command-line arguments:
+     *             <ul>
+     *             <li><code>args[0]</code> - Number of clicks (default: 17)</li>
+     *             <li><code>args[1]</code> - Number of threads (default: 8)</li>
+     *             <li><code>args[2]</code> - Question number (default: 35)</li>
+     *             </ul>
+     * @throws NumberFormatException    if the arguments cannot be parsed as integers.
+     * @throws IllegalArgumentException if the number of clicks is not between 1 and 109, the number of
+     *                                  threads is less than 1, or the question number is not one of the
+     *                                  valid options (13, 22, or 35).
+     * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask#GeneratorContext)
+     */
+    public static void main(String[] args) {
         long startTime = System.currentTimeMillis(); // Start timer
 
         int parsedNumClicks  = DEFAULT_NUM_CLICKS;
@@ -86,6 +192,20 @@ public class StartYourMonkeys
         } catch (Exception e) 
         {
             // Keep defaults
+        }
+
+        // Exception handling for invalid arguments
+        if (parsedNumClicks < 1 || parsedNumClicks > 109) 
+        {
+            throw new IllegalArgumentException("Number of clicks must be between 1 and 109 (inclusive).");
+        }
+        if (parsedNumThreads < 1) 
+        {
+            throw new IllegalArgumentException("Number of threads must be greater than 0.");
+        }
+        if (parsedQuestionNumber != 13 && parsedQuestionNumber != 22 && parsedQuestionNumber != 35) 
+        {
+            throw new IllegalArgumentException("Invalid question number. Must be one of: 13, 22, or 35.");
         }
 
         final int numClicks = parsedNumClicks;
@@ -121,16 +241,16 @@ public class StartYourMonkeys
             }
         }
 
-        int numGeneratorThreads = numThreads;
+        final int numGeneratorThreads = numThreads / 2;
 
         // Tell the queue how many generators we have on startup (since we will be using ForkJoinPool, there is effectively only one thread generating combinations)
         WorkBatch.setNumClicks(numClicks);
-        CombinationQueueArray queueArray = new CombinationQueueArray(numThreads, 1);
+        CombinationQueueArray queueArray = new CombinationQueueArray(numGeneratorThreads, 1);
         short[] trueCells = baseGrid.findTrueCells();
 
         // Start consumer threads BEFORE generation
-        TestClickCombination[] monkeys = new TestClickCombination[numThreads];
-        for(int i = 0; i < numThreads; i++)
+        TestClickCombination[] monkeys = new TestClickCombination[numGeneratorThreads];
+        for(int i = 0; i < numGeneratorThreads; i++)
         {
             String threadName = String.format("Monkey-%d", i);
             monkeys[i] = new TestClickCombination(threadName, queueArray.getQueue(i), queueArray, baseGrid.clone());

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -54,16 +54,16 @@ import org.apache.logging.log4j.Logger;
  * also safe to call here.
  * </p>
  * 
- * @threading Thread-safe due to single-threaded orchestration.
- * @performance ~O(1) for orchestration tasks
- * @algorithm Parses the command-line arguments, initializes the grid, starts the generator and
- *            monkey threads, and coordinates their activities until a solution is found or all
- *            combinations are exhausted.
- * @since 2025.04.01 - Multi-threaded Refactor
  * @see CombinationGeneratorTask
  * @see CombinationQueueArray
  * @see Grid
  * @see TestClickCombination
+ * @since 2025.04.01 - Multi-threaded Refactor
+ * @performance ~O(1) for orchestration tasks
+ * @threading Thread-safe due to single-threaded orchestration.
+ * @algorithm Parses the command-line arguments, initializes the grid, starts the generator and
+ *            monkey threads, and coordinates their activities until a solution is found or all
+ *            combinations are exhausted.
  */
 public class StartYourMonkeys {
     
@@ -86,15 +86,15 @@ public class StartYourMonkeys {
      * impact on the main application threads.
      * </p>
      * 
-     * @since 2025.05.04 - Log4j2 Integration
-     * @threading This is thread-safe due to Log4j2's asynchronous logging capabilities. None-the-less, there is only one thread that runs this main method, so the logger for this class is effectively single-threaded.
-     * @performance O(1) for logging operations, as they are buffered and processed asynchronously.
-     * @optimization Asynchronous logging is enabled to minimize the impact on application performance.
      * @see CombinationMessage
      * @see Logger
      * @see LogManager
      * @see LogManager#getLogger()
      * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous Logging</a>
+     * @since 2025.05.04 - Log4j2 Integration
+     * @performance O(1) for logging operations, as they are buffered and processed asynchronously.
+     * @threading This is thread-safe due to Log4j2's asynchronous logging capabilities. None-the-less, there is only one thread that runs this main method, so the logger for this class is effectively single-threaded.
+     * @optimization Asynchronous logging is enabled to minimize the impact on application performance.
      */
     private static final Logger logger = LogManager.getLogger();
 
@@ -110,10 +110,10 @@ public class StartYourMonkeys {
      * program.
      * </p>
      * 
-     * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @threading This is a constant value and is inherently thread-safe.
-     * @performance O(1) - This is a constant value used for configuration.
      * @see #main(String[])
+     * @since 2025.08.16 - Enhanced Documentation of Codebase
+     * @performance O(1) - This is a constant value used for configuration.
+     * @threading This is a constant value and is inherently thread-safe.
      */
     private static final int DEFAULT_NUM_CLICKS = 17;
     /**
@@ -127,10 +127,10 @@ public class StartYourMonkeys {
      * value at startup.
      * </p>
      * 
-     * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @threading This is a constant value and is inherently thread-safe.
-     * @performance O(1) - This is a constant value used for configuration.
      * @see #main(String[])
+     * @since 2025.08.16 - Enhanced Documentation of Codebase
+     * @performance O(1) - This is a constant value used for configuration.
+     * @threading This is a constant value and is inherently thread-safe.
      */
     private static final int DEFAULT_NUM_THREADS = 16;
     /**
@@ -141,10 +141,10 @@ public class StartYourMonkeys {
      * number for convenience.
      * </p>
      * 
-     * @since 2025.08.16 - Enhanced Documentation of Codebase
-     * @threading This is a constant value and is inherently thread-safe.
-     * @performance O(1) - This is a constant value used for configuration.
      * @see #main(String[])
+     * @since 2025.08.16 - Enhanced Documentation of Codebase
+     * @performance O(1) - This is a constant value used for configuration.
+     * @threading This is a constant value and is inherently thread-safe.
      */
     private static final int DEFAULT_QUESTION_NUMBER = 35;
 
@@ -249,10 +249,10 @@ public class StartYourMonkeys {
      *             <li><code>args[1]</code> - Number of threads (default: 8)</li>
      *             <li><code>args[2]</code> - Question number (default: 35)</li>
      *             </ul>
-     * @throws NumberFormatException    if the arguments cannot be parsed as integers.
      * @throws IllegalArgumentException if the number of clicks is not between 1 and 109, the number of
      *                                  threads is less than 1, or the question number is not one of the
      *                                  valid options (13, 22, or 35).
+     * @throws NumberFormatException    if the arguments cannot be parsed as integers.
      * @see CombinationGeneratorTask#computeRootSubtasks(CombinationGeneratorTask.GeneratorContext)
      */
     public static void main(String[] args) {
@@ -436,10 +436,10 @@ public class StartYourMonkeys {
      * 
      * @param millis Elapsed time in milliseconds.
      * @return A {@link java.lang.String String} representing the formatted elapsed time.
-     * @since 2025.06.29 - Millisecond Precision to Elapsed Time Formatting
-     * @threading This method is thread-safe as it does not modify any shared state.
-     * @performance O(1) operations and string formatting.
      * @see System#currentTimeMillis()
+     * @since 2025.06.29 - Millisecond Precision to Elapsed Time Formatting
+     * @performance O(1) operations and string formatting.
+     * @threading This method is thread-safe as it does not modify any shared state.
      */
     private static String formatElapsedTime(long millis) {
         long seconds = millis / 1000;

--- a/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
+++ b/src/main/java/com/github/mrgarbagegamer/StartYourMonkeys.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
  * <h2>Thread Safety</h2>
  * <p>[Concurrency model, synchronization approach, and usage patterns.]</p>
  * 
- * <h3>0/7 - 0% of documentation completed</h3>
+ * <h3>1/7 - 14% of documentation completed</h3>
  * 
  * @performance [Overall performance characteristics]
  * @threading [Thread safety guarantees]  
@@ -33,20 +33,49 @@ import org.apache.logging.log4j.Logger;
  */
 public class StartYourMonkeys 
 {
-    // Add a logger at the top of the class
-    private static final Logger logger = LogManager.getLogger(StartYourMonkeys.class);
+    
+    /**
+     * Logger for StartYourMonkeys class.
+     * 
+     * <p>
+     * Logging is used throughout the program to provide insights into the solver's progress,
+     * performance metrics, and any issues encountered during execution. By nature, though, logging
+     * is not thread-safe, and using System.out.println() in a multi-threaded environment can lead to
+     * interleaved output and/or blocked threads. We need an asynchronous logging framework
+     * that can handle concurrent writes without blocking, which is why we use Log4j2.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Log4j2 is designed for high performance and low latency, making it suitable for
+     * multi-threaded applications like this one. It supports asynchronous logging,
+     * which allows log messages to be processed in a separate thread, reducing the
+     * impact on the main application threads.
+     * </p>
+     * 
+     * @since 2025.05.04 - Log4j2 Integration
+     * @threading This is thread-safe due to Log4j2's asynchronous logging capabilities. None-the-less, there is only one thread that runs this main method, so the logger for this class is effectively single-threaded.
+     * @performance O(1) for logging operations, as they are buffered and processed asynchronously.
+     * @optimization Asynchronous logging is enabled to minimize the impact on application performance.
+     * @see CombinationMessage
+     * @see Logger
+     * @see LogManager
+     * @see LogManager#getLogger()
+     * @see <a href="https://logging.apache.org/log4j/2.x/manual/async.html">Log4j2 Asynchronous Logging</a>
+     */
+    private static final Logger logger = LogManager.getLogger();
+
+    private static final int DEFAULT_NUM_CLICKS = 17;
+    private static final int DEFAULT_NUM_THREADS = 8;
+    private static final int DEFAULT_QUESTION_NUMBER = 35;
 
     public static void main(String[] args) 
     {
         long startTime = System.currentTimeMillis(); // Start timer
 
-        int defaultNumClicks  = 10;
-        int defaultNumThreads = 8;
-        int defaultQuestionNumber = 35;
-
-        int parsedNumClicks  = defaultNumClicks;
-        int parsedNumThreads = defaultNumThreads;
-        int parsedQuestionNumber = defaultQuestionNumber;
+        int parsedNumClicks  = DEFAULT_NUM_CLICKS;
+        int parsedNumThreads = DEFAULT_NUM_THREADS;
+        int parsedQuestionNumber = DEFAULT_QUESTION_NUMBER;
 
         // retrieve the arguments if any or set a default value
         try 

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -1,63 +1,48 @@
 package com.github.mrgarbagegamer;
 
 /**
- * A high performance pool for pre-allocated {@link CombinationGeneratorTask} instances.
- * 
+ * A non-thread-safe, high-performance object pool for recycling {@link CombinationGeneratorTask}
+ * instances.
+ *
+ * <h2>Architectural Role</h2>
  * <p>
- * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
- * deallocations (GC) are expensive operations that can significantly impact performance, especially
- * in high-throughput or low-latency applications. By reusing objects through pooling mechanisms, we
- * can minimize the overhead associated with frequent allocations and deallocations, leading to more
- * efficient memory usage and improved application performance. This class implements a simple
- * object pool for {@link CombinationGeneratorTask} instances, allowing for the reuse of these
- * objects instead of creating new ones each time they are needed.
+ * In the {@link java.util.concurrent.ForkJoinPool ForkJoinPool} architecture used by this solver,
+ * thousands of {@link CombinationGeneratorTask} objects are created for recursive sub-problems.
+ * Allocating a new task for each fork operation creates immense pressure on the garbage collector,
+ * becoming a significant performance bottleneck.
  * </p>
  * 
- * <h2>Optimization Strategy</h2>
  * <p>
- * This pool uses a circular buffer to manage the pre-allocated tasks, allowing for {@code O(1)}
- * time complexity for both {@link #get()} and {@link #put(CombinationGeneratorTask)} operations.
- * The pool is initialized with a fixed capacity, and tasks are reused as they are returned to the
- * pool after use. This approach minimizes memory allocations and helps to reduce GC pressure,
- * leading to better performance in scenarios where tasks are frequently created and destroyed.
+ * This class provides a simple and efficient solution by implementing an object pool. Instead of
+ * creating new tasks, generator threads acquire pre-allocated tasks from the pool and return them
+ * after use. This strategy drastically reduces allocation rates and GC overhead.
  * </p>
- * 
- * <h2>Usage Patterns</h2>
+ *
+ * <h2>Implementation Details</h2>
  * <p>
- * This class should be used in scenarios where {@link CombinationGeneratorTask} instances are
- * frequently created and destroyed, such as in multi-threaded combination generation tasks. Each
- * thread should have its own instance of TaskPool to avoid concurrency issues, as this class is not
- * thread-safe. Tasks should be obtained from the pool using {@link #get()} and returned to the pool
- * using {@link #put(CombinationGeneratorTask)} when they are no longer needed. Do not retain a
- * reference to a task after returning to the pool, since another thread could obtain it via
- * stealing.
+ * The pool is implemented as a simple, {@link #arrays array-backed} circular buffer, which provides
+ * {@code O(1)} time complexity for both {@link #get()} and {@link #put(CombinationGeneratorTask)}
+ * operations.
  * </p>
- * 
- * <h2>Memory Management</h2>
+ *
+ * <h2>Thread Safety</h2>
  * <p>
- * The pool pre-allocates a fixed number of tasks at construction time, which helps to minimize
- * runtime allocations. The size of the pool should be chosen based on the expected workload and
- * memory constraints of the application. If the pool is exhausted (i.e., all tasks are in use), the
- * {@link #get()} method will create and return a new task, though this should be avoided where
- * possible.
+ * This class is <strong>not</strong> thread-safe. It is designed to be used within a
+ * {@link ThreadLocal} context, where each {@link CombinationGeneratorTask} thread owns its
+ * exclusive instance of the pool. This design avoids the need for synchronization, maximizing
+ * performance in the hot path.
  * </p>
- * 
+ *
  * @see ArrayPool
  * @see WorkBatch
- * @since 2025.07.11 - {@code TaskPool} Introduction
- * @performance The pool uses a circular buffer to achieve {@code O(1)} time complexity for both get
- *              and put operations. Pre-allocating tasks minimizes runtime allocations, reducing GC
- *              pressure and improving performance in high-throughput scenarios.
- * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
- *            {@code TaskPool} to avoid concurrency issues. Queues should be the only point of
- *            inter-thread communication.
- * @memory Pre-allocates a fixed number of tasks at construction time to minimize runtime
- *         allocations. The size of the pool should be chosen based on the expected workload and
- *         memory usage patterns of the application.
+ * @since 2025.07 - {@code TaskPool} Introduction
+ * @performance O(1) for both {@link #get()} and {@link #put(CombinationGeneratorTask)} operations.
+ * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+ * @memory Fixed memory footprint based on the {@link #capacity} specified at construction.
  */
 public class TaskPool {
     /**
-     * The array of pre-allocated tasks forming the pool. Implemented as a circular buffer.
+     * The array of pooled tasks, managed as a circular buffer.
      * 
      * @see #capacity
      * @see #head
@@ -65,13 +50,10 @@ public class TaskPool {
      * @see #tail
      * @see #get()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} time complexity for get and put operations due to circular buffer
-     *              implementation.
-     * @threading This field is <b>not</b> thread-safe. Each thread should have its own instance of
-     *            TaskPool to avoid concurrency issues.
-     * @memory Pre-allocated at {@link #TaskPool(int) construction time} to minimize runtime
-     *         allocations.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} accesses of elements in the array.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Fixed memory footprint of ~{@code capacity × 4} bytes as an array of references.
      */
     private final CombinationGeneratorTask[] arrays;
     /**
@@ -82,14 +64,14 @@ public class TaskPool {
      * @see #size
      * @see #tail
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance Constant time access.
-     * @threading This field is immutable after construction, making it inherently thread-safe.
-     * @memory Allocated once at construction time, minimal memory footprint.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} access.
+     * @threading Thread-safe as a {@code final} field.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private final int capacity;
     /**
-     * The index of the next task to be {@link #get() retrieved} from the pool.
+     * The index of the next task to be retrieved from the pool.
      * 
      * <p>
      * The head index tracks where the next available task is located in the circular {@link #arrays
@@ -115,15 +97,14 @@ public class TaskPool {
      * </p>
      * 
      * @see #capacity
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
-     * @threading This field is not thread-safe, as it is intended to be used within a single thread
-     *            context.
-     * @memory Minimal additional memory overhead (single {@code int}).
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} access.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private int head = 0;
     /**
-     * The tail index for the next {@link #put(CombinationGeneratorTask) returned} task.
+     * The index where the next returned task will be placed.
      * 
      * <p>
      * The tail index tracks where the next returned array should be placed in the circular
@@ -149,15 +130,14 @@ public class TaskPool {
      * </p>
      * 
      * @see #capacity
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
-     * @threading This field is not thread-safe, as it is intended to be used within a single thread
-     *            context.
-     * @memory Minimal additional memory overhead (single {@code int}).
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} access.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private int tail = 0;
     /**
-     * The current number of tasks in the pool.
+     * The current number of tasks available in the pool.
      * 
      * <p>
      * The {@code size} field tracks how many tasks are currently stored in the pool. It is incremented
@@ -186,28 +166,24 @@ public class TaskPool {
      * risk is minimal.
      * </p>
      * 
-     * @since 2025.07.02 - Custom Generator Pools
-     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
-     * @threading The field is not thread-safe, as it is intended to be used within a single thread
-     *            context.
-     * @memory Minimal additional memory overhead (single {@code int}).
+     * @since 2025.07 - Custom Generator Pools
+     * @performance O(1) access and updates.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
     private int size = 0;
 
     /**
-     * Constructs a {@code TaskPool} with the specified {@code capacity} and pre-allocates all tasks.
-     * 
-     * @param capacity the maximum number of tasks the pool can hold. Must be greater than 0.
-     * @throws IllegalArgumentException if capacity is less than or equal to 0.
+     * Constructs a {@code TaskPool} with the specified {@code capacity} and pre-allocates tasks.
+     *
+     * @param capacity The maximum number of tasks the pool can hold. Must be greater than 0.
+     * @throws IllegalArgumentException if capacity is not positive.
      * @see #arrays
      * @see #capacity
-     * @see #get()
-     * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(capacity)} time complexity due to pre-allocation of {@link #arrays tasks
-     *              array.}
-     * @memory Allocates memory for the specified number of tasks upfront to minimize runtime
-     *         allocations.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(capacity)} pre-allocation of tasks.
+     * @threading Thread-safe by nature of construction.
+     * @memory Allocates a {@code CombinationGeneratorTask[capacity]}.
      */
     public TaskPool(int capacity) {
         if (capacity <= 0) {
@@ -225,31 +201,31 @@ public class TaskPool {
     }
 
     /**
-     * Gets a {@link CombinationGeneratorTask} from the pool or creates a new one if the pool is empty.
+     * Retrieves a task from the pool.
      * 
      * <p>
-     * Note that, unlike {@link ArrayPool#get()}, this method will never return {@code null}. If the
-     * pool is empty, it will create and return a new task (though this should be avoided where
-     * possible).
-     * 
+     * If the pool is empty, a new {@link CombinationGeneratorTask} is created to prevent stalls rather
+     * than returning {@code null}. This fallback allocation is a performance anti-pattern and indicates
+     * that the pool may be undersized for the current workload.
+     * </p>
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * We need to ensure that the get operation is as fast as possible, as it is on the hot path of
-     * combination generation. By using a {@link #arrays circular buffer} and {@link #TaskPool(int)
-     * pre-allocating} all tasks, we can achieve an {@code O(1)} time complexity for this method. We
-     * avoid a {@code null} check on the returned task (as this should never happen if the pool is sized
-     * correctly and {@code null} tasks are never returned to the pool), which further improves
-     * performance, keeping only the {@link #size} check at the start for short-circuiting purposes. If
-     * extra performance is needed, we could remove this check as well, but this would risk causing
-     * {@code size} to go negative and allow for the return of {@code null} tasks.
+     * This operation is on the hot path of combination generation and must be extremely fast. The
+     * implementation uses a circular buffer for {@code O(1)} complexity. A {@code null} check on the
+     * retrieved task is avoided, as the pool should never contain {@code null}s if used correctly. The
+     * initial {@code size} check provides a fast path for the empty-pool case. Removing it could risk
+     * {@code size} becoming negative and returning a {@code null} task, so it is kept as a safety
+     * measure.
      * </p>
-     * 
-     * @return A {@link CombinationGeneratorTask} from the pool or a new one if the pool is empty.
+     *
+     * @return A recycled or newly created {@link CombinationGeneratorTask}.
      * @see #isEmpty()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
-     * @memory Only allocates if the pool is empty, otherwise reuses existing objects.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} time complexity.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Only allocates if the pool is empty, otherwise reuses existing tasks.
      */
     public CombinationGeneratorTask get() {
         if (size == 0)
@@ -265,29 +241,28 @@ public class TaskPool {
     }
 
     /**
-     * Returns a {@link CombinationGeneratorTask} to the {@link #tail} of the pool. Returns immediately
-     * if the pool is full or the task is {@code null}.
+     * Returns a task to the pool for recycling.
      * 
+     * <p>
+     * If the pool is full, the task is discarded and will be garbage collected. This indicates that the
+     * pool may be oversized.
+     * </p>
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * The put operation is also on the hot path, so it needs to be as fast as possible. By using a
-     * {@link #arrays circular buffer} and {@link #TaskPool(int) pre-allocating} all tasks, we can
-     * achieve {@code O(1)} performance for this operation as well. Unlike
-     * {@link ArrayPool#put(short[])}, we perform a {@code null} check on the task being returned to
-     * avoid adding {@code null} tasks to the pool, providing a safeguard against potential bugs in the
-     * calling code. This check isn't strictly necessary for performance, though, so if maximum speed is
-     * required and the calling code is trusted, it could be removed. On the other hand, the
-     * {@link #size} check is essential to prevent overfilling the pool, which could lead to memory
-     * corruption and unwanted behavior when polling tasks later.
+     * This operation is also on the hot path. A {@code null} check is performed as a safeguard against
+     * programming errors, though it could be removed in trusted-caller scenarios for a marginal speed
+     * gain. The check against {@code capacity} is essential to prevent overwriting tasks in the
+     * circular buffer, which could lead to corruption.
      * </p>
-     * 
+     *
      * @param task The {@link CombinationGeneratorTask} to return to the pool.
      * @see #size
      * @see #TaskPool(int)
      * @see #get()
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
-     * @memory Reuses existing objects, minimizing allocations.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} array access and update.
+     * @memory Does not allocate.
      */
     public void put(CombinationGeneratorTask task) {
         if (task == null || size >= capacity)
@@ -302,34 +277,32 @@ public class TaskPool {
 
     /**
      * Checks if the pool is empty.
-     * 
+     *
      * @return {@code true} if the pool is empty, {@code false} otherwise.
      * @see #size
      * @see #get()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} time complexity, as it involves a simple comparison.
-     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
-     *            thread context.
-     * @memory No additional memory usage.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} field access and comparison.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Does not allocate.
      */
     public boolean isEmpty() {
         return size == 0;
     }
 
     /**
-     * Gets the current number of tasks in the pool.
-     * 
-     * @return The current number of tasks in the pool.
+     * Returns the current number of available tasks in the pool.
+     *
+     * @return The number of tasks in the pool.
      * @see #size
      * @see #get()
      * @see #isEmpty()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - {@code TaskPool} Introduction
-     * @performance {@code O(1)} time complexity, as it involves a simple field access.
-     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
-     *            thread context.
-     * @memory No additional memory usage.
+     * @since 2025.07 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} field access.
+     * @threading Not thread-safe; intended for use in a {@link ThreadLocal} context.
+     * @memory Does not allocate.
      */
     public int size() {
         return size;

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -42,8 +42,6 @@ package com.github.mrgarbagegamer;
  * possible.
  * </p>
  * 
- * <h3>9/11 - ~81.8% of documentation completed</h3>
- * 
  * @since 2025.07.11 - TaskPool Introduction
  * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
  *            TaskPool to avoid concurrency issues. Queues should be the only point of inter-thread
@@ -57,8 +55,7 @@ package com.github.mrgarbagegamer;
  * @see ArrayPool
  * @see WorkBatch
  */
-public class TaskPool
-{
+public class TaskPool {
     /**
      * The array of pre-allocated tasks forming the pool. Implemented as a circular buffer.
      * 
@@ -290,18 +287,37 @@ public class TaskPool
     }
 
     /**
-     * Check if the pool is empty.
+     * Checks if the pool is empty.
+     * 
+     * @return <code>true</code> if the pool is empty, <code>false</code> otherwise.
+     * @since 2025.07.11 - TaskPool Introduction
+     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
+     *            thread context.
+     * @performance O(1) time complexity, as it involves a simple comparison.
+     * @memory No additional memory usage.
+     * @see #size
+     * @see #get()
+     * @see #put(CombinationGeneratorTask)
      */
-    public boolean isEmpty()
-    {
+    public boolean isEmpty() {
         return size == 0;
     }
 
     /**
-     * Get the current pool size.
+     * Gets the current number of tasks in the pool.
+     * 
+     * @return The current number of tasks in the pool.
+     * @since 2025.07.11 - TaskPool Introduction
+     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
+     *            thread context.
+     * @performance O(1) time complexity, as it involves a simple field access.
+     * @memory No additional memory usage.
+     * @see #size
+     * @see #get()
+     * @see #put(CombinationGeneratorTask)
+     * @see #isEmpty()
      */
-    public int size()
-    {
+    public int size() {
         return size;
     }
 }

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -1,7 +1,7 @@
 package com.github.mrgarbagegamer;
 
 /**
- * TaskPool - A high performance pool for pre-allocated {@link CombinationGeneratorTask} instances.
+ * A high performance pool for pre-allocated {@link CombinationGeneratorTask} instances.
  * 
  * <p>
  * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
@@ -15,11 +15,11 @@ package com.github.mrgarbagegamer;
  * 
  * <h2>Optimization Strategy</h2>
  * <p>
- * This pool uses a circular buffer to manage the pre-allocated tasks, allowing for O(1) time
- * complexity for both {@link #get()} and {@link #put(CombinationGeneratorTask)} operations. The
- * pool is initialized with a fixed capacity, and tasks are reused as they are returned to the pool
- * after use. This approach minimizes memory allocations and helps to reduce GC pressure, leading to
- * better performance in scenarios where tasks are frequently created and destroyed.
+ * This pool uses a circular buffer to manage the pre-allocated tasks, allowing for {@code O(1)}
+ * time complexity for both {@link #get()} and {@link #put(CombinationGeneratorTask)} operations.
+ * The pool is initialized with a fixed capacity, and tasks are reused as they are returned to the
+ * pool after use. This approach minimizes memory allocations and helps to reduce GC pressure,
+ * leading to better performance in scenarios where tasks are frequently created and destroyed.
  * </p>
  * 
  * <h2>Usage Patterns</h2>
@@ -44,13 +44,13 @@ package com.github.mrgarbagegamer;
  * 
  * @see ArrayPool
  * @see WorkBatch
- * @since 2025.07.11 - TaskPool Introduction
- * @performance The pool uses a circular buffer to achieve O(1) time complexity for both get and put
- *              operations. Pre-allocating tasks minimizes runtime allocations, reducing GC pressure
- *              and improving performance in high-throughput scenarios.
+ * @since 2025.07.11 - {@code TaskPool} Introduction
+ * @performance The pool uses a circular buffer to achieve {@code O(1)} time complexity for both get
+ *              and put operations. Pre-allocating tasks minimizes runtime allocations, reducing GC
+ *              pressure and improving performance in high-throughput scenarios.
  * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
- *            TaskPool to avoid concurrency issues. Queues should be the only point of inter-thread
- *            communication.
+ *            {@code TaskPool} to avoid concurrency issues. Queues should be the only point of
+ *            inter-thread communication.
  * @memory Pre-allocates a fixed number of tasks at construction time to minimize runtime
  *         allocations. The size of the pool should be chosen based on the expected workload and
  *         memory usage patterns of the application.
@@ -65,8 +65,8 @@ public class TaskPool {
      * @see #tail
      * @see #get()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) time complexity for get and put operations due to circular buffer
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} time complexity for get and put operations due to circular buffer
      *              implementation.
      * @threading This field is <b>not</b> thread-safe. Each thread should have its own instance of
      *            TaskPool to avoid concurrency issues.
@@ -82,7 +82,7 @@ public class TaskPool {
      * @see #size
      * @see #tail
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - TaskPool Introduction
+     * @since 2025.07.11 - {@code TaskPool} Introduction
      * @performance Constant time access.
      * @threading This field is immutable after construction, making it inherently thread-safe.
      * @memory Allocated once at construction time, minimal memory footprint.
@@ -100,25 +100,26 @@ public class TaskPool {
      * <h3>Performance Considerations</h3>
      * <p>
      * Using a circular buffer allows for efficient use of the pre-allocated tasks, minimizing memory
-     * usage while still allowing for fast {@link #put(CombinationGeneratorTask) put} and get
-     * operations. The head index is updated in constant time, ensuring that get operations remain
-     * efficient even as the pool fills up and empties out.
+     * usage while still allowing for fast {@link #put(CombinationGeneratorTask) put()} and
+     * {@code get()} operations. The head index is updated in constant time, ensuring that {@code get}
+     * operations remain efficient even as the pool fills up and empties out.
      * </p>
      * 
      * <p>
-     * We could use a short for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an int avoids potential overflow issues in long-running
-     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
-     * pointer for both head and {@link #tail}, but that would complicate the logic and force an extra
-     * arithmetic operation on each operation, which could impact performance.
+     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could also use a single pointer for both {@code head} and {@link #tail}, but that would
+     * complicate the logic and force an extra arithmetic operation on each operation, which could
+     * impact performance.
      * </p>
      * 
      * @see #capacity
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) for both put and get operations.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
      * @threading This field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @memory Minimal additional memory overhead (single int).
+     * @memory Minimal additional memory overhead (single {@code int}).
      */
     private int head = 0;
     /**
@@ -134,74 +135,79 @@ public class TaskPool {
      * <h3>Performance Considerations</h3>
      * <p>
      * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast put and {@link #get() get} operations. The tail index is
-     * updated in constant time, ensuring that put operations remain efficient even as the pool fills up
-     * and empties out.
+     * usage while still allowing for fast {@code put} and {@link #get() get} operations. The tail index
+     * is updated in constant time, ensuring that {@code put} operations remain efficient even as the
+     * pool fills up and empties out.
      * </p>
      * 
      * <p>
-     * We could use a short for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an int avoids potential overflow issues in long-running
-     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
-     * pointer for both {@link #head} and tail, but that would complicate the logic and force an extra
-     * arithmetic operation on each operation, which could impact performance.
+     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could also use a single pointer for both {@link #head} and tail, but that would complicate the
+     * logic and force an extra arithmetic operation on each operation, which could impact performance.
      * </p>
      * 
      * @see #capacity
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) for both put and get operations.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
      * @threading This field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @memory Minimal additional memory overhead (single int).
+     * @memory Minimal additional memory overhead (single {@code int}).
      */
     private int tail = 0;
     /**
      * The current number of tasks in the pool.
      * 
      * <p>
-     * The size field tracks how many tasks are currently stored in the pool. It is incremented each
-     * time a task is returned to the pool via {@link #put(CombinationGeneratorTask) put} and decremented each time a
-     * task is obtained from the pool via {@link #get() get}. This field is crucial for ensuring that
-     * we do not exceed the pool's {@link #capacity} and for determining if the pool is empty.
+     * The {@code size} field tracks how many tasks are currently stored in the pool. It is incremented
+     * each time a task is returned to the pool via {@link #put(CombinationGeneratorTask) put} and
+     * decremented each time a task is obtained from the pool via {@link #get() get}. This field is
+     * crucial for ensuring that we do not exceed the pool's {@link #capacity} and for determining if
+     * the pool is empty.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * The size field is updated in constant time during both put and get operations, ensuring that
-     * these operations remain efficient. It is also used to quickly check if the pool is empty (via
-     * {@link #isEmpty()}).
+     * The {@code size} field is updated in constant time during both {@code put} and get operations,
+     * ensuring that these operations remain efficient. It is also used to quickly check if the pool is
+     * empty (via {@link #isEmpty()}).
      * </p>
      * 
      * <p>
-     * We could use a short for the size to save a few bytes of memory, but the performance difference
-     * is negligible and using an int avoids potential overflow issues in long-running applications
-     * (plus, Java treats arithmetic with short values weirdly). We could avoid the size field entirely
-     * by using the {@link #head} and {@link #tail} indices to calculate the size on-the-fly (or by
-     * taking a {@link WorkBatch#remainingCapacity} approach and storing the remaining capacity), but
-     * that would complicate the logic and add extra arithmetic operations to the hot path of both put
-     * and get operations, which could impact performance. We also don't anticipate the size coming down
-     * to 0, so the deoptimization risk is minimal.
+     * We could use a {@code short} for the {@code size} to save a few bytes of memory, but the
+     * performance difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could avoid the {@code size} field entirely by using the {@link #head} and {@link #tail} indices
+     * to calculate the size on-the-fly (or by taking a {@link WorkBatch#remainingCapacity} approach and
+     * storing the remaining capacity), but that would complicate the logic and add extra arithmetic
+     * operations to the hot path of both {@code put} and {@code get} operations, which could impact
+     * performance. We also don't anticipate the {@code size} coming down to 0, so the deoptimization
+     * risk is minimal.
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
-     * @performance O(1) for both put and get operations.
+     * @performance {@code O(1)} for both {@code put} and {@code get} operations.
      * @threading The field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @memory Minimal additional memory overhead (single int).
+     * @memory Minimal additional memory overhead (single {@code int}).
      */
     private int size = 0;
 
     /**
-     * Constructs a TaskPool with the specified capacity and pre-allocates all tasks.
+     * Constructs a {@code TaskPool} with the specified {@code capacity} and pre-allocates all tasks.
+     * 
      * @param capacity the maximum number of tasks the pool can hold. Must be greater than 0.
      * @throws IllegalArgumentException if capacity is less than or equal to 0.
      * @see #arrays
      * @see #capacity
      * @see #get()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(n) time complexity due to pre-allocation of {@link #arrays tasks array.}
-     * @memory Allocates memory for the specified number of tasks upfront to minimize runtime allocations.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(capacity)} time complexity due to pre-allocation of {@link #arrays tasks
+     *              array.}
+     * @memory Allocates memory for the specified number of tasks upfront to minimize runtime
+     *         allocations.
      */
     public TaskPool(int capacity) {
         if (capacity <= 0) {
@@ -215,27 +221,27 @@ public class TaskPool {
      * Gets a {@link CombinationGeneratorTask} from the pool or creates a new one if the pool is empty.
      * 
      * <p>
-     * Note that, unlike {@link ArrayPool#get()}, this method will never return <code>null</code>. If
-     * the pool is empty, it will create and return a new task (though this should be avoided where
+     * Note that, unlike {@link ArrayPool#get()}, this method will never return {@code null}. If the
+     * pool is empty, it will create and return a new task (though this should be avoided where
      * possible).
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * We need to ensure that the get operation is as fast as possible, as it is on the hot path of
      * combination generation. By using a {@link #arrays circular buffer} and {@link #TaskPool(int)
-     * pre-allocating} all tasks, we can achieve an O(1) time complexity for this method. We avoid a
-     * null check on the returned task (as this should never happen if the pool is sized correctly and
-     * null tasks are never returned to the pool), which further improves performance, keeping only the
-     * {@link #size} check at the start for short-circuiting purposes. If extra performance is needed,
-     * we could remove this check as well, but this would risk causing <code>size</code> to go negative
-     * and allow for the return of null tasks.
+     * pre-allocating} all tasks, we can achieve an {@code O(1)} time complexity for this method. We
+     * avoid a {@code null} check on the returned task (as this should never happen if the pool is sized
+     * correctly and {@code null} tasks are never returned to the pool), which further improves
+     * performance, keeping only the {@link #size} check at the start for short-circuiting purposes. If
+     * extra performance is needed, we could remove this check as well, but this would risk causing
+     * {@code size} to go negative and allow for the return of {@code null} tasks.
      * </p>
      * 
      * @return A {@link CombinationGeneratorTask} from the pool or a new one if the pool is empty.
      * @see #isEmpty()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
      * @memory Only allocates if the pool is empty, otherwise reuses existing objects.
      */
     public CombinationGeneratorTask get() {
@@ -253,26 +259,27 @@ public class TaskPool {
 
     /**
      * Returns a {@link CombinationGeneratorTask} to the {@link #tail} of the pool. Returns immediately
-     * if the pool is full or the task is null.
+     * if the pool is full or the task is {@code null}.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * The put operation is also on the hot path, so it needs to be as fast as possible. By using a
      * {@link #arrays circular buffer} and {@link #TaskPool(int) pre-allocating} all tasks, we can
-     * achieve O(1) performance for this operation as well. Unlike {@link ArrayPool#put(short[])}, we
-     * perform a null check on the task being returned to avoid adding null tasks to the pool, providing
-     * a safeguard against potential bugs in the calling code. This check isn't strictly necessary for
-     * performance, though, so if maximum speed is required and the calling code is trusted, it could be
-     * removed. On the other hand, the {@link #size} check is essential to prevent overfilling the pool,
-     * which could lead to memory corruption and unwanted behavior when polling tasks later.
+     * achieve {@code O(1)} performance for this operation as well. Unlike
+     * {@link ArrayPool#put(short[])}, we perform a {@code null} check on the task being returned to
+     * avoid adding {@code null} tasks to the pool, providing a safeguard against potential bugs in the
+     * calling code. This check isn't strictly necessary for performance, though, so if maximum speed is
+     * required and the calling code is trusted, it could be removed. On the other hand, the
+     * {@link #size} check is essential to prevent overfilling the pool, which could lead to memory
+     * corruption and unwanted behavior when polling tasks later.
      * </p>
      * 
      * @param task The {@link CombinationGeneratorTask} to return to the pool.
      * @see #size
      * @see #TaskPool(int)
      * @see #get()
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} time complexity, as it involves simple arithmetic and array access.
      * @memory Reuses existing objects, minimizing allocations.
      */
     public void put(CombinationGeneratorTask task) {
@@ -289,12 +296,12 @@ public class TaskPool {
     /**
      * Checks if the pool is empty.
      * 
-     * @return <code>true</code> if the pool is empty, <code>false</code> otherwise.
+     * @return {@code true} if the pool is empty, {@code false} otherwise.
      * @see #size
      * @see #get()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) time complexity, as it involves a simple comparison.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} time complexity, as it involves a simple comparison.
      * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
      *            thread context.
      * @memory No additional memory usage.
@@ -311,8 +318,8 @@ public class TaskPool {
      * @see #get()
      * @see #isEmpty()
      * @see #put(CombinationGeneratorTask)
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(1) time complexity, as it involves a simple field access.
+     * @since 2025.07.11 - {@code TaskPool} Introduction
+     * @performance {@code O(1)} time complexity, as it involves a simple field access.
      * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
      *            thread context.
      * @memory No additional memory usage.

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -42,50 +42,50 @@ package com.github.mrgarbagegamer;
  * possible.
  * </p>
  * 
+ * @see ArrayPool
+ * @see WorkBatch
  * @since 2025.07.11 - TaskPool Introduction
- * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
- *            TaskPool to avoid concurrency issues. Queues should be the only point of inter-thread
- *            communication.
  * @performance The pool uses a circular buffer to achieve O(1) time complexity for both get and put
  *              operations. Pre-allocating tasks minimizes runtime allocations, reducing GC pressure
  *              and improving performance in high-throughput scenarios.
+ * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
+ *            TaskPool to avoid concurrency issues. Queues should be the only point of inter-thread
+ *            communication.
  * @memory Pre-allocates a fixed number of tasks at construction time to minimize runtime
  *         allocations. The size of the pool should be chosen based on the expected workload and
  *         memory usage patterns of the application.
- * @see ArrayPool
- * @see WorkBatch
  */
 public class TaskPool {
     /**
      * The array of pre-allocated tasks forming the pool. Implemented as a circular buffer.
      * 
-     * @since 2025.07.11 - TaskPool Introduction
-     * @threading This field is <b>not</b> thread-safe. Each thread should have its own instance of
-     *            TaskPool to avoid concurrency issues.
-     * @performance O(1) time complexity for get and put operations due to circular buffer
-     *              implementation.
-     * @memory Pre-allocated at {@link #TaskPool(int) construction time} to minimize runtime
-     *         allocations.
      * @see #capacity
      * @see #head
      * @see #size
      * @see #tail
      * @see #get()
      * @see #put(CombinationGeneratorTask)
+     * @since 2025.07.11 - TaskPool Introduction
+     * @performance O(1) time complexity for get and put operations due to circular buffer
+     *              implementation.
+     * @threading This field is <b>not</b> thread-safe. Each thread should have its own instance of
+     *            TaskPool to avoid concurrency issues.
+     * @memory Pre-allocated at {@link #TaskPool(int) construction time} to minimize runtime
+     *         allocations.
      */
     private final CombinationGeneratorTask[] arrays;
     /**
      * The maximum number of tasks the pool can hold.
      * 
-     * @since 2025.07.11 - TaskPool Introduction
-     * @threading This field is immutable after construction, making it inherently thread-safe.
-     * @performance Constant time access.
-     * @memory Allocated once at construction time, minimal memory footprint.
      * @see #arrays
      * @see #head
      * @see #size
      * @see #tail
      * @see #put(CombinationGeneratorTask)
+     * @since 2025.07.11 - TaskPool Introduction
+     * @performance Constant time access.
+     * @threading This field is immutable after construction, making it inherently thread-safe.
+     * @memory Allocated once at construction time, minimal memory footprint.
      */
     private final int capacity;
     /**
@@ -113,12 +113,12 @@ public class TaskPool {
      * arithmetic operation on each operation, which could impact performance.
      * </p>
      * 
+     * @see #capacity
      * @since 2025.07.11 - TaskPool Introduction
+     * @performance O(1) for both put and get operations.
      * @threading This field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @performance O(1) for both put and get operations.
      * @memory Minimal additional memory overhead (single int).
-     * @see #capacity
      */
     private int head = 0;
     /**
@@ -147,12 +147,12 @@ public class TaskPool {
      * arithmetic operation on each operation, which could impact performance.
      * </p>
      * 
+     * @see #capacity
      * @since 2025.07.11 - TaskPool Introduction
+     * @performance O(1) for both put and get operations.
      * @threading This field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @performance O(1) for both put and get operations.
      * @memory Minimal additional memory overhead (single int).
-     * @see #capacity
      */
     private int tail = 0;
     /**
@@ -184,9 +184,9 @@ public class TaskPool {
      * </p>
      * 
      * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) for both put and get operations.
      * @threading The field is not thread-safe, as it is intended to be used within a single thread
      *            context.
-     * @performance O(1) for both put and get operations.
      * @memory Minimal additional memory overhead (single int).
      */
     private int size = 0;
@@ -195,13 +195,13 @@ public class TaskPool {
      * Constructs a TaskPool with the specified capacity and pre-allocates all tasks.
      * @param capacity the maximum number of tasks the pool can hold. Must be greater than 0.
      * @throws IllegalArgumentException if capacity is less than or equal to 0.
-     * @since 2025.07.11 - TaskPool Introduction
-     * @performance O(n) time complexity due to pre-allocation of {@link #arrays tasks array.}
-     * @memory Allocates memory for the specified number of tasks upfront to minimize runtime allocations.
      * @see #arrays
      * @see #capacity
      * @see #get()
      * @see #put(CombinationGeneratorTask)
+     * @since 2025.07.11 - TaskPool Introduction
+     * @performance O(n) time complexity due to pre-allocation of {@link #arrays tasks array.}
+     * @memory Allocates memory for the specified number of tasks upfront to minimize runtime allocations.
      */
     public TaskPool(int capacity) {
         if (capacity <= 0) {
@@ -232,11 +232,11 @@ public class TaskPool {
      * </p>
      * 
      * @return A {@link CombinationGeneratorTask} from the pool or a new one if the pool is empty.
+     * @see #isEmpty()
+     * @see #put(CombinationGeneratorTask)
      * @since 2025.07.11 - TaskPool Introduction
      * @performance O(1) time complexity, as it involves simple arithmetic and array access.
      * @memory Only allocates if the pool is empty, otherwise reuses existing objects.
-     * @see #put(CombinationGeneratorTask)
-     * @see #isEmpty()
      */
     public CombinationGeneratorTask get() {
         if (size == 0)
@@ -268,12 +268,12 @@ public class TaskPool {
      * </p>
      * 
      * @param task The {@link CombinationGeneratorTask} to return to the pool.
+     * @see #size
+     * @see #TaskPool(int)
+     * @see #get()
      * @since 2025.07.11 - TaskPool Introduction
      * @performance O(1) time complexity, as it involves simple arithmetic and array access.
      * @memory Reuses existing objects, minimizing allocations.
-     * @see #size
-     * @see #get()
-     * @see #TaskPool(int)
      */
     public void put(CombinationGeneratorTask task) {
         if (task == null || size >= capacity)
@@ -290,14 +290,14 @@ public class TaskPool {
      * Checks if the pool is empty.
      * 
      * @return <code>true</code> if the pool is empty, <code>false</code> otherwise.
-     * @since 2025.07.11 - TaskPool Introduction
-     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
-     *            thread context.
-     * @performance O(1) time complexity, as it involves a simple comparison.
-     * @memory No additional memory usage.
      * @see #size
      * @see #get()
      * @see #put(CombinationGeneratorTask)
+     * @since 2025.07.11 - TaskPool Introduction
+     * @performance O(1) time complexity, as it involves a simple comparison.
+     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
+     *            thread context.
+     * @memory No additional memory usage.
      */
     public boolean isEmpty() {
         return size == 0;
@@ -307,15 +307,15 @@ public class TaskPool {
      * Gets the current number of tasks in the pool.
      * 
      * @return The current number of tasks in the pool.
-     * @since 2025.07.11 - TaskPool Introduction
-     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
-     *            thread context.
-     * @performance O(1) time complexity, as it involves a simple field access.
-     * @memory No additional memory usage.
      * @see #size
      * @see #get()
-     * @see #put(CombinationGeneratorTask)
      * @see #isEmpty()
+     * @see #put(CombinationGeneratorTask)
+     * @since 2025.07.11 - TaskPool Introduction
+     * @performance O(1) time complexity, as it involves a simple field access.
+     * @threading This method is <b>not</b> thread-safe, as it is intended to be used within a single
+     *            thread context.
+     * @memory No additional memory usage.
      */
     public int size() {
         return size;

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -1,5 +1,28 @@
 package com.github.mrgarbagegamer;
 
+/**
+ * TaskPool - [Performance Purpose - e.g., "High-performance memory pool"]
+ * 
+ * <p>[Detailed description of the performance problem this class solves.
+ * Include before/after metrics where applicable.]</p>
+ * 
+ * <h2>Optimization Strategy</h2>
+ * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
+ * Explain trade-offs made for performance gains.]</p>
+ * 
+ * <h2>Usage Patterns</h2>
+ * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * 
+ * <h2>Memory Management</h2>
+ * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * 
+ * <h3>0/10 - 0% of documentation completed</h3>
+ * 
+ * @performance [Specific performance characteristics and measurements]
+ * @memory [Memory usage patterns and optimizations]
+ * @threading [Thread safety model]
+ * @since [When introduced and why]
+ */
 public class TaskPool
 {
     private final CombinationGeneratorTask[] arrays;

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -16,7 +16,7 @@ package com.github.mrgarbagegamer;
  * <h2>Memory Management</h2>
  * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
  * 
- * <h3>0/10 - 0% of documentation completed</h3>
+ * <h3>3/11 - ~27.3% of documentation completed</h3>
  * 
  * @performance [Specific performance characteristics and measurements]
  * @memory [Memory usage patterns and optimizations]
@@ -31,17 +31,54 @@ public class TaskPool
     private int tail = 0;
     private int size = 0;
 
-    public TaskPool(int capacity)
-    {
+    /**
+     * Constructs a TaskPool with the specified capacity and pre-allocates all tasks.
+     * @param capacity the maximum number of tasks the pool can hold. Must be greater than 0.
+     * @throws IllegalArgumentException if capacity is less than or equal to 0.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(n) time complexity due to pre-allocation of {@link #arrays tasks array.}
+     * @memory Allocates memory for the specified number of tasks upfront to minimize runtime allocations.
+     * @see #arrays
+     * @see #capacity
+     * @see #get()
+     * @see #put(CombinationGeneratorTask)
+     */
+    public TaskPool(int capacity){
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Capacity must be greater than 0");
+        }
         this.capacity = capacity;
         this.arrays = new CombinationGeneratorTask[capacity];
     }
 
     /**
-     * Get a CombinationGeneratorTask from the pool, returning a new one if the pool is empty.
+     * Gets a {@link CombinationGeneratorTask} from the pool or creates a new one if the pool is empty.
+     * 
+     * <p>
+     * Note that, unlike {@link ArrayPool#get()}, this method will never return <code>null</code>. If
+     * the pool is empty, it will create and return a new task (though this should be avoided where
+     * possible).
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * We need to ensure that the get operation is as fast as possible, as it is on the hot path of
+     * combination generation. By using a {@link #arrays circular buffer} and {@link #TaskPool(int)
+     * pre-allocating} all tasks, we can achieve an O(1) time complexity for this method. We avoid a
+     * null check on the returned task (as this should never happen if the pool is sized correctly and
+     * null tasks are never returned to the pool), which further improves performance, keeping only the
+     * {@link #size} check at the start for short-circuiting purposes. If extra performance is needed,
+     * we could remove this check as well, but this would risk causing <code>size</code> to go negative
+     * and allow for the return of null tasks.
+     * </p>
+     * 
+     * @return A {@link CombinationGeneratorTask} from the pool or a new one if the pool is empty.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @memory Only allocates if the pool is empty, otherwise reuses existing objects.
+     * @see #put(CombinationGeneratorTask)
+     * @see #isEmpty()
      */
-    public CombinationGeneratorTask get()
-    {
+    public CombinationGeneratorTask get() {
         if (size == 0)
         {
             return new CombinationGeneratorTask(); // Return a new task if the pool is empty
@@ -55,10 +92,30 @@ public class TaskPool
     }
 
     /**
-     * Return a CombinationGeneratorTask to the pool if there's space.
+     * Returns a {@link CombinationGeneratorTask} to the {@link #tail} of the pool. Returns immediately
+     * if the pool is full or the task is null.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The put operation is also on the hot path, so it needs to be as fast as possible. By using a
+     * {@link #arrays circular buffer} and {@link #TaskPool(int) pre-allocating} all tasks, we can
+     * achieve O(1) performance for this operation as well. Unlike {@link ArrayPool#put(short[])}, we
+     * perform a null check on the task being returned to avoid adding null tasks to the pool, providing
+     * a safeguard against potential bugs in the calling code. This check isn't strictly necessary for
+     * performance, though, so if maximum speed is required and the calling code is trusted, it could be
+     * removed. On the other hand, the {@link #size} check is essential to prevent overfilling the pool,
+     * which could lead to memory corruption and unwanted behavior when polling tasks later.
+     * </p>
+     * 
+     * @param task The {@link CombinationGeneratorTask} to return to the pool.
+     * @since 2025.07.02 - Custom Generator Pools
+     * @performance O(1) time complexity, as it involves simple arithmetic and array access.
+     * @memory Reuses existing objects, minimizing allocations.
+     * @see #size
+     * @see #get()
+     * @see #TaskPool(int)
      */
-    public void put(CombinationGeneratorTask task)
-    {
+    public void put(CombinationGeneratorTask task) {
         if (task == null || size >= capacity)
         {
             return;

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -1,41 +1,204 @@
 package com.github.mrgarbagegamer;
 
 /**
- * TaskPool - [Performance Purpose - e.g., "High-performance memory pool"]
+ * TaskPool - A high performance pool for pre-allocated {@link CombinationGeneratorTask} instances.
  * 
- * <p>[Detailed description of the performance problem this class solves.
- * Include before/after metrics where applicable.]</p>
+ * <p>
+ * The golden rule of JVM optimizations is the following: <b>Don't allocate.</b> Allocations and
+ * deallocations (GC) are expensive operations that can significantly impact performance, especially
+ * in high-throughput or low-latency applications. By reusing objects through pooling mechanisms, we
+ * can minimize the overhead associated with frequent allocations and deallocations, leading to more
+ * efficient memory usage and improved application performance. This class implements a simple
+ * object pool for {@link CombinationGeneratorTask} instances, allowing for the reuse of these
+ * objects instead of creating new ones each time they are needed.
+ * </p>
  * 
  * <h2>Optimization Strategy</h2>
- * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
- * Explain trade-offs made for performance gains.]</p>
+ * <p>
+ * This pool uses a circular buffer to manage the pre-allocated tasks, allowing for O(1) time
+ * complexity for both {@link #get()} and {@link #put(CombinationGeneratorTask)} operations. The
+ * pool is initialized with a fixed capacity, and tasks are reused as they are returned to the pool
+ * after use. This approach minimizes memory allocations and helps to reduce GC pressure, leading to
+ * better performance in scenarios where tasks are frequently created and destroyed.
+ * </p>
  * 
  * <h2>Usage Patterns</h2>
- * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * <p>
+ * This class should be used in scenarios where {@link CombinationGeneratorTask} instances are
+ * frequently created and destroyed, such as in multi-threaded combination generation tasks. Each
+ * thread should have its own instance of TaskPool to avoid concurrency issues, as this class is not
+ * thread-safe. Tasks should be obtained from the pool using {@link #get()} and returned to the pool
+ * using {@link #put(CombinationGeneratorTask)} when they are no longer needed. Do not retain a
+ * reference to a task after returning to the pool, since another thread could obtain it via
+ * stealing.
+ * </p>
  * 
  * <h2>Memory Management</h2>
- * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * <p>
+ * The pool pre-allocates a fixed number of tasks at construction time, which helps to minimize
+ * runtime allocations. The size of the pool should be chosen based on the expected workload and
+ * memory constraints of the application. If the pool is exhausted (i.e., all tasks are in use), the
+ * {@link #get()} method will create and return a new task, though this should be avoided where
+ * possible.
+ * </p>
  * 
- * <h3>3/11 - ~27.3% of documentation completed</h3>
+ * <h3>9/11 - ~81.8% of documentation completed</h3>
  * 
- * @performance [Specific performance characteristics and measurements]
- * @memory [Memory usage patterns and optimizations]
- * @threading [Thread safety model]
- * @since [When introduced and why]
+ * @since 2025.07.11 - TaskPool Introduction
+ * @threading This class is <b>not</b> thread-safe. Each thread should have its own instance of
+ *            TaskPool to avoid concurrency issues. Queues should be the only point of inter-thread
+ *            communication.
+ * @performance The pool uses a circular buffer to achieve O(1) time complexity for both get and put
+ *              operations. Pre-allocating tasks minimizes runtime allocations, reducing GC pressure
+ *              and improving performance in high-throughput scenarios.
+ * @memory Pre-allocates a fixed number of tasks at construction time to minimize runtime
+ *         allocations. The size of the pool should be chosen based on the expected workload and
+ *         memory usage patterns of the application.
+ * @see ArrayPool
+ * @see WorkBatch
  */
 public class TaskPool
 {
+    /**
+     * The array of pre-allocated tasks forming the pool. Implemented as a circular buffer.
+     * 
+     * @since 2025.07.11 - TaskPool Introduction
+     * @threading This field is <b>not</b> thread-safe. Each thread should have its own instance of
+     *            TaskPool to avoid concurrency issues.
+     * @performance O(1) time complexity for get and put operations due to circular buffer
+     *              implementation.
+     * @memory Pre-allocated at {@link #TaskPool(int) construction time} to minimize runtime
+     *         allocations.
+     * @see #capacity
+     * @see #head
+     * @see #size
+     * @see #tail
+     * @see #get()
+     * @see #put(CombinationGeneratorTask)
+     */
     private final CombinationGeneratorTask[] arrays;
+    /**
+     * The maximum number of tasks the pool can hold.
+     * 
+     * @since 2025.07.11 - TaskPool Introduction
+     * @threading This field is immutable after construction, making it inherently thread-safe.
+     * @performance Constant time access.
+     * @memory Allocated once at construction time, minimal memory footprint.
+     * @see #arrays
+     * @see #head
+     * @see #size
+     * @see #tail
+     * @see #put(CombinationGeneratorTask)
+     */
     private final int capacity;
+    /**
+     * The index of the next task to be {@link #get() retrieved} from the pool.
+     * 
+     * <p>
+     * The head index tracks where the next available task is located in the circular {@link #arrays
+     * buffer}. It is incremented each time a task is obtained from the pool, wrapping around to the
+     * start of the buffer when it reaches the end, implementing a circular buffer mechanism.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a circular buffer allows for efficient use of the pre-allocated tasks, minimizing memory
+     * usage while still allowing for fast {@link #put(CombinationGeneratorTask) put} and get
+     * operations. The head index is updated in constant time, ensuring that get operations remain
+     * efficient even as the pool fills up and empties out.
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an int avoids potential overflow issues in long-running
+     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
+     * pointer for both head and {@link #tail}, but that would complicate the logic and force an extra
+     * arithmetic operation on each operation, which could impact performance.
+     * </p>
+     * 
+     * @since 2025.07.11 - TaskPool Introduction
+     * @threading This field is not thread-safe, as it is intended to be used within a single thread
+     *            context.
+     * @performance O(1) for both put and get operations.
+     * @memory Minimal additional memory overhead (single int).
+     * @see #capacity
+     */
     private int head = 0;
+    /**
+     * The tail index for the next {@link #put(CombinationGeneratorTask) returned} task.
+     * 
+     * <p>
+     * The tail index tracks where the next returned array should be placed in the circular
+     * {@link #arrays buffer}. It is incremented each time an array is returned to the pool, wrapping
+     * around to the start of the buffer when it reaches the end, implementing a circular buffer
+     * mechanism.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
+     * usage while still allowing for fast put and {@link #get() get} operations. The tail index is
+     * updated in constant time, ensuring that put operations remain efficient even as the pool fills up
+     * and empties out.
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an int avoids potential overflow issues in long-running
+     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
+     * pointer for both {@link #head} and tail, but that would complicate the logic and force an extra
+     * arithmetic operation on each operation, which could impact performance.
+     * </p>
+     * 
+     * @since 2025.07.11 - TaskPool Introduction
+     * @threading This field is not thread-safe, as it is intended to be used within a single thread
+     *            context.
+     * @performance O(1) for both put and get operations.
+     * @memory Minimal additional memory overhead (single int).
+     * @see #capacity
+     */
     private int tail = 0;
+    /**
+     * The current number of tasks in the pool.
+     * 
+     * <p>
+     * The size field tracks how many tasks are currently stored in the pool. It is incremented each
+     * time a task is returned to the pool via {@link #put(CombinationGeneratorTask) put} and decremented each time a
+     * task is obtained from the pool via {@link #get() get}. This field is crucial for ensuring that
+     * we do not exceed the pool's {@link #capacity} and for determining if the pool is empty.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The size field is updated in constant time during both put and get operations, ensuring that
+     * these operations remain efficient. It is also used to quickly check if the pool is empty (via
+     * {@link #isEmpty()}).
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the size to save a few bytes of memory, but the performance difference
+     * is negligible and using an int avoids potential overflow issues in long-running applications
+     * (plus, Java treats arithmetic with short values weirdly). We could avoid the size field entirely
+     * by using the {@link #head} and {@link #tail} indices to calculate the size on-the-fly (or by
+     * taking a {@link WorkBatch#remainingCapacity} approach and storing the remaining capacity), but
+     * that would complicate the logic and add extra arithmetic operations to the hot path of both put
+     * and get operations, which could impact performance. We also don't anticipate the size coming down
+     * to 0, so the deoptimization risk is minimal.
+     * </p>
+     * 
+     * @since 2025.07.02 - Custom Generator Pools
+     * @threading The field is not thread-safe, as it is intended to be used within a single thread
+     *            context.
+     * @performance O(1) for both put and get operations.
+     * @memory Minimal additional memory overhead (single int).
+     */
     private int size = 0;
 
     /**
      * Constructs a TaskPool with the specified capacity and pre-allocates all tasks.
      * @param capacity the maximum number of tasks the pool can hold. Must be greater than 0.
      * @throws IllegalArgumentException if capacity is less than or equal to 0.
-     * @since 2025.07.02 - Custom Generator Pools
+     * @since 2025.07.11 - TaskPool Introduction
      * @performance O(n) time complexity due to pre-allocation of {@link #arrays tasks array.}
      * @memory Allocates memory for the specified number of tasks upfront to minimize runtime allocations.
      * @see #arrays
@@ -43,7 +206,7 @@ public class TaskPool
      * @see #get()
      * @see #put(CombinationGeneratorTask)
      */
-    public TaskPool(int capacity){
+    public TaskPool(int capacity) {
         if (capacity <= 0) {
             throw new IllegalArgumentException("Capacity must be greater than 0");
         }
@@ -72,7 +235,7 @@ public class TaskPool
      * </p>
      * 
      * @return A {@link CombinationGeneratorTask} from the pool or a new one if the pool is empty.
-     * @since 2025.07.02 - Custom Generator Pools
+     * @since 2025.07.11 - TaskPool Introduction
      * @performance O(1) time complexity, as it involves simple arithmetic and array access.
      * @memory Only allocates if the pool is empty, otherwise reuses existing objects.
      * @see #put(CombinationGeneratorTask)
@@ -108,7 +271,7 @@ public class TaskPool
      * </p>
      * 
      * @param task The {@link CombinationGeneratorTask} to return to the pool.
-     * @since 2025.07.02 - Custom Generator Pools
+     * @since 2025.07.11 - TaskPool Introduction
      * @performance O(1) time complexity, as it involves simple arithmetic and array access.
      * @memory Reuses existing objects, minimizing allocations.
      * @see #size

--- a/src/main/java/com/github/mrgarbagegamer/TaskPool.java
+++ b/src/main/java/com/github/mrgarbagegamer/TaskPool.java
@@ -215,6 +215,13 @@ public class TaskPool {
         }
         this.capacity = capacity;
         this.arrays = new CombinationGeneratorTask[capacity];
+        
+        // Pre-allocate all tasks
+        for (int i = 0; i < capacity; i++) {
+            this.arrays[i] = new CombinationGeneratorTask();
+        }
+        
+        this.size = capacity;
     }
 
     /**

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -85,8 +85,6 @@ import org.apache.logging.log4j.Logger;
  * monkeys, and therefore the entire solver.
  * </p>
  * 
- * <h3>11/15 - ~73.3% of documentation completed</h3>
- * 
  * @since 2025.04.01 - Multi-threaded Solver Introduction
  * @algorithm {@link #getWork() Pulls} a {@link WorkBatch batch of work} (either its own or by
  *            stealing), then processes each combination in the batch by
@@ -115,6 +113,32 @@ import org.apache.logging.log4j.Logger;
  * @see WorkBatch
  */
 public class TestClickCombination extends Thread {
+    /**
+     * The {@link Logger logger} for this class, used for logging significant events and errors.
+     * 
+     * <p>
+     * Logging is an important aspect of monitoring the behavior of the monkeys, especially in a
+     * multi-threaded environment where issues can be hard to trace. This logger is used to log
+     * significant events such as finding a solution, failed attempts, and interruptions.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * While logging is essential for diagnostics, it can introduce latency and contention if not
+     * handled carefully. To mitigate this, we restrict logging to significant events and use log4j2's
+     * asynchronous logger to offload the logging work to a separate thread. This helps ensure that the
+     * monkeys can continue processing without being blocked by logging operations.
+     * </p>
+     * 
+     * @since 2025.05.04 - Async Logging Introduction
+     * @threading The logger is thread-safe and can be used concurrently by multiple threads.
+     * @performance Logging operations are offloaded to a separate thread, minimizing impact on the main
+     *              processing loop.
+     * @memory The logger itself has a minimal memory footprint and tries to reuse objects to reduce GC
+     *         pressure.
+     * @see #run()
+     * @see CombinationMessage
+     */
     private static final Logger logger = LogManager.getLogger(TestClickCombination.class);
     /**
      * A constant defining how often to log failed attempts. After this many failed combinations per
@@ -136,8 +160,59 @@ public class TestClickCombination extends Thread {
      */
     private static final int LOG_EVERY_N_FAILURES = 100_000; // Log every N failures to avoid flooding the logs
 
+    /**
+     * The monkey's {@link CombinationQueue queue}. The monkey will first attempt to pull work from this
+     * queue before trying to steal from other monkeys' queues.
+     * 
+     * <p>
+     * Each monkey has its own queue to minimize contention and allow for efficient work retrieval. If
+     * this queue is empty, the monkey will attempt to steal work from other monkeys' queues in the
+     * {@link CombinationQueueArray queue array}, and failing that, will sleep briefly before retrying.
+     * </p>
+     * 
+     * @since 2025.05.23 - Dedicated Queue per Monkey
+     * @threading This field is final and immutable, ensuring thread safety.
+     * @performance O(1) work retrieval from this queue and O(1) accesses of this reference.
+     * @see #queueArray
+     * @see #allQueuesEmpty()
+     * @see #getWork()
+     * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
+     */
     private final CombinationQueue combinationQueue;
+    /**
+     * A reference to the shared {@link CombinationQueueArray queue array}.
+     * 
+     * <p>
+     * To minimize contention and allow for efficient work distribution, each monkey has its own
+     * {@link #combinationQueue queue} to pull work from. However, monkeys also need a way to steal work
+     * from others if their own queue is empty, and they need to be able to check if a
+     * {@link CombinationQueueArray#solutionFound solution has been found} or if
+     * {@link CombinationQueueArray#generationComplete generation is marked as complete}. This reference
+     * to the shared queue array gives the monkeys access to this information.
+     * </p>
+     * 
+     * @since 2025.05.23 - Dedicated Queue per Monkey
+     * @threading This field is final and immutable, ensuring thread safety.
+     * @performance O(1) accesses of this reference.
+     * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
+     */
     private final CombinationQueueArray queueArray;
+    /**
+     * The monkey's dedicated {@link Grid puzzle grid} for applying click combinations to.
+     * 
+     * <p>
+     * Since monkeys are designed to test the validity of click combinations, they need a way to apply
+     * the clicks to a grid and check if the puzzle is solved. To avoid contention and ensure thread
+     * safety, each monkey has its own dedicated grid that it uses for this purpose. This grid is
+     * initialized with the puzzle's initial state and is reset after each combination is tested.
+     * </p>
+     * 
+     * @since 2025.04.01 - Multi-threaded Solver Introduction
+     * @threading This field is final and immutable, ensuring thread safety.
+     * @performance O(1) accesses of this reference.
+     * @see #run()
+     * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
+     */
     private final Grid puzzleGrid;
 
     /**

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -6,330 +6,248 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * A highly optimized worker thread that tests click combinations on a {@link Grid puzzle grid}.
- * 
+ * An optimized worker thread that tests potential puzzle solutions from a shared work queue.
+ *
  * <p>
- * This class represents a worker thread that continuously {@link #getWork() fetches} click
- * combinations from {@link CombinationQueue a queue} (either its own or by stealing from others),
- * {@link #satisfiesOddAdjacency(short[]) checks them for odd adjacency}, and applies them to a
- * puzzle grid to see if they solve the puzzle. It is designed to be efficient and responsive,
- * minimizing contention and branching to allow for aggressive JIT optimizations.
+ * This class implements the "consumer" role in the solver's producer-consumer architecture. Each
+ * instance, referred to as a "monkey," runs on a dedicated thread. Its primary responsibility is to
+ * fetch {@link WorkBatch} objects from the {@link CombinationQueueArray}, test the thousands of
+ * combinations within each batch against a local {@link Grid} clone, and validate them.
  * </p>
- * 
+ *
  * <p>
- * The name "monkey" is used here as a playful nod to the "infinite monkey theorem," which states
- * that a monkey hitting keys at random on a typewriter for an infinite amount of time will almost
- * surely type any given text, such as the complete works of Shakespeare. In this case, our monkeys
- * are clicking cells on a grid in an attempt to find the correct combination that solves the
- * puzzle. The metaphor is fitting, though I'm currently unsure how to extend it to the
- * {@link CombinationGeneratorTask generators} (are they the typewriters? The paper? The ink?).
- * Regardless, the name adds a bit of whimsy to the otherwise boring nature of the code.
+ * The name "monkey" is a playful nod to the "infinite monkey theorem." In our context, the monkeys
+ * are tirelessly testing combinations on the grid, hoping to find the one that solves the puzzle.
+ * This terminology is used throughout the codebase to add a bit of whimsy and distinguish these
+ * worker threads from the {@link CombinationGeneratorTask "generator"} threads.
  * </p>
- * 
+ *
  * <h2>Execution Model</h2>
  * <p>
- * A monkey is designed to operate as an independent thread, allowing for the use of parallelism to
- * speed up the search for a solution. However, monkeys do not generate their own work; they rely on
- * generators to produce and enqueue batches of combinations. This separation of concerns allows for
- * a clear division of labor, with generators focusing on producing combinations and monkeys
- * focusing on testing them.
+ * Monkeys operate in a simple, continuous loop. They do not generate their own work; instead, they
+ * {@link #getWork() pull} batches from a queue system. Each monkey has a preferred queue but will
+ * steal work from other queues if its own is empty.
  * </p>
  * 
  * <p>
- * For greater efficiency, each monkey has {@link #combinationQueue its own} {@link CombinationQueue
- * queue} to pull work from, and it only resorts to stealing work from other monkeys' queues when
- * its own is empty. After acquiring a batch to work on, the monkey processes each combination in
- * the batch, checking for odd adjacency to prune invalid combinations before applying them to the
- * grid. This check is more thorough than the pruning done by generators, reducing the number of
- * expensive grid operations that need to performed. Logging is restricted to failed attempts that
- * pass the adjacency check to avoid overwhelming {@link #logger the logger} with messages.
- * Successful attempts are also logged, with the winning monkey {@link #triggerGeneratorShutdown()
- * triggering a shutdown of the generators.}
+ * For each combination, the monkey performs a highly-optimized
+ * {@link #satisfiesOddAdjacency(short[]) odd adjacency check}. This acts as a final, more stringent
+ * filter than the pruning done by generators, significantly reducing the number of expensive grid
+ * state manipulations. If a combination passes this check, it is applied to the grid. If it solves
+ * the puzzle, the monkey logs the solution, signals a global shutdown, and terminates.
  * </p>
- * 
- * <p>
- * If work is not immediately available, the monkey will check if a
- * {@link CombinationQueueArray#solutionFound solution has been found} OR if
- * {@link CombinationQueueArray#generationComplete generation is marked as complete} (all generators
- * have finished their work) and {@link #allQueuesEmpty() all queues are empty}. If either of these
- * conditions is met, the monkey will exit its loop and terminate. Otherwise, it will sleep for a
- * short period and retry fetching work.
- * </p>
- * 
+ *
  * <h2>Resource Management</h2>
  * <p>
- * Monkeys manage their own resources, including their own {@link #puzzleGrid grid} to avoid
- * contention with other threads. All resources used by a monkey are either specific to that thread,
- * shared in a static immutable manner, or are accessed in a thread-safe way through the
- * {@link CombinationQueueArray queue array}. An important note of monkeys in comparison to
- * generators is that monkeys' execution is confined to {@link #run() a loop}, and each monkey is
- * its own {@link java.lang.Thread Thread}. Since monkeys do not have changing contexts, their
- * lifecycle is simpler and we can avoid using {@link java.lang.ThreadLocal ThreadLocals}. This
- * saves us the overhead of calling and managing {@code ThreadLocal}s, which can be significant in
- * tight loops.
+ * To eliminate contention, each monkey operates on its own private {@link Grid} instance. Unlike
+ * generator tasks, which use {@link ThreadLocal} storage to manage resources within a
+ * {@link ForkJoinPool}, monkeys are simple {@link Thread}s with a persistent state, avoiding the
+ * overhead of {@code ThreadLocal} lookups in their hot loop.
  * </p>
  * 
  * <p>
- * Monkeys recycle {@link WorkBatch work batches} back to the
- * {@link CombinationQueueArray#getWorkBatchPool() shared pool} upon completion of processing,
- * allowing for efficient reuse of these objects and reducing the overhead of frequent allocations.
- * Because of this, monkeys do not allocate ANY object in their hot paths, aside from logging
- * overhead (an area for future improvement).
+ * The only shared, mutable resource monkeys interact with directly is the central
+ * {@link CombinationQueueArray}, from which they fetch work and to which they
+ * {@link CombinationQueueArray#getWorkBatchPool() recycle} {@link WorkBatch} objects after use.
+ * This design ensures that no objects are allocated in the hot path, with the minor exception of
+ * logging.
  * </p>
- * 
- * <h2>Performance Critical Paths</h2>
+ *
+ * <h2>Performance and Critical Paths</h2>
  * <p>
- * The hottest methods in this class are {@link #run()} and {@link #satisfiesOddAdjacency(short[])}.
- * Changes to these two methods can have a significant impact on the overall performance of the
- * monkeys, and therefore the entire solver.
+ * The performance of the entire solver is heavily influenced by the efficiency of the monkey's main
+ * {@link #run() run loop} and, most importantly, the {@link #satisfiesOddAdjacency(short[])} check.
+ * These sections are heavily optimized to be JIT-friendly, minimizing branching and using bitwise
+ * operations for fast validation.
  * </p>
- * 
- * @see CombinationGeneratorTask
- * @see CombinationQueue
- * @see CombinationQueueArray
- * @see Grid
- * @see WorkBatch
- * @since 2025.04.01 - Multi-threaded Solver Introduction
+ *
+ * @since 2025.04 - Multi-threaded Solver Introduction
  * @performance The main loop's overall time complexity is
- *              <code>O({@link CombinationGeneratorTask#BATCH_SIZE BATCH_SIZE} × combination.length)</code> per
- *              batch. The {@link #satisfiesOddAdjacency(short[]) odd adjacency check} is
- *              {@code O(combination.length)}. However, due to pruning and parallelism, the
- *              effective workload is significantly reduced. Most bottlenecks arise from contention
- *              on shared resources or the process of enqueuing batches.
- * @threading Each monkey is its own {@link java.lang.Thread thread}, operating independently with
- *            its own testing resources. Work is {@link #getWork() obtained} in a thread-safe manner
- *            from a {@link CombinationQueue queue} ({@link #combinationQueue its own} or another's
- *            via stealing) and uses pre-initialized thread-specific data structures to operate on
- *            them.
- * @algorithm {@link #getWork() Pulls} a {@link WorkBatch batch of work} (either its own or by
- *            stealing), then processes each combination in the batch by
- *            {@link #satisfiesOddAdjacency(short[]) checking} for odd adjacency. If the combination
- *            passes the check, it is applied to the {@link Grid grid} to see if it solves the
- *            puzzle. If a solution is found, it is logged and other threads are signaled to
- *            terminate. If no work is available, the monkey checks for its exit condition and (if
- *            not met) sleeps briefly before retrying.
- * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
- *         in the hot path. The only allocations in the hot path are due to logging overhead.
+ *              {@code O(CombinationGeneratorTask.BATCH_SIZE)} per batch, dominated by the
+ *              {@code O(combination.length)} odd adjacency check performed for each combination.
+ * @threading Each monkey is a {@link Thread} that operates on its own {@link Grid} instance. Work
+ *            is obtained in a thread-safe manner from the shared {@link CombinationQueueArray}.
+ * @algorithm {@link #getWork() Pulls} a {@link WorkBatch} (from its own queue or by stealing), then
+ *            iterates through its combinations. Each is validated with an
+ *            {@link #satisfiesOddAdjacency(short[]) odd adjacency check}. Valid combinations are
+ *            tested on the grid. On success, the monkey triggers a global shutdown.
+ * @memory Fixed memory footprint with minimal allocations, except for logging.
  */
 public class TestClickCombination extends Thread {
     /**
-     * The {@link Logger logger} for this class, used for logging significant events and errors.
-     * 
+     * The {@link Logger logger} for this class.
+     *
      * <p>
-     * Logging is an important aspect of monitoring the behavior of the monkeys, especially in a
-     * multi-threaded environment where issues can be hard to trace. This logger is used to log
-     * significant events such as finding a solution, failed attempts, and interruptions.
+     * Logging is used to report significant events, such as finding a solution, interruptions, and
+     * periodic progress updates. To minimize performance impact on the worker threads, an asynchronous
+     * Log4j2 logger is used, which offloads I/O operations to a separate background thread.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * While logging is essential for diagnostics, it can introduce latency and contention if not
-     * handled carefully. To mitigate this, we restrict logging to significant events and use log4j2's
-     * asynchronous logger to offload the logging work to a separate thread. This helps ensure that the
-     * monkeys can continue processing without being blocked by logging operations.
-     * </p>
-     * 
+     *
      * @see #run()
      * @see CombinationMessage
-     * @since 2025.05.04 - Async Logging Introduction
-     * @performance Logging operations are offloaded to a separate thread, minimizing impact on the main
-     *              processing loop.
-     * @threading The logger is thread-safe and can be used concurrently by multiple threads.
-     * @memory The logger itself has a minimal memory footprint and tries to reuse objects to reduce GC
-     *         pressure.
+     * @since 2025.05 - Async Logging Introduction
+     * @performance {@code O(1)} for logger retrieval.
+     * @threading Thread-safe per Log4j2 design.
+     * @memory Fixed memory footprint of 4 bytes for the {@code static} reference.
      */
     private static final Logger logger = LogManager.getLogger(TestClickCombination.class);
     /**
-     * A constant defining how often to log failed attempts. After this many failed combinations per
-     * thread (not including combinations that fail the odd adjacency check), a debug log entry will be
-     * made. This helps monitor progress without overwhelming the logs.
-     * 
+     * A constant defining the frequency of logging for failed attempts.
+     *
      * <p>
-     * Logging is purely a diagnostic feature and does not affect the algorithm, but excessive logging
-     * can block threads and degrade performance, even with asynchronous logging. Therefore, we log only
-     * every N failures, where N is defined by this constant.
+     * To avoid overwhelming the logs and impacting performance, a debug entry for a failed combination
+     * is made only once per this many failures. This check applies only to combinations that have
+     * already passed the {@link #satisfiesOddAdjacency(short[])} check.
      * </p>
-     * 
+     *
      * @see #run()
      * @see CombinationMessage
-     * @since 2025.05.31 - Logging Threshold Introduction
-     * @performance {@code O(1)} check per failed combination.
-     * @threading This constant is immutable and thread-safe.
-     * @memory Minimal memory impact as it's just a single integer.
+     * @since 2025.05 - Logging Threshold Introduction
+     * @performance {@code O(1)} retrieval for checks.
+     * @threading Thread-safe as a {@code static final} constant.
+     * @memory Fixed memory footprint of 4 bytes as a primitive {@code int}.
      */
-    private static final int LOG_EVERY_N_FAILURES = 100_000; // Log every N failures to avoid flooding the logs
+    private static final int LOG_EVERY_N_FAILURES = 100_000;
 
     /**
-     * The monkey's {@link CombinationQueue queue}. The monkey will first attempt to pull work from this
-     * queue before trying to steal from other monkeys' queues.
-     * 
+     * The monkey's preferred {@link CombinationQueue}.
+     *
      * <p>
-     * Each monkey has its own queue to minimize contention and allow for efficient work retrieval. If
-     * this queue is empty, the monkey will attempt to steal work from other monkeys' queues in the
-     * {@link CombinationQueueArray queue array}, and failing that, will sleep briefly before retrying.
+     * Each monkey has an assigned queue to pull work from. This affinity helps reduce contention. If
+     * this queue is empty, the monkey will attempt to steal work from other queues in the shared
+     * {@link #queueArray}.
      * </p>
-     * 
-     * @see #queueArray
+     *
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
      * @see #allQueuesEmpty()
      * @see #getWork()
-     * @since 2025.05.23 - Dedicated Queue per Monkey
-     * @performance {@code O(1)} work retrieval from this queue and {@code O(1)} accesses of this
-     *              reference.
-     * @threading This field is final and immutable, ensuring thread safety.
+     * @since 2025.05 - Dedicated Queue per Monkey
+     * @performance {@code O(1)} dequeue operations.
+     * @threading Thread-safe through JCTools wizardry.
+     * @memory Fixed memory footprint of 4 bytes for the reference.
      */
     private final CombinationQueue combinationQueue;
     /**
-     * A reference to the shared {@link CombinationQueueArray queue array}.
-     * 
+     * A reference to the shared {@link CombinationQueueArray}.
+     *
      * <p>
-     * To minimize contention and allow for efficient work distribution, each monkey has its own
-     * {@link #combinationQueue queue} to pull work from. However, monkeys also need a way to steal work
-     * from others if their own queue is empty, and they need to be able to check if a
-     * {@link CombinationQueueArray#solutionFound solution has been found} or if
-     * {@link CombinationQueueArray#generationComplete generation is marked as complete}. This reference
-     * to the shared queue array gives the monkeys access to this information.
+     * This provides access to all work queues for stealing, the shared {@link WorkBatch} pool for
+     * recycling, and global state flags like {@link CombinationQueueArray#solutionFound} and
+     * {@link CombinationQueueArray#generationComplete}.
      * </p>
-     * 
+     *
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
-     * @since 2025.05.23 - Dedicated Queue per Monkey
-     * @performance {@code O(1)} accesses of this reference.
-     * @threading This field is final and immutable, ensuring thread safety.
+     * @since 2025.05 - Dedicated Queue per Monkey
+     * @performance {@code O(1)} access to queues and flags.
+     * @threading Thread-safe through use of {@code volatile} flags and concurrent queues.
+     * @memory Fixed memory footprint of 4 bytes for the reference.
      */
     private final CombinationQueueArray queueArray;
     /**
-     * The monkey's dedicated {@link Grid puzzle grid} for applying click combinations to.
-     * 
+     * The monkey's dedicated {@link Grid} instance for testing combinations.
+     *
      * <p>
-     * Since monkeys are designed to test the validity of click combinations, they need a way to apply
-     * the clicks to a grid and check if the puzzle is solved. To avoid contention and ensure thread
-     * safety, each monkey has its own dedicated grid that it uses for this purpose. This grid is
-     * initialized with the puzzle's initial state and is reset after each combination is tested.
+     * To prevent any thread contention, each monkey operates on a {@code private} clone of the puzzle
+     * grid. The grid's state is {@link Grid#initialize() reset} after each failed combination test.
      * </p>
-     * 
+     *
      * @see #run()
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
-     * @since 2025.04.01 - Multi-threaded Solver Introduction
-     * @performance {@code O(1)} accesses of this reference.
-     * @threading This field is final and immutable, ensuring thread safety.
+     * @since 2025.04 - Multi-threaded Solver Introduction
+     * @performance {@code O(1)} state resets and cell toggles.
+     * @threading Thread-safe by design, as each thread has its own instance.
+     * @memory Fixed memory footprint of 4 bytes for the reference.
      */
     private final Grid puzzleGrid;
 
     /**
-     * Lookup table mapping each possible click to a bitmask of true cells it affects. These are
-     * semantically similar to the adjacency masks in {@link Grid}, but only for the true cells in the
-     * current puzzle.
-     * 
+     * A pre-computed lookup table mapping a cell click to its effect on the puzzle's {@code true}
+     * cells.
+     *
      * <p>
-     * While generators have their own pruning logic, the vast majority of combinations that make their
-     * way to monkeys are not valid due to odd adjacency violations, and we need to filter these out
-     * before they reach the grid. To do this, we need a mechanism to quickly check what {@code true}
-     * cells a click will affect, and we can use a bitmask for this purpose.
+     * This table is the core of the {@link #satisfiesOddAdjacency(short[])} check. Each index
+     * corresponds to a cell on the grid (0-108). The {@code long} value at that index is a
+     * {@link Grid.ValueFormat#Bitmask bitmask} where the Nth bit is 1 if clicking that cell toggles the
+     * Nth {@code true} cell of the puzzle.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
+     *
      * <p>
-     * We statically initialize this table once per puzzle in {@link #initializeLookupTable(short[])}
-     * using double-checked locking to ensure thread safety. This avoids redundant computation and
-     * allows all threads to share the same table without contention, which is crucial for performance.
-     * Bitmasks are used to efficiently represent the affected true cells, and while a long can only
-     * store 64 bits of data, all puzzles in this game have less than 64 initially {@code true} cells,
-     * letting us use just one {@code long} per cell (and perform one bitwise operation per click).
+     * This table is initialized once per puzzle via {@link #initializeLookupTable(short[])} using
+     * double-checked locking for thread-safety. All monkey threads share this single {@code static}
+     * instance. Since all puzzles have fewer than 64 {@code true} cells, a single {@code long} is
+     * sufficient for the bitmask.
      * </p>
-     * 
+     *
      * @see #EXPECTED_MASK
      * @see #satisfiesOddAdjacency(short[])
-     * @since 2025.06.30 - Bitmask Pre-computations
-     * @performance {@code O(1)} lookup time for each cell in the combination.
-     * @threading The lookup table is initialized once per puzzle in a thread-safe manner using
-     *            double-checked locking.
-     * @memory The lookup table is an array of 109 {@code long} values, taking up 872 bytes (109 * 8
-     *         bytes).
+     * @since 2025.06 - Bitmask Pre-computations
+     * @performance {@code O(NUM_CELLS)} initialization cost amortized across threads; {@code O(1)}
+     *              lookups during checks.
+     * @threading Thread-safe via double-checked locking during initialization.
+     * @memory Fixed memory footprint of ~{@code 8 × Grid.NUM_CELLS} bytes (872 bytes).
      */
     private static volatile long[] CLICK_TO_TRUE_CELL_MASK = null;
     /**
-     * The expected mask for a valid combination of clicks, which is the bitmask where all {@code true}
-     * cells are set to 1. This is computed once during initialization and used to validate
-     * combinations.
-     * 
+     * The target {@link Grid.ValueFormat#Bitmask bitmask} for a valid combination, where all bits
+     * corresponding to {@code true} cells are 1.
+     *
      * <p>
-     * As part of the odd adjacency check in monkey threads, we need to ensure that the number of clicks
-     * affecting each {@code true} cell is odd, which is done by XORing the mask for each click in
-     * {@link #CLICK_TO_TRUE_CELL_MASK}. A valid combination would have all 1s in the mask up to the
-     * number of {@code true} cells, but we can't know the value until we have the {@code true} cells.
-     * Recomputing the mask every time we perform a check would be inefficient, so we compute it once
-     * during initialization and store it here.
+     * A combination is valid under the odd adjacency rule if the final result of XORing the
+     * {@link #CLICK_TO_TRUE_CELL_MASK} for each click equals this expected mask. This means every true
+     * cell was toggled an odd number of times.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
+     *
      * <p>
-     * Bitmasks are used for their efficiency in representing the state of affected {@code true} cells
-     * as well as their fast operations. By making this variable {@code static} and {@code volatile}, we
-     * ensure that only one thread ever has to compute the mask, and all threads can read it without
-     * contention.
+     * Like the lookup table, this value is computed once per puzzle via
+     * {@link #initializeLookupTable(short[])} and shared {@code static}ally.
      * </p>
-     * 
+     *
      * @see #CLICK_TO_TRUE_CELL_MASK
      * @see #satisfiesOddAdjacency(short[])
-     * @since 2025.06.30 - Bitmask Pre-computations
-     * @performance {@code O(1)} lookup time.
-     * @threading The expected mask is computed once per puzzle in a thread-safe manner using
-     *            double-checked locking.
-     * @memory The expected mask is a single {@code long} value, taking up just 8 bytes.
+     * @since 2025.06 - Bitmask Pre-computations
+     * @performance {@code O(1)} lookups.
+     * @threading Thread-safe via double-checked locking during initialization.
+     * @memory Fixed memory footprint of 8 bytes as a primitive {@code long}.
      */
     private static volatile long EXPECTED_MASK = 0L;
 
     /**
-     * Constructs a monkey thread with the specified name, associated {@link CombinationQueue queue} and
-     * {@link Grid grid}, and the shared {@link CombinationQueueArray queue array}.
-     * 
+     * Constructs a monkey thread.
+     *
      * <p>
-     * Each monkey operates independently with its own resources, including a dedicated puzzle grid and
-     * queue for fetching work. We also need access to the shared queue array to check for a solution,
-     * recycle work batches, steal work from other monkeys, and potentially signal generators and other
-     * monkeys to shut down. This constructor sets up all these relationships while also calling for the
-     * {@link #initializeLookupTable(short[]) initialization} of {@link #CLICK_TO_TRUE_CELL_MASK the
-     * lookup table}.
+     * Each monkey requires its own {@link Grid} instance to test combinations, a preferred
+     * {@link CombinationQueue} to pull work from, and a reference to the shared
+     * {@link CombinationQueueArray} for work-stealing and global state coordination.
      * </p>
-     * 
+     *
      * <p>
-     * Note that the lookup table is only initialized once per puzzle, so even if multiple monkeys are
-     * created for the same puzzle, the initialization will only occur once in a thread-safe manner.
+     * This constructor also triggers the one-time, thread-safe {@link #initializeLookupTable(short[])
+     * initialization} of the {@code static} {@link #CLICK_TO_TRUE_CELL_MASK} and {@link #EXPECTED_MASK}
+     * lookup tables, which are shared across all monkey instances for a given puzzle.
      * </p>
-     * 
+     *
      * <h3>Performance Considerations</h3>
      * <p>
-     * This constructor is not performance-critical as it is only called once per monkey thread. We
-     * delegate most of the allocation work to the caller to allow for more flexible resource management
-     * and make the monkeys' constructor simpler. The queue array could be made {@code static} for the
-     * class and be set by a {@code static} method, though we left this as-is for simplicity. Making the
-     * queue array {@code static} could be a future optimization if we find that the overhead of passing
-     * it around is significant and want to save on the memory footprint of storing a reference in each
-     * monkey.
+     * The design delegates resource allocation to the caller for flexibility. A potential
+     * micro-optimization could be to make the {@link #queueArray} a {@code static} field, set once,
+     * rather than passing it as a reference to each monkey. This would save a small amount of memory
+     * per thread but was omitted for design simplicity.
      * </p>
-     * 
-     * @param threadName       the <b>UNIQUE</b> name for this monkey thread, used in logging.
-     * @param combinationQueue the {@link CombinationQueue queue} from which this monkey will pull from.
-     * @param queueArray       the shared {@link CombinationQueueArray queue array} for coordination
-     *                         with other monkeys. This field should be <b>IDENTICAL</b> for each monkey
-     *                         working on the same puzzle.
-     * @param puzzleGrid       the <b>UNIQUE</b> {@link Grid grid} that this monkey will apply
-     *                         combinations to. Do not share grids between monkeys.
+     *
+     * @param threadName       The unique name for this monkey thread, used for logging.
+     * @param combinationQueue The monkey's preferred work queue.
+     * @param queueArray       The shared array of all queues, used for work-stealing and coordination.
+     * @param puzzleGrid       A <b>unique</b> {@link Grid} instance for this monkey to use for testing.
      * @see #combinationQueue
      * @see #puzzleGrid
      * @see #queueArray
-     * @see #initializeLookupTable(short[])
-     * @see CombinationQueue
-     * @see CombinationQueueArray
-     * @see Grid
      * @see Grid#findTrueCells(Grid.ValueFormat)
-     * @since 2025.04.01 - Monkey Thread Introduction
-     * @performance {@code O(1)} assignments and a single call to initialize the lookup table.
-     * @threading Thread-safe since the lookup table is statically initialized and all other fields are
-     *            final.
-     * @memory Memory usage is minimal, with only a few references and primitive fields. The only
-     *         explicit allocation in this method (other than the thread itself) is the allocation of a
-     *         trueCells {@code short[]} for lookup table initialization.
+     * @since 2025.04 - Monkey Thread Introduction
+     * @performance {@code O(1)} assignments. The one-time cost of
+     *              {@link #initializeLookupTable(short[])} is amortized across all threads.
+     * @threading Thread-safe by nature of construction.
+     * @memory Allocates only a temporary {@code short[]} during the first lookup table initialization,
+     *         in addition to the thread itself.
      */
     public TestClickCombination(String threadName, CombinationQueue combinationQueue, CombinationQueueArray queueArray,
             Grid puzzleGrid) {
@@ -344,50 +262,27 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * Initializes the lookup table for click combinations based on the provided {@code true} cells.
-     * 
+     * Initializes the {@code static}, shared lookup tables for the odd adjacency check.
+     *
      * <p>
-     * To efficiently prune combinations that do not satisfy the odd adjacency/parity condition, we need
-     * a way to quickly check which {@code true} cells are affected by each possible click. Though it's
-     * possible to compute this on-the-fly, it would incur a significant performance penalty due to the
-     * redundant calculations and temporary allocation overhead. The pre-computed masks in
-     * {@link #CLICK_TO_TRUE_CELL_MASK} solve both of these issues, but a pre-computed mask is nothing
-     * without code to generate it. This method fills these masks based on the initial state of the
-     * grid.
+     * This method pre-computes the {@link #CLICK_TO_TRUE_CELL_MASK} and {@link #EXPECTED_MASK} values.
+     * It is called from the constructor but uses double-checked locking to ensure it only executes once
+     * per puzzle, making initialization thread-safe and lazy.
      * </p>
-     * 
-     * <h3>Algorithm Details</h3>
+     *
      * <p>
-     * The method first checks if the lookup table has already been initialized using double-checked
-     * locking to ensure thread safety. If it hasn't, it creates a new array of {@code long} values, one
-     * for each possible click (109 total). It then iterates over each possible click and, for each true
-     * cell, checks if the click is adjacent to the true cell using
-     * {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}. If they are adjacent, it sets the
-     * corresponding bit in the mask for that click. After processing all possible clicks, it computes
-     * the {@link #EXPECTED_MASK expected mask} (a mask containing all bits set to 1 for the number of
-     * {@code true} cells) and atomically publishes the results to the {@code static} variables
-     * {@code CLICK_TO_TRUE_CELL_MASK} and {@code EXPECTED_MASK.}
+     * For each of the {@value Grid#NUM_CELLS} possible clicks, it determines which of the puzzle's
+     * {@code true} cells are adjacent and encodes that information into a
+     * {@link Grid.ValueFormat#Bitmask bitmask}. It then computes the final expected mask where all
+     * relevant bits are set.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Since this method is only called once per puzzle, it is not performance-critical, allowing for
-     * more complex logic without impacting the overall performance of the solver. We use a simple
-     * {@code long[]} to store the masks for quick accesses and bitwise operations, and we pre-compute
-     * as much as we can to avoid redundant calculations during the
-     * {@link #satisfiesOddAdjacency(short[]) odd adjacency checks}.
-     * </p>
-     * 
-     * @param trueCells the array of initially true cells in {@link Grid.ValueFormat#Index index} format
-     * @see #CLICK_TO_TRUE_CELL_MASK
-     * @see #EXPECTED_MASK
-     * @since 2025.07.13 - Long Array Grid State Representation
-     * @performance <code>O({@value Grid#NUM_CELLS} × trueCells.length)</code>.
+     *
+     * @param trueCells The array of initially true cells in {@link Grid.ValueFormat#Index Index}
+     *                  format.
+     * @since 2025.07 - Long Array Grid State Representation
+     * @performance {@code O(Grid.NUM_CELLS × trueCells.length)} initialization.
      * @threading Thread-safe due to double-checked locking.
-     * @algorithm Pre-computation of click masks for fast odd adjacency checks.
-     * @memory The lookup table is an array of 109 {@code long} values, taking up 872 bytes (109 * 8
-     *         bytes). The expected mask is a single {@code long} value, taking up 8 bytes.
-     * @optimization Uses double-checked locking for thread-safe lazy initialization.
+     * @memory Allocates the lookup table (approx. 872 bytes) once.
      */
     private static void initializeLookupTable(short[] trueCells) {
         // Double-checked locking for thread-safe lazy initialization
@@ -422,101 +317,49 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * The main execution loop for the TestClickCombination thread. This method continuously processes
-     * click combinations from {@link WorkBatch a batch} obtained from a {@link CombinationQueue queue},
-     * {@link #satisfiesOddAdjacency(short[]) checks} them for odd adjacency, and applies them to the
-     * {@link Grid puzzle grid} to see if they solve the puzzle.
-     * 
+     * The main execution loop for the monkey thread.
+     *
      * <p>
-     * To operate as an independent worker, the monkey needs a core loop that can fetch work, process
-     * it, and handle termination conditions from other threads. This loop is designed to meet those
-     * needs while being efficient and responsive.
+     * This loop continuously fetches and processes {@link WorkBatch} objects until a solution is found
+     * or all work is complete.
      * </p>
-     * 
-     * <h3>Algorithm Details</h3>
+     *
+     * <h3>Algorithm</h3>
+     * <ol>
+     * <li>Attempt to {@link #getWork() get a work batch}.</li>
+     * <li>If no work is found, check for termination conditions
+     * ({@link CombinationQueueArray#solutionFound solution found}, or
+     * {@link CombinationQueueArray#generationComplete generation is complete} and
+     * {@link #allQueuesEmpty() all queues are empty}). If no reason to terminate,
+     * {@link Thread#sleep(long) sleep briefly} and continue.</li>
+     * <li>If a batch is acquired, iterate through each combination within it.</li>
+     * <li>For each combination, perform the {@link #satisfiesOddAdjacency(short[])} check.</li>
+     * <li>If the check passes, apply the clicks to the local {@link #puzzleGrid}.</li>
+     * <li>If the grid {@link Grid#isSolved() is solved}, log the solution, trigger a global
+     * {@link #triggerGeneratorShutdown() shutdown}, and terminate.</li>
+     * <li>If the grid is not solved, {@link Grid#initialize() reset} it and continue.</li>
+     * <li>After the batch is exhausted, recycle it to {@link CombinationQueueArray#getWorkBatchPool()
+     * the shared pool} and repeat the loop.</li>
+     * </ol>
+     *
+     * <h3>Performance &amp; Future Optimizations</h3>
      * <p>
-     * After defining a local counter for failed attempts (to control logging frequency), we enter a
-     * loop that continues until a solution is found or all queues are empty. We first attempt to
-     * {@link #getWork() get a batch} of work from our own queue or from another monkey's queue by
-     * stealing. If no work is available, we check if the solution has been found or if generation is
-     * marked as complete (all generators have finished their work) and {@link #allQueuesEmpty() all
-     * queues are empty}. If so, we know that another thread has found the solution or that all work has
-     * been processed, and we can exit the loop. If those conditions aren't met, we
-     * {@link Thread#sleep(long) sleep} for a short time (1s) to avoid busy-waiting and give the
-     * generators time to catch up.
+     * The loop is structured to be JIT-friendly. A key future optimization would be a more direct
+     * cancellation mechanism. Instead of polling the {@code solutionFound} flag, a direct interrupt or
+     * signal to all worker threads would be more efficient. Additionally, the logging of failed
+     * combinations currently requires cloning an array and creating a {@link CombinationMessage}, which
+     * could be optimized to be allocation-free.
      * </p>
-     * 
-     * <p>
-     * Once we have a batch of work, we process each combination in the batch. We
-     * {@link WorkBatch#poll() poll} from the batch and check if the combination satisfies the odd
-     * adjacency condition before applying it to the puzzle grid. If the combination passes the check
-     * and grants the solution, we {@link Logger#info(String, Object...) log} the solution and exit out
-     * of the thread. If the combination doesn't solve the puzzle, we reset the grid back to its initial
-     * state and increment the failed attempt counter, logging the attempt if it reaches the threshold
-     * defined by {@link #LOG_EVERY_N_FAILURES LOG_EVERY_N_FAILURES}.
-     * </p>
-     * 
-     * <p>
-     * Finally, after processing all combinations in the batch, we recycle the batch back to the
-     * {@link CombinationQueueArray queue array} for reuse by other threads and begin the next iteration
-     * of the loop.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This loop is designed to minimize contention and branching, allowing the JIT compiler to employ
-     * the most aggressive optimizations possible. We use a single loop to process all combinations and
-     * delegate certain tasks to helper methods to keep the main loop clean and focused.
-     * </p>
-     * 
-     * <p>
-     * Logging is controlled by a counter to avoid overwhelming the logs with debug messages, which can
-     * cause performance issues even with asynchronous logging. We also ensure that we only log when the
-     * odd adjacency condition is satisfied, which reduces unnecessary logging overhead of invalid
-     * combinations.
-     * </p>
-     * 
-     * <p>
-     * Some potential areas for future optimization include a shift towards an explicit cancellation
-     * mechanism for the monkeys similar to that of the generators. If the winning monkey can directly
-     * signal for all other monkeys to terminate, we can avoid the need for them to check the
-     * {@code solutionFound} flag on every iteration, which would reduce the overhead of constant
-     * {@code volatile} reads.
-     * </p>
-     * 
-     * <p>
-     * We could also rework the logging mechanism with {@link CombinationMessage} to try to allow for
-     * more efficient, GC-free logging of combinations rather than the current approach that creates a
-     * new {@code CombinationMessage} object for each log entry. This would reduce the memory overhead
-     * and help bring down the number of temporary objects created, but it would require a more complex
-     * approach to interface with {@link org.apache.logging.log4j.message.ReusableMessage} and
-     * {@link org.apache.logging.log4j.message.MessageFactory}. Previous attempts have been made to
-     * implement this, but it's going to take some clever design to avoid concurrent modification issues
-     * (since async logging can modify the message while we're trying to log it). However, this may be
-     * worth pursuing in the future to reduce the memory footprint of the logging system and allow for
-     * more efficient logging.
-     * </p>
-     * 
-     * @see #allQueuesEmpty()
-     * @see #getWork()
-     * @see #satisfiesOddAdjacency(short[])
-     * @see #triggerGeneratorShutdown()
-     * @see CombinationQueue
-     * @see CombinationQueueArray
-     * @see Grid
-     * @see WorkBatch
-     * @since 2025.04.01 - Monkey Thread Introduction
-     * @performance <code>O({@link CombinationGeneratorTask#BATCH_SIZE BATCH_SIZE})</code> per batch,
-     *              excluding the cost of {@link #getWork() getting work}, logging, and
-     *              {@link #satisfiesOddAdjacency(short[]) odd adjacency checks}.
-     * @threading This method is executed by a single thread, which processes work from its own queue
-     *            and potentially steals from others. It is designed to be thread-safe with respect to
-     *            the shared {@link CombinationQueueArray} and uses its own {@link Grid} for safety.
-     * @algorithm Brute force search with pruning based on odd adjacency checks.
-     * @memory Other than logging overhead, this method does not allocate any objects in the hot path.
-     * @optimization Avoids unnecessary branching and redundant checks by processing entire batches in a
-     *               single loop. Uses bitmasking for fast odd adjacency checks that prune invalid
-     *               combinations before they reach the grid.
+     *
+     * @since 2025.04 - Monkey Thread Introduction
+     * @performance {@code O(CombinationGeneratorTask.BATCH_SIZE)} per batch, excluding the cost of
+     *              {@link #getWork() retrieval}, logging, and {@link #satisfiesOddAdjacency(short[])
+     *              checks}.
+     * @threading Thread-safe; independent state per thread, shared access to concurrent structures.
+     * @algorithm Continuously {@link #getWork() pulls} batches, iterates through combinations, performs
+     *            {@link #satisfiesOddAdjacency(short[]) checks}, tests on the grid, and handles success
+     *            or recycling.
+     * @memory Does not allocate, except for logging.
      */
     @Override
     public void run() {
@@ -589,41 +432,20 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * Triggers an immediate shutdown of the {@link CombinationGeneratorTask#getForkJoinPool() generator
-     * pool} to stop all {@link CombinationGeneratorTask generators}.
-     * 
+     * Triggers an immediate shutdown of the generator {@link ForkJoinPool}.
+     *
      * <p>
-     * Since monkeys are the final step in the processing pipeline (and are independent of the
-     * generators), they are the only threads that can find a solution to the puzzle. Since our program
-     * is concerned only with finding a single solution to the puzzle, once a monkey finds a solution,
-     * we need a way to stop all other processing as soon as possible to avoid wasting extra time and
-     * CPU cycles.
+     * When a solution is found, this method is called to halt the creation of new work. It directly
+     * invokes {@link ForkJoinPool#shutdownNow()} on the {@code static} pool instance held by
+     * {@link CombinationGeneratorTask}. This is more efficient than relying on cancellation flags, as
+     * it uses the {@code ForkJoinPool}'s built-in, low-overhead mechanism to interrupt all active
+     * generator tasks.
      * </p>
-     * 
-     * <p>
-     * Before this method was implemented, generators had explicit flags for termination and had to
-     * perform cancellation checks on every iteration of their processing loops. This was not ideal, as
-     * it added overhead to the generators and increased branching in the hot path. Since the generators
-     * are all part of a {@link java.util.concurrent.ForkJoinPool ForkJoinPool}, they already have
-     * functionality to handle shutdowns and cancellations in the form of
-     * {@link ForkJoinPool#shutdownNow() shutdownNow()}. This method leverages that functionality to
-     * provide a clean and efficient way to stop all generators when a solution is found.
-     * </p>
-     * 
-     * <p>
-     * We have to statically access the generator pool from the {@link CombinationGeneratorTask} class,
-     * as monkeys do not have direct access to the pool. This isn't perfect, but is simple for our needs
-     * and can be handled during the initialization of the pool in
-     * {@link StartYourMonkeys#main(String[])}.
-     * </p>
-     * 
-     * @see CombinationGeneratorTask
-     * @see java.util.concurrent.ForkJoinPool
+     *
      * @since 2025.07.23 - Explicit Cancellation Checks Removal
-     * @performance {@code O(1)} operation to trigger the shutdown.
-     * @threading This method is thread-safe as it accesses the {@code ForkJoinPool} in a safe manner.
-     * @optimization Uses the built-in shutdown mechanism of {@code ForkJoinPool} to avoid adding
-     *               overhead to the generators.
+     * @performance {@code O(1)} shutdown signaling.
+     * @threading Thread-safe as per {@code ForkJoinPool} design.
+     * @memory Does not allocate (except for logging).
      */
     private void triggerGeneratorShutdown() {
         // Access the generator pool from CombinationGeneratorTask if stored there,
@@ -637,60 +459,27 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * Obtains a {@link WorkBatch} of combinations to process. It first tries to get a batch from its
-     * own {@link CombinationQueue}, and if that is empty, it attempts to steal a batch from other
-     * {@link CombinationQueue queues} in the {@link CombinationQueueArray queue array}.
-     * 
+     * Obtains a {@link WorkBatch} to process, using a work-stealing strategy.
+     *
      * <p>
-     * To take advantage of multi-threading, we need a way for the {@link CombinationGeneratorTask}
-     * threads to exchange work with the monkeys. Queues provide storage for combination exchanges and
-     * generators have {@link CombinationGeneratorTask#flushBatchFast(WorkBatch) a method} to quickly
-     * flush batches to a queue, but monkeys need a way to efficiently obtain work from these queues
-     * without blocking. This method serves that purpose.
+     * This method first attempts to {@link CombinationQueue#getWorkBatch() poll} from
+     * {@link #combinationQueue the monkey's preferred} {@link CombinationQueue queue}. If that is
+     * empty, it iterates through all other queues in the shared {@link CombinationQueueArray} to
+     * "steal" a batch. This non-blocking approach allows idle monkeys to pick up work from busy
+     * threads, helping to balance the load.
      * </p>
-     * 
-     * <h3>Algorithm Details</h3>
+     *
      * <p>
-     * The method first attempts to {@link CombinationQueue#getWorkBatch() get a work batch} from the
-     * monkey's own queue. If that queue is empty, it attempts to steal a batch from another queue,
-     * iterating across the queues in increasing order of their indices. The method is short-circuiting,
-     * returning the first non-null batch it finds. If no batches are available in any queue, it returns
-     * {@code null}, indicating that there is no work to process at the moment.
+     * A more advanced implementation might use some load-balanced algorithm for stealing to reduce
+     * contention, but the current linear scan is simple and effective enough.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is designed to be efficient and non-blocking, allowing monkeys to quickly obtain work
-     * without waiting for other threads. It is optimized to reduce contention and branching, and
-     * therefore has no sleeping mechanism built in. It is the responsibility of the caller to handle
-     * some sort of sleeping or waiting; this method is made simple to increase the chances of
-     * aggressive JIT optimizations.
-     * </p>
-     * 
-     * <p>
-     * We could potentially optimize this further by implementing a more sophisticated work-stealing
-     * algorithm that takes into account the load of each queue, but that would require extra logic that
-     * may be too high in overhead for the benefit it provides (since
-     * {@link org.jctools.queues.MpmcArrayQueue#size() size()} calls are not {@code O(1)}). Caching the
-     * reference to the array of queues could be beneficial as a micro-optimization, but it isn't likely
-     * to have a major impact since the compiler's profiling will likely determine that the array
-     * reference is stable and optimize accordingly.
-     * </p>
-     * 
-     * @return a {@link WorkBatch} of combinations to process, or {@code null} if no work is available
-     * @see CombinationQueue
-     * @see CombinationQueueArray
-     * @see WorkBatch
-     * @since 2025.07.07 - Enqueueing Work Batches
-     * @performance {@code O(1)} to steal from the first available queue, or
-     *              <code>O({@link CombinationQueueArray#getAllQueues() queueArray.getAllQueues()}.length)</code> in
-     *              the worst case.
-     * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
-     *            thread-safe methods.
-     * @algorithm Work-stealing algorithm to obtain work batches from queues.
-     * @memory Minimal memory impact as it only returns a reference to an existing {@code WorkBatch}.
-     * @optimization Designed to minimize contention and branching, allowing for aggressive JIT
-     *               optimizations.
+     *
+     * @return A {@link WorkBatch} to process, or {@code null} if no work is available anywhere.
+     * @since 2025.07 - Enqueueing Work Batches
+     * @performance {@code O(1)} to steal from the preferred queue, and {@code O(queues.length)} in the
+     *              worst case for stealing.
+     * @threading Thread-safe; uses non-blocking queue operations.
+     * @memory Does not allocate.
      */
     private WorkBatch getWork() {
         // Try my own queue first
@@ -715,43 +504,22 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * Checks if all {@link CombinationQueue queues} in the {@link CombinationQueueArray queue array}
-     * are empty. This is used by {@link #run()} as part of the exit condition, determining if work is
-     * still available.
-     * 
+     * Checks if all work {@link CombinationQueue queues} in the {@link CombinationQueueArray system}
+     * {@link CombinationQueue#isEmpty() are empty}.
+     *
      * <p>
-     * Since monkeys and {@link CombinationGeneratorTask generators} operate independently and the
-     * program can be run on puzzle configurations without a solution, it is possible for all generators
-     * to finish generating combinations and exit before the monkeys have processed all available work.
-     * Monkeys can't just exit the second that {@link CombinationQueueArray#generationComplete
-     * generation is marked as complete}, since there may still be work left in the queues. On the other
-     * hand, monkeys can't just wait indefinitely for new work to be generated, since if the generators
-     * are done, no new work will ever arrive. Therefore, we need another component to our completed
-     * generation exit condition: all queues must be empty. This method checks that condition.
+     * This is a key part of the shutdown logic. A monkey can only safely terminate when
+     * {@link CombinationQueueArray#generationComplete generation is complete} <em>and</em> all queues
+     * are empty (or if the solution is found), ensuring no work is left unprocessed. This check is only
+     * performed when a monkey is idle, so its {@code O(queues.length)} complexity is acceptable.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is not performance-critical, as it is only called when a monkey's own queue is empty
-     * and it is checking for exit conditions. Therefore, we can afford to use a simple loop to check
-     * each queue, performing an <code>O({@link CombinationQueueArray#getAllQueues()
-     * queueArray.getAllQueues()}.length)</code> operation. However, we can't just attempt to poll from
-     * each queue for our check, since that could consume an item and interfere with the normal
-     * processing of the queues. Instead, we use the {@link CombinationQueue#isEmpty() isEmpty()}
-     * method, which is a non-destructive, constant-time check.
-     * </p>
-     * 
+     *
      * @return {@code true} if all queues are empty, {@code false} otherwise.
-     * @see CombinationQueue
-     * @see CombinationQueue#isEmpty()
-     * @see CombinationQueueArray
-     * @since 2025.08.02 - Preallocate WorkBatches for Queues
-     * @performance <code>O({@link CombinationQueueArray#getAllQueues()
-     *              queueArray.getAllQueues()}.length)</code>, but not performance-critical as it is
-     *              only called during exit condition checks.
-     * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
-     *            thread-safe methods.
-     * @memory Does not allocate any objects, only uses existing references.
+     * @since 2025.08 - Preallocate WorkBatches for Queues
+     * @performance {@code O(queues.length)} in the worst case due to iteration.
+     * @threading Thread-safe; calls {@link CombinationQueue#isEmpty() a thread-safe method} on each
+     *            queue.
+     * @memory Does not allocate.
      */
     private boolean allQueuesEmpty() {
         for (CombinationQueue q : queueArray.getAllQueues())
@@ -765,117 +533,60 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * Checks if the given combination satisfies the odd adjacency condition.
-     * 
+     * Checks if a combination is valid based on the "odd adjacency" rule.
+     *
      * <p>
-     * While much work has been done to optimize click operations and reinitializations of the
-     * {@link Grid}, they are still expensive operations that can cause significant slowdowns if
-     * performed too often. Therefore, we need a way to quickly prune combinations in a {@link WorkBatch
-     * batch} that are not valid before they reach the grid. This method serves that purpose.
+     * This is the most performance-critical method in the monkey's hot loop. It provides a final,
+     * highly-efficient check to prune invalid combinations before they are tested on the expensive
+     * {@link Grid} object.
+     * </p>
+     *
+     * <p>
+     * The logic relies on a property of this puzzle type: for a solution to be valid, every initially
+     * {@code true} cell must be toggled an odd number of times. This method validates this by XORing
+     * the {@link #initializeLookupTable(short[]) pre-computed} {@link #CLICK_TO_TRUE_CELL_MASK} for
+     * each click in the combination. If the final result equals the {@link #EXPECTED_MASK}, the rule is
+     * satisfied.
+     * </p>
+     *
+     * <h3>Performance &amp; JIT Optimizations</h3>
+     * <p>
+     * The method is heavily optimized for the JIT compiler. It uses local {@code final} variables to
+     * cache array references and loop bounds, which encourages the JIT to perform optimizations like
+     * loop unrolling. The core logic is a tight loop of XOR operations, which is extremely fast on
+     * modern CPUs.
      * </p>
      * 
      * <p>
-     * This method takes advantage of a few properties of the Lights Out puzzle:
+     * Further SIMD (Single Instruction, Multiple Data) optimizations were considered but were deemed
+     * impractical for the following reasons:
      * <ul>
-     * <li>Clicks toggle the state of the cells adjacent to the clicked cell.</li>
-     * <li>Since a cell can only be on or off (true or false), 2 clicks on a cell is the same as no
-     * clicks, and 3 clicks is the same as 1 click. This makes the puzzle mod-2.</li>
-     * <li>All initially {@code true} cells must therefore be toggled an odd number of times to be
-     * turned off.</li>
+     * <li><b>Vector API:</b> While promising, it suffered from excessive heap allocations for vector
+     * operations in tested JDK versions, negating the performance benefits. This may become viable with
+     * future improvements like Project Valhalla.</li>
+     * <li><b>JNI (Java Native Interface):</b> The overhead of marshalling data between Java and native
+     * code for each combination would outweigh the gains from using C++ intrinsics. Batching calls
+     * would introduce significant complexity in managing the return values.</li>
+     * <li><b>JIT Auto-Vectorization:</b> This is the most desirable approach, but the JIT is currently
+     * unable to vectorize this loop due to a data dependency (the running XOR) and the indirect array
+     * access pattern ({@code masks[click]}).</li>
      * </ul>
-     * Therefore, we can eliminate combinations that do not toggle each initially {@code true} cell an
-     * odd number of times.
+     * Manual loop unrolling or restructuring the loop into a gather-reduce pattern remain potential,
+     * albeit more complex, future optimizations if this method becomes a bottleneck.
      * </p>
-     * 
-     * <h3>Algorithm Details</h3>
-     * <p>
-     * Since we only care about initially {@code true} cells in this check, we can simplify the grid
-     * state to a bitmask that is the same length as the number of initially {@code true} cells, and
-     * where each bit represents whether a {@code true} cell is toggled an odd (1) or even (0) number of
-     * times. We iterate over the clicks in the combination and, for each click, we XOR the bitmask of
-     * the {@code true} cells it affects (from {@link #CLICK_TO_TRUE_CELL_MASK}) with our running total.
-     * At the end, if the resulting bitmask is equal to the {@link #EXPECTED_MASK expected mask} (where
-     * all bits are 1), then the combination satisfies the odd adjacency condition. Otherwise, it does
-     * not meet the condition and can be discarded.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is designed to be as efficient as possible, with a focus on minimizing branching and
-     * redundant checks. We cache all array references and the length at the start of the method to
-     * avoid array dereferencing. By {@link #initializeLookupTable(short[]) precomputing} the necessary
-     * bitmasks for each click, we can reduce the complexity of the check to
-     * {@code O(combination.length)} per combination. The use of bitwise operations (XOR) allows for
-     * extremely fast computations that are well-optimized by the JIT compiler, encouraging inlining and
-     * loop unrolling. The method is also marked as final to further encourage inlining by the JIT.
-     * </p>
-     * 
-     * <p>
-     * This method is crucial for performance, and optimizing it has a significant impact on the overall
-     * performance of the solver. The most tantalizing future optimization would be to leverage SIMD
-     * (Single Instruction, Multiple Data) CPU instructions to process multiple clicks in parallel, but
-     * this is more difficult than it seems. Java does not provide direct access to SIMD instructions,
-     * making the only realistic options being to use the Vector API, JNI (Java Native Interface), or
-     * JIT auto-vectorization.
-     * </p>
-     * 
-     * <p>
-     * The Vector API seems promising, but is utterly destroyed in feasibility by the significant
-     * allocation overhead it introduces (as each lanewise operation internally creates upwards of 4
-     * temporary objects that have no way of being reused). This overhead negates most of the
-     * performance benefits of SIMD, and until something like Project Valhalla is introduced (allowing
-     * for value types that allocate on the stack rather than the heap), it is not viable.
-     * </p>
-     * 
-     * <p>
-     * JNI would allow for direct use of SIMD instructions through C++ intrinsics, but it introduces
-     * heavy overhead in data marshalling between Java and native code, which negates most of the
-     * benefits. This could potentially be mitigated by batching multiple combinations into a single JNI
-     * call, but this then introduces problems regarding return values, since we'd need to return a
-     * boolean for each combination in the batch (and have some way for the Java side to associate
-     * results with combinations). I can't anticipate a clean way to do this without extreme overhead,
-     * so this option is also not viable.
-     * </p>
-     * 
-     * <p>
-     * Last but not least, JIT auto-vectorization is the most appealing option, as it would allow us to
-     * stay entirely within Java while still leveraging SIMD instructions. However, the JIT is very
-     * picky when it comes to auto-vectorization and requires very specific coding patterns to be able
-     * to apply it. Loop unrolling is crucial to this, as it allows the JIT to see a larger chunk of
-     * code at once. Worse, we have a data dependency in our loop (the XOR operation depends on the
-     * result of the previous iteration) and indirect array accesses (the click value is used as an
-     * index in another array), preventing the JIT from being able to vectorize the loop as-is.
-     * </p>
-     * 
-     * <p>
-     * Not all hope is lost though; we could manually unroll the loop for fixed combination lengths and
-     * create specialized methods, as well as using a {@code switch} statement to pick the proper method
-     * based on the combination length. This would sacrifice some code maintainability for performance,
-     * but it could be worth it if the JIT inlines the method appropriately. We could also create a
-     * {@code long} array for each thread to store the array masks that are XORed together, breaking the
-     * loop into a gather operation followed by a reduction operation. This would eliminate the data
-     * dependency and could allow for the JIT to vectorize the reduction step (as well as the gather
-     * step if we're lucky), but it would introduce complexity. This is still something worth exploring
-     * in the future if a monkey bottleneck arises.
-     * </p>
-     * 
-     * @param combination the combination of clicks to check, in {@link Grid.ValueFormat#Index index}
-     *                    format
-     * @return {@code true} if the combination satisfies the odd adjacency condition, {@code false}
-     *         otherwise
-     * @see #CLICK_TO_TRUE_CELL_MASK
-     * @see #EXPECTED_MASK
-     * @see #initializeLookupTable(short[])
-     * @see Grid#areAdjacent(short, short)
-     * @see Grid#findTrueCells(com.github.mrgarbagegamer.Grid.ValueFormat)
-     * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
-     * @performance {@code O(combination.length)} per combination.
-     * @threading This method is thread-safe as it only reads from shared {@code static} data that is
-     *            immutable after initialization.
-     * @memory Minimal memory impact as it only uses existing arrays and a few primitive variables (that
-     *         allocate on the stack).
-     * @optimization Uses bitmasking and bitwise operations for fast checks. Designed to be JIT-friendly
-     *               with minimal branching and encourages inlining and loop unrolling.
+     *
+     * @param combination The combination of clicks to check, in {@link Grid.ValueFormat#Index Index}
+     *                    format.
+     * @return {@code true} if the combination is valid, {@code false} otherwise.
+     * @see Grid#areAdjacent(short, short, Grid.ValueFormat)
+     * @see Grid#findTrueCells(Grid.ValueFormat)
+     * @since 2025.06 - Odd Adjacency Pruning for Monkeys
+     * @performance {@code O(combination.length)} iteration, dominated by XOR operations.
+     * @threading Thread-safe; uses only {@code static final} data and local variables.
+     * @algorithm Iterates through the combination, XORing the pre-computed
+     *            {@link #CLICK_TO_TRUE_CELL_MASK} for each click, and compares the final result to the
+     *            {@link #EXPECTED_MASK}.
+     * @memory Does not allocate.
      */
     private final boolean satisfiesOddAdjacency(short[] combination) {
         // JIT OPTIMIZATION: Cache array references and length to encourage optimization

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -85,7 +85,23 @@ import org.apache.logging.log4j.Logger;
  * monkeys, and therefore the entire solver.
  * </p>
  * 
+ * @see CombinationGeneratorTask
+ * @see CombinationQueue
+ * @see CombinationQueueArray
+ * @see Grid
+ * @see WorkBatch
  * @since 2025.04.01 - Multi-threaded Solver Introduction
+ * @performance The main loop's overall time complexity is O(n * m) per batch, where n is the number
+ *              of combinations in the batch and m is the combination length. The
+ *              {@link #satisfiesOddAdjacency(short[]) odd adjacency check} is O(m). However, due to
+ *              pruning and parallelism, the effective workload is significantly reduced. Most
+ *              bottlenecks arise from contention on shared resources or the process of enqueuing
+ *              batches.
+ * @threading Each monkey is its own {@link java.lang.Thread thread}, operating independently with
+ *            its own testing resources. Work is {@link #getWork() obtained} in a thread-safe manner
+ *            from a {@link CombinationQueue queue} ({@link #combinationQueue its own} or another's
+ *            via stealing) and uses pre-initialized thread-specific data structures to operate on
+ *            them.
  * @algorithm {@link #getWork() Pulls} a {@link WorkBatch batch of work} (either its own or by
  *            stealing), then processes each combination in the batch by
  *            {@link #satisfiesOddAdjacency(short[]) checking} for odd adjacency. If the combination
@@ -93,24 +109,8 @@ import org.apache.logging.log4j.Logger;
  *            puzzle. If a solution is found, it is logged and other threads are signaled to
  *            terminate. If no work is available, the monkey checks for its exit condition and (if
  *            not met) sleeps briefly before retrying.
- * @threading Each monkey is its own {@link java.lang.Thread thread}, operating independently with
- *            its own testing resources. Work is {@link #getWork() obtained} in a thread-safe manner
- *            from a {@link CombinationQueue queue} ({@link #combinationQueue its own} or another's
- *            via stealing) and uses pre-initialized thread-specific data structures to operate on
- *            them.
- * @performance The main loop's overall time complexity is O(n * m) per batch, where n is the number
- *              of combinations in the batch and m is the combination length. The
- *              {@link #satisfiesOddAdjacency(short[]) odd adjacency check} is O(m). However, due to
- *              pruning and parallelism, the effective workload is significantly reduced. Most
- *              bottlenecks arise from contention on shared resources or the process of enqueuing
- *              batches.
  * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
  *         in the hot path. The only allocations in the hot path are due to logging overhead.
- * @see CombinationGeneratorTask
- * @see CombinationQueue
- * @see CombinationQueueArray
- * @see Grid
- * @see WorkBatch
  */
 public class TestClickCombination extends Thread {
     /**
@@ -130,14 +130,14 @@ public class TestClickCombination extends Thread {
      * monkeys can continue processing without being blocked by logging operations.
      * </p>
      * 
-     * @since 2025.05.04 - Async Logging Introduction
-     * @threading The logger is thread-safe and can be used concurrently by multiple threads.
-     * @performance Logging operations are offloaded to a separate thread, minimizing impact on the main
-     *              processing loop.
-     * @memory The logger itself has a minimal memory footprint and tries to reuse objects to reduce GC
-     *         pressure.
      * @see #run()
      * @see CombinationMessage
+     * @since 2025.05.04 - Async Logging Introduction
+     * @performance Logging operations are offloaded to a separate thread, minimizing impact on the main
+     *              processing loop.
+     * @threading The logger is thread-safe and can be used concurrently by multiple threads.
+     * @memory The logger itself has a minimal memory footprint and tries to reuse objects to reduce GC
+     *         pressure.
      */
     private static final Logger logger = LogManager.getLogger(TestClickCombination.class);
     /**
@@ -151,12 +151,12 @@ public class TestClickCombination extends Thread {
      * only every N failures, where N is defined by this constant.
      * </p>
      * 
-     * @since 2025.05.31 - Logging Threshold Introduction
-     * @threading This constant is immutable and thread-safe.
-     * @performance O(1) check per failed combination.
-     * @memory Minimal memory impact as it's just a single integer.
      * @see #run()
      * @see CombinationMessage
+     * @since 2025.05.31 - Logging Threshold Introduction
+     * @performance O(1) check per failed combination.
+     * @threading This constant is immutable and thread-safe.
+     * @memory Minimal memory impact as it's just a single integer.
      */
     private static final int LOG_EVERY_N_FAILURES = 100_000; // Log every N failures to avoid flooding the logs
 
@@ -170,13 +170,13 @@ public class TestClickCombination extends Thread {
      * {@link CombinationQueueArray queue array}, and failing that, will sleep briefly before retrying.
      * </p>
      * 
-     * @since 2025.05.23 - Dedicated Queue per Monkey
-     * @threading This field is final and immutable, ensuring thread safety.
-     * @performance O(1) work retrieval from this queue and O(1) accesses of this reference.
      * @see #queueArray
+     * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
      * @see #allQueuesEmpty()
      * @see #getWork()
-     * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
+     * @since 2025.05.23 - Dedicated Queue per Monkey
+     * @performance O(1) work retrieval from this queue and O(1) accesses of this reference.
+     * @threading This field is final and immutable, ensuring thread safety.
      */
     private final CombinationQueue combinationQueue;
     /**
@@ -191,10 +191,10 @@ public class TestClickCombination extends Thread {
      * to the shared queue array gives the monkeys access to this information.
      * </p>
      * 
-     * @since 2025.05.23 - Dedicated Queue per Monkey
-     * @threading This field is final and immutable, ensuring thread safety.
-     * @performance O(1) accesses of this reference.
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
+     * @since 2025.05.23 - Dedicated Queue per Monkey
+     * @performance O(1) accesses of this reference.
+     * @threading This field is final and immutable, ensuring thread safety.
      */
     private final CombinationQueueArray queueArray;
     /**
@@ -207,11 +207,11 @@ public class TestClickCombination extends Thread {
      * initialized with the puzzle's initial state and is reset after each combination is tested.
      * </p>
      * 
-     * @since 2025.04.01 - Multi-threaded Solver Introduction
-     * @threading This field is final and immutable, ensuring thread safety.
-     * @performance O(1) accesses of this reference.
      * @see #run()
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
+     * @since 2025.04.01 - Multi-threaded Solver Introduction
+     * @performance O(1) accesses of this reference.
+     * @threading This field is final and immutable, ensuring thread safety.
      */
     private final Grid puzzleGrid;
 
@@ -237,13 +237,13 @@ public class TestClickCombination extends Thread {
      * just one long per cell (and perform one bitwise operation per click).
      * </p>
      * 
+     * @see #EXPECTED_MASK
+     * @see #satisfiesOddAdjacency(short[])
      * @since 2025.06.30 - Bitmask Pre-computations
+     * @performance O(1) lookup time for each cell in the combination.
      * @threading The lookup table is initialized once per puzzle in a thread-safe manner using
      *             double-checked locking.
-     * @performance O(1) lookup time for each cell in the combination.
      * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes).
-     * @see EXPECTED_MASK
-     * @see #satisfiesOddAdjacency(short[])
      */
     private static volatile long[] CLICK_TO_TRUE_CELL_MASK = null;
     /**
@@ -266,13 +266,13 @@ public class TestClickCombination extends Thread {
      * thread ever has to compute the mask, and all threads can read it without contention.
      * </p>
      * 
+     * @see #CLICK_TO_TRUE_CELL_MASK
+     * @see #satisfiesOddAdjacency(short[])
      * @since 2025.06.30 - Bitmask Pre-computations
+     * @performance O(1) lookup time.
      * @threading The expected mask is computed once per puzzle in a thread-safe manner using
      *             double-checked locking.
-     * @performance O(1) lookup time.
      * @memory The expected mask is a single long value, taking up just 8 bytes.
-     * @see CLICK_TO_TRUE_CELL_MASK
-     * @see #satisfiesOddAdjacency(short[])
      */
     private static volatile long EXPECTED_MASK = 0L;
 
@@ -311,21 +311,21 @@ public class TestClickCombination extends Thread {
      *                         working on the same puzzle.
      * @param puzzleGrid       the <b>UNIQUE</b> {@link Grid grid} that this monkey will apply
      *                         combinations to. Do not share grids between monkeys.
-     * @since 2025.04.01 - Monkey Thread Introduction
-     * @threading Thread-safe since the lookup table is statically initialized and all other fields are
-     *            final.
-     * @performance O(1) assignments and a single call to initialize the lookup table.
-     * @memory Memory usage is minimal, with only a few references and primitive fields. The only
-     *         explicit allocation in this method (other than the thread itself) is the allocation of a
-     *         trueCells <code>short[]</code> for lookup table initialization.
      * @see #combinationQueue
-     * @see #queueArray
      * @see #puzzleGrid
+     * @see #queueArray
      * @see #initializeLookupTable(short[])
      * @see CombinationQueue
      * @see CombinationQueueArray
      * @see Grid
      * @see Grid#findTrueCells(Grid.ValueFormat)
+     * @since 2025.04.01 - Monkey Thread Introduction
+     * @performance O(1) assignments and a single call to initialize the lookup table.
+     * @threading Thread-safe since the lookup table is statically initialized and all other fields are
+     *            final.
+     * @memory Memory usage is minimal, with only a few references and primitive fields. The only
+     *         explicit allocation in this method (other than the thread itself) is the allocation of a
+     *         trueCells <code>short[]</code> for lookup table initialization.
      */
     public TestClickCombination(String threadName, CombinationQueue combinationQueue,
                                CombinationQueueArray queueArray, Grid puzzleGrid) {
@@ -375,15 +375,15 @@ public class TestClickCombination extends Thread {
      * </p>
      * 
      * @param trueCells the array of initially true cells in {@link Grid.ValueFormat#Index index} format
-     * @since 2025.07.13 - Long Array Grid State Representation
-     * @threading Thread-safe due to double-checked locking.
-     * @performance O(n * m) where n is the number of clicks (109) and m is the number of true cells.
-     * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes). The
-     *         expected mask is a single long value, taking up 8 bytes.
-     * @algorithm Pre-computation of click masks for fast odd adjacency checks.
-     * @optimization Uses double-checked locking for thread-safe lazy initialization.
      * @see #CLICK_TO_TRUE_CELL_MASK
      * @see #EXPECTED_MASK
+     * @since 2025.07.13 - Long Array Grid State Representation
+     * @performance O(n * m) where n is the number of clicks (109) and m is the number of true cells.
+     * @threading Thread-safe due to double-checked locking.
+     * @algorithm Pre-computation of click masks for fast odd adjacency checks.
+     * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes). The
+     *         expected mask is a single long value, taking up 8 bytes.
+     * @optimization Uses double-checked locking for thread-safe lazy initialization.
      */
     private static void initializeLookupTable(short[] trueCells) {
         // Double-checked locking for thread-safe lazy initialization
@@ -493,25 +493,25 @@ public class TestClickCombination extends Thread {
      * more efficient logging.
      * </p>
      * 
+     * @see #allQueuesEmpty()
+     * @see #getWork()
+     * @see #satisfiesOddAdjacency(short[])
+     * @see #triggerGeneratorShutdown()
+     * @see CombinationQueue
+     * @see CombinationQueueArray
+     * @see Grid
+     * @see WorkBatch
      * @since 2025.04.01 - Monkey Thread Introduction
+     * @performance O(n) per batch, where n is the number of combinations in the batch. The odd
+     *              adjacency check is O(m), where m is the combination length.
      * @threading This method is executed by a single thread, which processes work from its own queue
      *            and potentially steals from others. It is designed to be thread-safe with respect to
      *            the shared {@link CombinationQueueArray} and uses its own {@link Grid} for safety.
-     * @performance O(n) per batch, where n is the number of combinations in the batch. The odd
-     *              adjacency check is O(m), where m is the combination length.
-     * @memory Other than logging overhead, this method does not allocate any objects in the hot path.
      * @algorithm Brute force search with pruning based on odd adjacency checks.
+     * @memory Other than logging overhead, this method does not allocate any objects in the hot path.
      * @optimization Avoids unnecessary branching and redundant checks by processing entire batches in a
      *               single loop. Uses bitmasking for fast odd adjacency checks that prune invalid
      *               combinations before they reach the grid.
-     * @see #satisfiesOddAdjacency(short[])
-     * @see #triggerGeneratorShutdown()
-     * @see #getWork()
-     * @see #allQueuesEmpty()
-     * @see CombinationQueue
-     * @see CombinationQueueArray
-     * @see WorkBatch
-     * @see Grid
      */
     @Override
     public void run() {
@@ -611,13 +611,13 @@ public class TestClickCombination extends Thread {
      * and can be handled during the initialization of the pool in {@link StartYourMonkeys#main(String[])}.
      * </p>
      * 
-     * @since 2025.07.23 - Explicit Cancellation Checks Removal
-     * @threading This method is thread-safe as it accesses the ForkJoinPool in a safe manner.
-     * @performance O(1) operation to trigger the shutdown.
-     * @optimization Uses the built-in shutdown mechanism of ForkJoinPool to avoid adding overhead to
-     *               the generators.
      * @see CombinationGeneratorTask
      * @see java.util.concurrent.ForkJoinPool
+     * @since 2025.07.23 - Explicit Cancellation Checks Removal
+     * @performance O(1) operation to trigger the shutdown.
+     * @threading This method is thread-safe as it accesses the ForkJoinPool in a safe manner.
+     * @optimization Uses the built-in shutdown mechanism of ForkJoinPool to avoid adding overhead to
+     *               the generators.
      */
     private void triggerGeneratorShutdown() {
         // Access the generator pool from CombinationGeneratorTask if stored there,
@@ -673,18 +673,18 @@ public class TestClickCombination extends Thread {
      * 
      * @return a {@link WorkBatch} of combinations to process, or <code>null</code> if no work is
      *         available
+     * @see CombinationQueue
+     * @see CombinationQueueArray
+     * @see WorkBatch
      * @since 2025.07.07 - Enqueueing Work Batches
      * @performance O(1) to steal from the first available queue, or O(n) in the worst case where n is
      *              the number of queues
-     * @memory Minimal memory impact as it only returns a reference to an existing WorkBatch object.
      * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
      *            thread-safe methods.
      * @algorithm Work-stealing algorithm to obtain work batches from queues.
+     * @memory Minimal memory impact as it only returns a reference to an existing WorkBatch object.
      * @optimization Designed to minimize contention and branching, allowing for aggressive JIT
      *               optimizations.
-     * @see CombinationQueueArray
-     * @see CombinationQueue
-     * @see WorkBatch
      */
     private WorkBatch getWork() {
         // Try my own queue first
@@ -733,15 +733,15 @@ public class TestClickCombination extends Thread {
      * </p>
      * 
      * @return <code>true</code> if all queues are empty, <code>false</code> otherwise.
-     * @since 2025.08.02 - Preallocate WorkBatches for Queues
-     * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
-     *            thread-safe methods.
-     * @performance O(n) where n is the number of queues, but not performance-critical as it is only called
-     *              during exit condition checks.
-     * @memory Does not allocate any objects, only uses existing references.
      * @see CombinationQueue
      * @see CombinationQueue#isEmpty()
      * @see CombinationQueueArray
+     * @since 2025.08.02 - Preallocate WorkBatches for Queues
+     * @performance O(n) where n is the number of queues, but not performance-critical as it is only called
+     *              during exit condition checks.
+     * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
+     *            thread-safe methods.
+     * @memory Does not allocate any objects, only uses existing references.
      */
     private boolean allQueuesEmpty() {
         for (CombinationQueue q : queueArray.getAllQueues())
@@ -853,19 +853,19 @@ public class TestClickCombination extends Thread {
      *                    format
      * @return <code>true</code> if the combination satisfies the odd adjacency condition,
      *         <code>false</code> otherwise
-     * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
-     * @performance O(n) where n is the length of the combination.
-     * @memory Minimal memory impact as it only uses existing arrays and a few primitive variables (that
-     *         allocate on the stack).
-     * @threading This method is thread-safe as it only reads from shared static data that is immutable
-     *            after initialization.
-     * @optimization Uses bitmasking and bitwise operations for fast checks. Designed to be JIT-friendly
-     *               with minimal branching and encourages inlining and loop unrolling.
      * @see #CLICK_TO_TRUE_CELL_MASK
      * @see #EXPECTED_MASK
      * @see #initializeLookupTable(short[])
      * @see Grid#areAdjacent(short, short)
      * @see Grid#findTrueCells(com.github.mrgarbagegamer.Grid.ValueFormat)
+     * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
+     * @performance O(n) where n is the length of the combination.
+     * @threading This method is thread-safe as it only reads from shared static data that is immutable
+     *            after initialization.
+     * @memory Minimal memory impact as it only uses existing arrays and a few primitive variables (that
+     *         allocate on the stack).
+     * @optimization Uses bitmasking and bitwise operations for fast checks. Designed to be JIT-friendly
+     *               with minimal branching and encourages inlining and loop unrolling.
      */
     private final boolean satisfiesOddAdjacency(short[] combination) {
         // JIT OPTIMIZATION: Cache array references and length to encourage optimization

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -5,6 +5,29 @@ import java.util.concurrent.ForkJoinPool;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * TestClickCombination - [Worker Purpose - e.g., "ForkJoin recursive combination generator"]
+ * 
+ * <p>[High-level description of what this worker does in the algorithm.
+ * Explain its role in the concurrent processing pipeline.]</p>
+ * 
+ * <h2>Execution Model</h2>
+ * <p>[How this task executes - recursive subdivision, work-stealing, etc.
+ * Include task granularity and splitting criteria.]</p>
+ * 
+ * <h2>Resource Management</h2>
+ * <p>[How resources are acquired, used, and cleaned up. Pool usage patterns.]</p>
+ * 
+ * <h2>Performance Critical Paths</h2>
+ * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
+ * 
+ * <h3>0/15 - 0% of documentation completed</h3>
+ * 
+ * @algorithm [Detailed algorithm description with complexity analysis]
+ * @threading [Concurrency model and synchronization approach]
+ * @performance [Performance characteristics and bottleneck analysis]
+ * @see [Related worker classes and coordination mechanisms]
+ */
 public class TestClickCombination extends Thread
 {
     private static final Logger logger = LogManager.getLogger(TestClickCombination.class);

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -6,15 +6,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * TestClickCombination - Highly optimized worker thread that tests click combinations on a puzzle
- * grid.
+ * A highly optimized worker thread that tests click combinations on a {@link Grid puzzle grid}.
  * 
  * <p>
  * This class represents a worker thread that continuously {@link #getWork() fetches} click
  * combinations from {@link CombinationQueue a queue} (either its own or by stealing from others),
  * {@link #satisfiesOddAdjacency(short[]) checks them for odd adjacency}, and applies them to a
- * {@link Grid puzzle grid} to see if they solve the puzzle. It is designed to be efficient and
- * responsive, minimizing contention and branching to allow for aggressive JIT optimizations.
+ * puzzle grid to see if they solve the puzzle. It is designed to be efficient and responsive,
+ * minimizing contention and branching to allow for aggressive JIT optimizations.
  * </p>
  * 
  * <p>
@@ -66,8 +65,8 @@ import org.apache.logging.log4j.Logger;
  * generators is that monkeys' execution is confined to {@link #run() a loop}, and each monkey is
  * its own {@link java.lang.Thread Thread}. Since monkeys do not have changing contexts, their
  * lifecycle is simpler and we can avoid using {@link java.lang.ThreadLocal ThreadLocals}. This
- * saves us the overhead of calling and managing <code>ThreadLocal</code>s, which can be significant
- * in tight loops.
+ * saves us the overhead of calling and managing {@code ThreadLocal}s, which can be significant in
+ * tight loops.
  * </p>
  * 
  * <p>
@@ -91,12 +90,12 @@ import org.apache.logging.log4j.Logger;
  * @see Grid
  * @see WorkBatch
  * @since 2025.04.01 - Multi-threaded Solver Introduction
- * @performance The main loop's overall time complexity is O(n * m) per batch, where n is the number
- *              of combinations in the batch and m is the combination length. The
- *              {@link #satisfiesOddAdjacency(short[]) odd adjacency check} is O(m). However, due to
- *              pruning and parallelism, the effective workload is significantly reduced. Most
- *              bottlenecks arise from contention on shared resources or the process of enqueuing
- *              batches.
+ * @performance The main loop's overall time complexity is
+ *              <code>O({@link CombinationGeneratorTask#BATCH_SIZE BATCH_SIZE} × combination.length)</code> per
+ *              batch. The {@link #satisfiesOddAdjacency(short[]) odd adjacency check} is
+ *              {@code O(combination.length)}. However, due to pruning and parallelism, the
+ *              effective workload is significantly reduced. Most bottlenecks arise from contention
+ *              on shared resources or the process of enqueuing batches.
  * @threading Each monkey is its own {@link java.lang.Thread thread}, operating independently with
  *            its own testing resources. Work is {@link #getWork() obtained} in a thread-safe manner
  *            from a {@link CombinationQueue queue} ({@link #combinationQueue its own} or another's
@@ -147,14 +146,14 @@ public class TestClickCombination extends Thread {
      * 
      * <p>
      * Logging is purely a diagnostic feature and does not affect the algorithm, but excessive logging
-     * can block threads and degrade performance, even with asynchronous logging. Therefore, we log
-     * only every N failures, where N is defined by this constant.
+     * can block threads and degrade performance, even with asynchronous logging. Therefore, we log only
+     * every N failures, where N is defined by this constant.
      * </p>
      * 
      * @see #run()
      * @see CombinationMessage
      * @since 2025.05.31 - Logging Threshold Introduction
-     * @performance O(1) check per failed combination.
+     * @performance {@code O(1)} check per failed combination.
      * @threading This constant is immutable and thread-safe.
      * @memory Minimal memory impact as it's just a single integer.
      */
@@ -175,7 +174,8 @@ public class TestClickCombination extends Thread {
      * @see #allQueuesEmpty()
      * @see #getWork()
      * @since 2025.05.23 - Dedicated Queue per Monkey
-     * @performance O(1) work retrieval from this queue and O(1) accesses of this reference.
+     * @performance {@code O(1)} work retrieval from this queue and {@code O(1)} accesses of this
+     *              reference.
      * @threading This field is final and immutable, ensuring thread safety.
      */
     private final CombinationQueue combinationQueue;
@@ -193,7 +193,7 @@ public class TestClickCombination extends Thread {
      * 
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
      * @since 2025.05.23 - Dedicated Queue per Monkey
-     * @performance O(1) accesses of this reference.
+     * @performance {@code O(1)} accesses of this reference.
      * @threading This field is final and immutable, ensuring thread safety.
      */
     private final CombinationQueueArray queueArray;
@@ -210,7 +210,7 @@ public class TestClickCombination extends Thread {
      * @see #run()
      * @see #TestClickCombination(String, CombinationQueue, CombinationQueueArray, Grid)
      * @since 2025.04.01 - Multi-threaded Solver Introduction
-     * @performance O(1) accesses of this reference.
+     * @performance {@code O(1)} accesses of this reference.
      * @threading This field is final and immutable, ensuring thread safety.
      */
     private final Grid puzzleGrid;
@@ -223,8 +223,8 @@ public class TestClickCombination extends Thread {
      * <p>
      * While generators have their own pruning logic, the vast majority of combinations that make their
      * way to monkeys are not valid due to odd adjacency violations, and we need to filter these out
-     * before they reach the grid. To do this, we need a mechanism to quickly check what true cells a
-     * click will affect, and we can use a bitmask for this purpose.
+     * before they reach the grid. To do this, we need a mechanism to quickly check what {@code true}
+     * cells a click will affect, and we can use a bitmask for this purpose.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -232,47 +232,50 @@ public class TestClickCombination extends Thread {
      * We statically initialize this table once per puzzle in {@link #initializeLookupTable(short[])}
      * using double-checked locking to ensure thread safety. This avoids redundant computation and
      * allows all threads to share the same table without contention, which is crucial for performance.
-     * Bitmasks are used to efficiently represent the affected true cells, and while a long can only store
-     * 64 bits of data, all puzzles in this game have less than 64 initially true cells, letting us use
-     * just one long per cell (and perform one bitwise operation per click).
+     * Bitmasks are used to efficiently represent the affected true cells, and while a long can only
+     * store 64 bits of data, all puzzles in this game have less than 64 initially {@code true} cells,
+     * letting us use just one {@code long} per cell (and perform one bitwise operation per click).
      * </p>
      * 
      * @see #EXPECTED_MASK
      * @see #satisfiesOddAdjacency(short[])
      * @since 2025.06.30 - Bitmask Pre-computations
-     * @performance O(1) lookup time for each cell in the combination.
+     * @performance {@code O(1)} lookup time for each cell in the combination.
      * @threading The lookup table is initialized once per puzzle in a thread-safe manner using
-     *             double-checked locking.
-     * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes).
+     *            double-checked locking.
+     * @memory The lookup table is an array of 109 {@code long} values, taking up 872 bytes (109 * 8
+     *         bytes).
      */
     private static volatile long[] CLICK_TO_TRUE_CELL_MASK = null;
     /**
-     * The expected mask for a valid combination of clicks, which is the bitmask where all true cells
-     * are set to 1. This is computed once during initialization and used to validate combinations.
+     * The expected mask for a valid combination of clicks, which is the bitmask where all {@code true}
+     * cells are set to 1. This is computed once during initialization and used to validate
+     * combinations.
      * 
      * <p>
      * As part of the odd adjacency check in monkey threads, we need to ensure that the number of clicks
-     * affecting each true cell is odd, which is done by XORing the mask for each click in
+     * affecting each {@code true} cell is odd, which is done by XORing the mask for each click in
      * {@link #CLICK_TO_TRUE_CELL_MASK}. A valid combination would have all 1s in the mask up to the
-     * number of true cells, but we can't know the value until we have the true cells. Recomputing the
-     * mask every time we perform a check would be inefficient, so we compute it once during
-     * initialization and store it here.
+     * number of {@code true} cells, but we can't know the value until we have the {@code true} cells.
+     * Recomputing the mask every time we perform a check would be inefficient, so we compute it once
+     * during initialization and store it here.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * Bitmasks are used for their efficiency in representing the state of affected true cells as well
-     * as their fast operations. By making this variable static and volatile, we ensure that only one
-     * thread ever has to compute the mask, and all threads can read it without contention.
+     * Bitmasks are used for their efficiency in representing the state of affected {@code true} cells
+     * as well as their fast operations. By making this variable {@code static} and {@code volatile}, we
+     * ensure that only one thread ever has to compute the mask, and all threads can read it without
+     * contention.
      * </p>
      * 
      * @see #CLICK_TO_TRUE_CELL_MASK
      * @see #satisfiesOddAdjacency(short[])
      * @since 2025.06.30 - Bitmask Pre-computations
-     * @performance O(1) lookup time.
+     * @performance {@code O(1)} lookup time.
      * @threading The expected mask is computed once per puzzle in a thread-safe manner using
-     *             double-checked locking.
-     * @memory The expected mask is a single long value, taking up just 8 bytes.
+     *            double-checked locking.
+     * @memory The expected mask is a single {@code long} value, taking up just 8 bytes.
      */
     private static volatile long EXPECTED_MASK = 0L;
 
@@ -298,10 +301,11 @@ public class TestClickCombination extends Thread {
      * <p>
      * This constructor is not performance-critical as it is only called once per monkey thread. We
      * delegate most of the allocation work to the caller to allow for more flexible resource management
-     * and make the monkeys' constructor simpler. The queue array could be made static for the class and
-     * be set by a static method, though we left this as-is for simplicity. Making the queue array
-     * static could be a future optimization if we find that the overhead of passing it around is
-     * significant and want to save on the memory footprint of storing a reference in each monkey.
+     * and make the monkeys' constructor simpler. The queue array could be made {@code static} for the
+     * class and be set by a {@code static} method, though we left this as-is for simplicity. Making the
+     * queue array {@code static} could be a future optimization if we find that the overhead of passing
+     * it around is significant and want to save on the memory footprint of storing a reference in each
+     * monkey.
      * </p>
      * 
      * @param threadName       the <b>UNIQUE</b> name for this monkey thread, used in logging.
@@ -320,15 +324,15 @@ public class TestClickCombination extends Thread {
      * @see Grid
      * @see Grid#findTrueCells(Grid.ValueFormat)
      * @since 2025.04.01 - Monkey Thread Introduction
-     * @performance O(1) assignments and a single call to initialize the lookup table.
+     * @performance {@code O(1)} assignments and a single call to initialize the lookup table.
      * @threading Thread-safe since the lookup table is statically initialized and all other fields are
      *            final.
      * @memory Memory usage is minimal, with only a few references and primitive fields. The only
      *         explicit allocation in this method (other than the thread itself) is the allocation of a
-     *         trueCells <code>short[]</code> for lookup table initialization.
+     *         trueCells {@code short[]} for lookup table initialization.
      */
-    public TestClickCombination(String threadName, CombinationQueue combinationQueue,
-                               CombinationQueueArray queueArray, Grid puzzleGrid) {
+    public TestClickCombination(String threadName, CombinationQueue combinationQueue, CombinationQueueArray queueArray,
+            Grid puzzleGrid) {
         super(threadName);
         this.combinationQueue = combinationQueue;
         this.queueArray = queueArray;
@@ -340,13 +344,13 @@ public class TestClickCombination extends Thread {
     }
 
     /**
-     * Initializes the lookup table for click combinations based on the provided true cells.
+     * Initializes the lookup table for click combinations based on the provided {@code true} cells.
      * 
      * <p>
      * To efficiently prune combinations that do not satisfy the odd adjacency/parity condition, we need
-     * a way to quickly check which true cells are affected by each possible click. Though it's possible
-     * to compute this on-the-fly, it would incur a significant performance penalty due to the redundant
-     * calculations and temporary allocation overhead. The pre-computed masks in
+     * a way to quickly check which {@code true} cells are affected by each possible click. Though it's
+     * possible to compute this on-the-fly, it would incur a significant performance penalty due to the
+     * redundant calculations and temporary allocation overhead. The pre-computed masks in
      * {@link #CLICK_TO_TRUE_CELL_MASK} solve both of these issues, but a pre-computed mask is nothing
      * without code to generate it. This method fills these masks based on the initial state of the
      * grid.
@@ -355,34 +359,34 @@ public class TestClickCombination extends Thread {
      * <h3>Algorithm Details</h3>
      * <p>
      * The method first checks if the lookup table has already been initialized using double-checked
-     * locking to ensure thread safety. If it hasn't, it creates a new array of long values, one for
-     * each possible click (109 total). It then iterates over each possible click and, for each true
+     * locking to ensure thread safety. If it hasn't, it creates a new array of {@code long} values, one
+     * for each possible click (109 total). It then iterates over each possible click and, for each true
      * cell, checks if the click is adjacent to the true cell using
      * {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}. If they are adjacent, it sets the
      * corresponding bit in the mask for that click. After processing all possible clicks, it computes
      * the {@link #EXPECTED_MASK expected mask} (a mask containing all bits set to 1 for the number of
-     * true cells) and atomically publishes the results to the static variables
-     * <code>CLICK_TO_TRUE_CELL_MASK</code> and <code>EXPECTED_MASK.</code>
+     * {@code true} cells) and atomically publishes the results to the {@code static} variables
+     * {@code CLICK_TO_TRUE_CELL_MASK} and {@code EXPECTED_MASK.}
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Since this method is only called once per puzzle, it is not performance-critical, allowing for
-     * more complex logic without impacting the overall performance of the solver. We use a simple long
-     * array to store the masks for quick accesses and bitwise operations, and we pre-compute as much as
-     * we can to avoid redundant calculations during the {@link #satisfiesOddAdjacency(short[]) odd
-     * adjacency checks}.
+     * more complex logic without impacting the overall performance of the solver. We use a simple
+     * {@code long[]} to store the masks for quick accesses and bitwise operations, and we pre-compute
+     * as much as we can to avoid redundant calculations during the
+     * {@link #satisfiesOddAdjacency(short[]) odd adjacency checks}.
      * </p>
      * 
      * @param trueCells the array of initially true cells in {@link Grid.ValueFormat#Index index} format
      * @see #CLICK_TO_TRUE_CELL_MASK
      * @see #EXPECTED_MASK
      * @since 2025.07.13 - Long Array Grid State Representation
-     * @performance O(n * m) where n is the number of clicks (109) and m is the number of true cells.
+     * @performance <code>O({@value Grid#NUM_CELLS} × trueCells.length)</code>.
      * @threading Thread-safe due to double-checked locking.
      * @algorithm Pre-computation of click masks for fast odd adjacency checks.
-     * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes). The
-     *         expected mask is a single long value, taking up 8 bytes.
+     * @memory The lookup table is an array of 109 {@code long} values, taking up 872 bytes (109 * 8
+     *         bytes). The expected mask is a single {@code long} value, taking up 8 bytes.
      * @optimization Uses double-checked locking for thread-safe lazy initialization.
      */
     private static void initializeLookupTable(short[] trueCells) {
@@ -420,8 +424,8 @@ public class TestClickCombination extends Thread {
     /**
      * The main execution loop for the TestClickCombination thread. This method continuously processes
      * click combinations from {@link WorkBatch a batch} obtained from a {@link CombinationQueue queue},
-     * {@link #satisfiesOddAdjacency(short[]) checks} them for odd adjacency, and applies them
-     * to the {@link Grid puzzle grid} to see if they solve the puzzle.
+     * {@link #satisfiesOddAdjacency(short[]) checks} them for odd adjacency, and applies them to the
+     * {@link Grid puzzle grid} to see if they solve the puzzle.
      * 
      * <p>
      * To operate as an independent worker, the monkey needs a core loop that can fetch work, process
@@ -476,16 +480,16 @@ public class TestClickCombination extends Thread {
      * Some potential areas for future optimization include a shift towards an explicit cancellation
      * mechanism for the monkeys similar to that of the generators. If the winning monkey can directly
      * signal for all other monkeys to terminate, we can avoid the need for them to check the
-     * solutionFound flag on every iteration, which would reduce the overhead of constant volatile
-     * reads.
+     * {@code solutionFound} flag on every iteration, which would reduce the overhead of constant
+     * {@code volatile} reads.
      * </p>
      * 
      * <p>
      * We could also rework the logging mechanism with {@link CombinationMessage} to try to allow for
      * more efficient, GC-free logging of combinations rather than the current approach that creates a
-     * new CombinationMessage object for each log entry. This would reduce the memory overhead and help
-     * bring down the number of temporary objects created, but it would require a more complex approach
-     * to interface with {@link org.apache.logging.log4j.message.ReusableMessage} and
+     * new {@code CombinationMessage} object for each log entry. This would reduce the memory overhead
+     * and help bring down the number of temporary objects created, but it would require a more complex
+     * approach to interface with {@link org.apache.logging.log4j.message.ReusableMessage} and
      * {@link org.apache.logging.log4j.message.MessageFactory}. Previous attempts have been made to
      * implement this, but it's going to take some clever design to avoid concurrent modification issues
      * (since async logging can modify the message while we're trying to log it). However, this may be
@@ -502,8 +506,9 @@ public class TestClickCombination extends Thread {
      * @see Grid
      * @see WorkBatch
      * @since 2025.04.01 - Monkey Thread Introduction
-     * @performance O(n) per batch, where n is the number of combinations in the batch. The odd
-     *              adjacency check is O(m), where m is the combination length.
+     * @performance <code>O({@link CombinationGeneratorTask#BATCH_SIZE BATCH_SIZE})</code> per batch,
+     *              excluding the cost of {@link #getWork() getting work}, logging, and
+     *              {@link #satisfiesOddAdjacency(short[]) odd adjacency checks}.
      * @threading This method is executed by a single thread, which processes work from its own queue
      *            and potentially steals from others. It is designed to be thread-safe with respect to
      *            the shared {@link CombinationQueueArray} and uses its own {@link Grid} for safety.
@@ -608,16 +613,17 @@ public class TestClickCombination extends Thread {
      * <p>
      * We have to statically access the generator pool from the {@link CombinationGeneratorTask} class,
      * as monkeys do not have direct access to the pool. This isn't perfect, but is simple for our needs
-     * and can be handled during the initialization of the pool in {@link StartYourMonkeys#main(String[])}.
+     * and can be handled during the initialization of the pool in
+     * {@link StartYourMonkeys#main(String[])}.
      * </p>
      * 
      * @see CombinationGeneratorTask
      * @see java.util.concurrent.ForkJoinPool
      * @since 2025.07.23 - Explicit Cancellation Checks Removal
-     * @performance O(1) operation to trigger the shutdown.
-     * @threading This method is thread-safe as it accesses the ForkJoinPool in a safe manner.
-     * @optimization Uses the built-in shutdown mechanism of ForkJoinPool to avoid adding overhead to
-     *               the generators.
+     * @performance {@code O(1)} operation to trigger the shutdown.
+     * @threading This method is thread-safe as it accesses the {@code ForkJoinPool} in a safe manner.
+     * @optimization Uses the built-in shutdown mechanism of {@code ForkJoinPool} to avoid adding
+     *               overhead to the generators.
      */
     private void triggerGeneratorShutdown() {
         // Access the generator pool from CombinationGeneratorTask if stored there,
@@ -649,7 +655,7 @@ public class TestClickCombination extends Thread {
      * monkey's own queue. If that queue is empty, it attempts to steal a batch from another queue,
      * iterating across the queues in increasing order of their indices. The method is short-circuiting,
      * returning the first non-null batch it finds. If no batches are available in any queue, it returns
-     * <code>null</code>, indicating that there is no work to process at the moment.
+     * {@code null}, indicating that there is no work to process at the moment.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -665,24 +671,24 @@ public class TestClickCombination extends Thread {
      * We could potentially optimize this further by implementing a more sophisticated work-stealing
      * algorithm that takes into account the load of each queue, but that would require extra logic that
      * may be too high in overhead for the benefit it provides (since
-     * {@link org.jctools.queues.MpmcArrayQueue#size() size()} calls are not O(1)). Caching the
+     * {@link org.jctools.queues.MpmcArrayQueue#size() size()} calls are not {@code O(1)}). Caching the
      * reference to the array of queues could be beneficial as a micro-optimization, but it isn't likely
      * to have a major impact since the compiler's profiling will likely determine that the array
      * reference is stable and optimize accordingly.
      * </p>
      * 
-     * @return a {@link WorkBatch} of combinations to process, or <code>null</code> if no work is
-     *         available
+     * @return a {@link WorkBatch} of combinations to process, or {@code null} if no work is available
      * @see CombinationQueue
      * @see CombinationQueueArray
      * @see WorkBatch
      * @since 2025.07.07 - Enqueueing Work Batches
-     * @performance O(1) to steal from the first available queue, or O(n) in the worst case where n is
-     *              the number of queues
+     * @performance {@code O(1)} to steal from the first available queue, or
+     *              <code>O({@link CombinationQueueArray#getAllQueues() queueArray.getAllQueues()}.length)</code> in
+     *              the worst case.
      * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
      *            thread-safe methods.
      * @algorithm Work-stealing algorithm to obtain work batches from queues.
-     * @memory Minimal memory impact as it only returns a reference to an existing WorkBatch object.
+     * @memory Minimal memory impact as it only returns a reference to an existing {@code WorkBatch}.
      * @optimization Designed to minimize contention and branching, allowing for aggressive JIT
      *               optimizations.
      */
@@ -714,31 +720,35 @@ public class TestClickCombination extends Thread {
      * still available.
      * 
      * <p>
-     * Since monkeys and {@link CombinationGeneratorTask generators} operate independently and the program can be
-     * run on puzzle configurations without a solution, it is possible for all generators to finish generating
-     * combinations and exit before the monkeys have processed all available work. Monkeys can't just exit the second
-     * that {@link CombinationQueueArray#generationComplete generation is marked as complete}, since there may still be
-     * work left in the queues. On the other hand, monkeys can't just wait indefinitely for new work to be generated, since
-     * if the generators are done, no new work will ever arrive. Therefore, we need another component to our completed generation
-     * exit condition: all queues must be empty. This method checks that condition.
+     * Since monkeys and {@link CombinationGeneratorTask generators} operate independently and the
+     * program can be run on puzzle configurations without a solution, it is possible for all generators
+     * to finish generating combinations and exit before the monkeys have processed all available work.
+     * Monkeys can't just exit the second that {@link CombinationQueueArray#generationComplete
+     * generation is marked as complete}, since there may still be work left in the queues. On the other
+     * hand, monkeys can't just wait indefinitely for new work to be generated, since if the generators
+     * are done, no new work will ever arrive. Therefore, we need another component to our completed
+     * generation exit condition: all queues must be empty. This method checks that condition.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
-     * This method is not performance-critical, as it is only called when a monkey's own queue is empty and
-     * it is checking for exit conditions. Therefore, we can afford to use a simple loop to check each queue, performing
-     * an O(n) operation where n is the number of queues. However, we can't just attempt to poll from each queue for our
-     * check, since that could consume an item and interfere with the normal processing of the queues. Instead, we use the
-     * {@link CombinationQueue#isEmpty() isEmpty()} method, which is a non-destructive, constant-time check.
+     * This method is not performance-critical, as it is only called when a monkey's own queue is empty
+     * and it is checking for exit conditions. Therefore, we can afford to use a simple loop to check
+     * each queue, performing an <code>O({@link CombinationQueueArray#getAllQueues()
+     * queueArray.getAllQueues()}.length)</code> operation. However, we can't just attempt to poll from
+     * each queue for our check, since that could consume an item and interfere with the normal
+     * processing of the queues. Instead, we use the {@link CombinationQueue#isEmpty() isEmpty()}
+     * method, which is a non-destructive, constant-time check.
      * </p>
      * 
-     * @return <code>true</code> if all queues are empty, <code>false</code> otherwise.
+     * @return {@code true} if all queues are empty, {@code false} otherwise.
      * @see CombinationQueue
      * @see CombinationQueue#isEmpty()
      * @see CombinationQueueArray
      * @since 2025.08.02 - Preallocate WorkBatches for Queues
-     * @performance O(n) where n is the number of queues, but not performance-critical as it is only called
-     *              during exit condition checks.
+     * @performance <code>O({@link CombinationQueueArray#getAllQueues()
+     *              queueArray.getAllQueues()}.length)</code>, but not performance-critical as it is
+     *              only called during exit condition checks.
      * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
      *            thread-safe methods.
      * @memory Does not allocate any objects, only uses existing references.
@@ -770,23 +780,23 @@ public class TestClickCombination extends Thread {
      * <li>Clicks toggle the state of the cells adjacent to the clicked cell.</li>
      * <li>Since a cell can only be on or off (true or false), 2 clicks on a cell is the same as no
      * clicks, and 3 clicks is the same as 1 click. This makes the puzzle mod-2.</li>
-     * <li>All initially true cells must therefore be toggled an odd number of times to be turned
-     * off.</li>
+     * <li>All initially {@code true} cells must therefore be toggled an odd number of times to be
+     * turned off.</li>
      * </ul>
-     * Therefore, we can eliminate combinations that do not toggle each initially true cell an odd
-     * number of times.
+     * Therefore, we can eliminate combinations that do not toggle each initially {@code true} cell an
+     * odd number of times.
      * </p>
      * 
      * <h3>Algorithm Details</h3>
      * <p>
-     * Since we only care about initially true cells in this check, we can simplify the grid state to a
-     * bitmask that is the same length as the number of initially true cells, and where each bit
-     * represents whether a true cell is toggled an odd (1) or even (0) number of times. We iterate over
-     * the clicks in the combination and, for each click, we XOR the bitmask of the true cells it
-     * affects (from {@link #CLICK_TO_TRUE_CELL_MASK}) with our running total. At the end, if the
-     * resulting bitmask is equal to the {@link #EXPECTED_MASK expected mask} (where all bits are 1),
-     * then the combination satisfies the odd adjacency condition. Otherwise, it does not meet the
-     * condition and can be discarded.
+     * Since we only care about initially {@code true} cells in this check, we can simplify the grid
+     * state to a bitmask that is the same length as the number of initially {@code true} cells, and
+     * where each bit represents whether a {@code true} cell is toggled an odd (1) or even (0) number of
+     * times. We iterate over the clicks in the combination and, for each click, we XOR the bitmask of
+     * the {@code true} cells it affects (from {@link #CLICK_TO_TRUE_CELL_MASK}) with our running total.
+     * At the end, if the resulting bitmask is equal to the {@link #EXPECTED_MASK expected mask} (where
+     * all bits are 1), then the combination satisfies the odd adjacency condition. Otherwise, it does
+     * not meet the condition and can be discarded.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
@@ -794,10 +804,10 @@ public class TestClickCombination extends Thread {
      * This method is designed to be as efficient as possible, with a focus on minimizing branching and
      * redundant checks. We cache all array references and the length at the start of the method to
      * avoid array dereferencing. By {@link #initializeLookupTable(short[]) precomputing} the necessary
-     * bitmasks for each click, we can reduce the complexity of the check to O(n) per combination, where
-     * n is the length of the combination. The use of bitwise operations (XOR) allows for extremely fast
-     * computations that are well-optimized by the JIT compiler, encouraging inlining and loop
-     * unrolling. The method is also marked as final to further encourage inlining by the JIT.
+     * bitmasks for each click, we can reduce the complexity of the check to
+     * {@code O(combination.length)} per combination. The use of bitwise operations (XOR) allows for
+     * extremely fast computations that are well-optimized by the JIT compiler, encouraging inlining and
+     * loop unrolling. The method is also marked as final to further encourage inlining by the JIT.
      * </p>
      * 
      * <p>
@@ -839,29 +849,29 @@ public class TestClickCombination extends Thread {
      * 
      * <p>
      * Not all hope is lost though; we could manually unroll the loop for fixed combination lengths and
-     * create specialized methods, as well as using a switch statement to pick the proper method based
-     * on the combination length. This would sacrifice some code maintainability for performance, but it
-     * could be worth it if the JIT inlines the method appropriately. We could also create a long array
-     * for each thread to store the array masks that are XORed together, breaking the loop into a gather
-     * operation followed by a reduction operation. This would eliminate the data dependency and could
-     * allow for the JIT to vectorize the reduction step (as well as the gather step if we're lucky),
-     * but it would introduce complexity. This is still something worth exploring in the future if a
-     * monkey bottleneck arises.
+     * create specialized methods, as well as using a {@code switch} statement to pick the proper method
+     * based on the combination length. This would sacrifice some code maintainability for performance,
+     * but it could be worth it if the JIT inlines the method appropriately. We could also create a
+     * {@code long} array for each thread to store the array masks that are XORed together, breaking the
+     * loop into a gather operation followed by a reduction operation. This would eliminate the data
+     * dependency and could allow for the JIT to vectorize the reduction step (as well as the gather
+     * step if we're lucky), but it would introduce complexity. This is still something worth exploring
+     * in the future if a monkey bottleneck arises.
      * </p>
      * 
      * @param combination the combination of clicks to check, in {@link Grid.ValueFormat#Index index}
      *                    format
-     * @return <code>true</code> if the combination satisfies the odd adjacency condition,
-     *         <code>false</code> otherwise
+     * @return {@code true} if the combination satisfies the odd adjacency condition, {@code false}
+     *         otherwise
      * @see #CLICK_TO_TRUE_CELL_MASK
      * @see #EXPECTED_MASK
      * @see #initializeLookupTable(short[])
      * @see Grid#areAdjacent(short, short)
      * @see Grid#findTrueCells(com.github.mrgarbagegamer.Grid.ValueFormat)
      * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
-     * @performance O(n) where n is the length of the combination.
-     * @threading This method is thread-safe as it only reads from shared static data that is immutable
-     *            after initialization.
+     * @performance {@code O(combination.length)} per combination.
+     * @threading This method is thread-safe as it only reads from shared {@code static} data that is
+     *            immutable after initialization.
      * @memory Minimal memory impact as it only uses existing arrays and a few primitive variables (that
      *         allocate on the stack).
      * @optimization Uses bitmasking and bitwise operations for fast checks. Designed to be JIT-friendly

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -6,30 +6,115 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * TestClickCombination - [Worker Purpose - e.g., "ForkJoin recursive combination generator"]
+ * TestClickCombination - Highly optimized worker thread that tests click combinations on a puzzle
+ * grid.
  * 
- * <p>[High-level description of what this worker does in the algorithm.
- * Explain its role in the concurrent processing pipeline.]</p>
+ * <p>
+ * This class represents a worker thread that continuously {@link #getWork() fetches} click
+ * combinations from {@link CombinationQueue a queue} (either its own or by stealing from others),
+ * {@link #satisfiesOddAdjacency(short[]) checks them for odd adjacency}, and applies them to a
+ * {@link Grid puzzle grid} to see if they solve the puzzle. It is designed to be efficient and
+ * responsive, minimizing contention and branching to allow for aggressive JIT optimizations.
+ * </p>
+ * 
+ * <p>
+ * The name "monkey" is used here as a playful nod to the "infinite monkey theorem," which states
+ * that a monkey hitting keys at random on a typewriter for an infinite amount of time will almost
+ * surely type any given text, such as the complete works of Shakespeare. In this case, our monkeys
+ * are clicking cells on a grid in an attempt to find the correct combination that solves the
+ * puzzle. The metaphor is fitting, though I'm currently unsure how to extend it to the
+ * {@link CombinationGeneratorTask generators} (are they the typewriters? The paper? The ink?).
+ * Regardless, the name adds a bit of whimsy to the otherwise boring nature of the code.
+ * </p>
  * 
  * <h2>Execution Model</h2>
- * <p>[How this task executes - recursive subdivision, work-stealing, etc.
- * Include task granularity and splitting criteria.]</p>
+ * <p>
+ * A monkey is designed to operate as an independent thread, allowing for the use of parallelism to
+ * speed up the search for a solution. However, monkeys do not generate their own work; they rely on
+ * generators to produce and enqueue batches of combinations. This separation of concerns allows for
+ * a clear division of labor, with generators focusing on producing combinations and monkeys
+ * focusing on testing them.
+ * </p>
+ * 
+ * <p>
+ * For greater efficiency, each monkey has {@link #combinationQueue its own} {@link CombinationQueue
+ * queue} to pull work from, and it only resorts to stealing work from other monkeys' queues when
+ * its own is empty. After acquiring a batch to work on, the monkey processes each combination in
+ * the batch, checking for odd adjacency to prune invalid combinations before applying them to the
+ * grid. This check is more thorough than the pruning done by generators, reducing the number of
+ * expensive grid operations that need to performed. Logging is restricted to failed attempts that
+ * pass the adjacency check to avoid overwhelming {@link #logger the logger} with messages.
+ * Successful attempts are also logged, with the winning monkey {@link #triggerGeneratorShutdown()
+ * triggering a shutdown of the generators.}
+ * </p>
+ * 
+ * <p>
+ * If work is not immediately available, the monkey will check if a
+ * {@link CombinationQueueArray#solutionFound solution has been found} OR if
+ * {@link CombinationQueueArray#generationComplete generation is marked as complete} (all generators
+ * have finished their work) and {@link #allQueuesEmpty() all queues are empty}. If either of these
+ * conditions is met, the monkey will exit its loop and terminate. Otherwise, it will sleep for a
+ * short period and retry fetching work.
+ * </p>
  * 
  * <h2>Resource Management</h2>
- * <p>[How resources are acquired, used, and cleaned up. Pool usage patterns.]</p>
+ * <p>
+ * Monkeys manage their own resources, including their own {@link #puzzleGrid grid} to avoid
+ * contention with other threads. All resources used by a monkey are either specific to that thread,
+ * shared in a static immutable manner, or are accessed in a thread-safe way through the
+ * {@link CombinationQueueArray queue array}. An important note of monkeys in comparison to
+ * generators is that monkeys' execution is confined to {@link #run() a loop}, and each monkey is
+ * its own {@link java.lang.Thread Thread}. Since monkeys do not have changing contexts, their
+ * lifecycle is simpler and we can avoid using {@link java.lang.ThreadLocal ThreadLocals}. This
+ * saves us the overhead of calling and managing <code>ThreadLocal</code>s, which can be significant
+ * in tight loops.
+ * </p>
+ * 
+ * <p>
+ * Monkeys recycle {@link WorkBatch work batches} back to the
+ * {@link CombinationQueueArray#getWorkBatchPool() shared pool} upon completion of processing,
+ * allowing for efficient reuse of these objects and reducing the overhead of frequent allocations.
+ * Because of this, monkeys do not allocate ANY object in their hot paths, aside from logging
+ * overhead (an area for future improvement).
+ * </p>
  * 
  * <h2>Performance Critical Paths</h2>
- * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
+ * <p>
+ * The hottest methods in this class are {@link #run()} and {@link #satisfiesOddAdjacency(short[])}.
+ * Changes to these two methods can have a significant impact on the overall performance of the
+ * monkeys, and therefore the entire solver.
+ * </p>
  * 
- * <h3>3/15 - 20% of documentation completed</h3>
+ * <h3>11/15 - ~73.3% of documentation completed</h3>
  * 
- * @algorithm [Detailed algorithm description with complexity analysis]
- * @threading [Concurrency model and synchronization approach]
- * @performance [Performance characteristics and bottleneck analysis]
- * @see [Related worker classes and coordination mechanisms]
+ * @since 2025.04.01 - Multi-threaded Solver Introduction
+ * @algorithm {@link #getWork() Pulls} a {@link WorkBatch batch of work} (either its own or by
+ *            stealing), then processes each combination in the batch by
+ *            {@link #satisfiesOddAdjacency(short[]) checking} for odd adjacency. If the combination
+ *            passes the check, it is applied to the {@link Grid grid} to see if it solves the
+ *            puzzle. If a solution is found, it is logged and other threads are signaled to
+ *            terminate. If no work is available, the monkey checks for its exit condition and (if
+ *            not met) sleeps briefly before retrying.
+ * @threading Each monkey is its own {@link java.lang.Thread thread}, operating independently with
+ *            its own testing resources. Work is {@link #getWork() obtained} in a thread-safe manner
+ *            from a {@link CombinationQueue queue} ({@link #combinationQueue its own} or another's
+ *            via stealing) and uses pre-initialized thread-specific data structures to operate on
+ *            them.
+ * @performance The main loop's overall time complexity is O(n * m) per batch, where n is the number
+ *              of combinations in the batch and m is the combination length. The
+ *              {@link #satisfiesOddAdjacency(short[]) odd adjacency check} is O(m). However, due to
+ *              pruning and parallelism, the effective workload is significantly reduced. Most
+ *              bottlenecks arise from contention on shared resources or the process of enqueuing
+ *              batches.
+ * @memory Memory usage is optimized via resource pooling and pre-allocation, minimizing allocations
+ *         in the hot path. The only allocations in the hot path are due to logging overhead.
+ * @see CombinationGeneratorTask
+ * @see CombinationQueue
+ * @see CombinationQueueArray
+ * @see Grid
+ * @see WorkBatch
  */
-public class TestClickCombination extends Thread
-{
+public class TestClickCombination extends Thread {
     private static final Logger logger = LogManager.getLogger(TestClickCombination.class);
     /**
      * A constant defining how often to log failed attempts. After this many failed combinations per
@@ -83,7 +168,7 @@ public class TestClickCombination extends Thread
      * @performance O(1) lookup time for each cell in the combination.
      * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes).
      * @see EXPECTED_MASK
-     * @see #satisfiesOddAdjacency(short[], short[])
+     * @see #satisfiesOddAdjacency(short[])
      */
     private static volatile long[] CLICK_TO_TRUE_CELL_MASK = null;
     /**
@@ -112,13 +197,63 @@ public class TestClickCombination extends Thread
      * @performance O(1) lookup time.
      * @memory The expected mask is a single long value, taking up just 8 bytes.
      * @see CLICK_TO_TRUE_CELL_MASK
-     * @see #satisfiesOddAdjacency(short[], short[])
+     * @see #satisfiesOddAdjacency(short[])
      */
     private static volatile long EXPECTED_MASK = 0L;
 
+    /**
+     * Constructs a monkey thread with the specified name, associated {@link CombinationQueue queue} and
+     * {@link Grid grid}, and the shared {@link CombinationQueueArray queue array}.
+     * 
+     * <p>
+     * Each monkey operates independently with its own resources, including a dedicated puzzle grid and
+     * queue for fetching work. We also need access to the shared queue array to check for a solution,
+     * recycle work batches, steal work from other monkeys, and potentially signal generators and other
+     * monkeys to shut down. This constructor sets up all these relationships while also calling for the
+     * {@link #initializeLookupTable(short[]) initialization} of {@link #CLICK_TO_TRUE_CELL_MASK the
+     * lookup table}.
+     * </p>
+     * 
+     * <p>
+     * Note that the lookup table is only initialized once per puzzle, so even if multiple monkeys are
+     * created for the same puzzle, the initialization will only occur once in a thread-safe manner.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This constructor is not performance-critical as it is only called once per monkey thread. We
+     * delegate most of the allocation work to the caller to allow for more flexible resource management
+     * and make the monkeys' constructor simpler. The queue array could be made static for the class and
+     * be set by a static method, though we left this as-is for simplicity. Making the queue array
+     * static could be a future optimization if we find that the overhead of passing it around is
+     * significant and want to save on the memory footprint of storing a reference in each monkey.
+     * </p>
+     * 
+     * @param threadName       the <b>UNIQUE</b> name for this monkey thread, used in logging.
+     * @param combinationQueue the {@link CombinationQueue queue} from which this monkey will pull from.
+     * @param queueArray       the shared {@link CombinationQueueArray queue array} for coordination
+     *                         with other monkeys. This field should be <b>IDENTICAL</b> for each monkey
+     *                         working on the same puzzle.
+     * @param puzzleGrid       the <b>UNIQUE</b> {@link Grid grid} that this monkey will apply
+     *                         combinations to. Do not share grids between monkeys.
+     * @since 2025.04.01 - Monkey Thread Introduction
+     * @threading Thread-safe since the lookup table is statically initialized and all other fields are
+     *            final.
+     * @performance O(1) assignments and a single call to initialize the lookup table.
+     * @memory Memory usage is minimal, with only a few references and primitive fields. The only
+     *         explicit allocation in this method (other than the thread itself) is the allocation of a
+     *         trueCells <code>short[]</code> for lookup table initialization.
+     * @see #combinationQueue
+     * @see #queueArray
+     * @see #puzzleGrid
+     * @see #initializeLookupTable(short[])
+     * @see CombinationQueue
+     * @see CombinationQueueArray
+     * @see Grid
+     * @see Grid#findTrueCells(Grid.ValueFormat)
+     */
     public TestClickCombination(String threadName, CombinationQueue combinationQueue,
-                               CombinationQueueArray queueArray, Grid puzzleGrid)
-    {
+                               CombinationQueueArray queueArray, Grid puzzleGrid) {
         super(threadName);
         this.combinationQueue = combinationQueue;
         this.queueArray = queueArray;
@@ -129,9 +264,53 @@ public class TestClickCombination extends Thread
         initializeLookupTable(trueCells);
     }
 
-    // Initialize the static lookup table for fast odd adjacency checks
-    private static void initializeLookupTable(short[] trueCells)
-    {
+    /**
+     * Initializes the lookup table for click combinations based on the provided true cells.
+     * 
+     * <p>
+     * To efficiently prune combinations that do not satisfy the odd adjacency/parity condition, we need
+     * a way to quickly check which true cells are affected by each possible click. Though it's possible
+     * to compute this on-the-fly, it would incur a significant performance penalty due to the redundant
+     * calculations and temporary allocation overhead. The pre-computed masks in
+     * {@link #CLICK_TO_TRUE_CELL_MASK} solve both of these issues, but a pre-computed mask is nothing
+     * without code to generate it. This method fills these masks based on the initial state of the
+     * grid.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The method first checks if the lookup table has already been initialized using double-checked
+     * locking to ensure thread safety. If it hasn't, it creates a new array of long values, one for
+     * each possible click (109 total). It then iterates over each possible click and, for each true
+     * cell, checks if the click is adjacent to the true cell using
+     * {@link Grid#areAdjacent(short, short, Grid.ValueFormat)}. If they are adjacent, it sets the
+     * corresponding bit in the mask for that click. After processing all possible clicks, it computes
+     * the {@link #EXPECTED_MASK expected mask} (a mask containing all bits set to 1 for the number of
+     * true cells) and atomically publishes the results to the static variables
+     * <code>CLICK_TO_TRUE_CELL_MASK</code> and <code>EXPECTED_MASK.</code>
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since this method is only called once per puzzle, it is not performance-critical, allowing for
+     * more complex logic without impacting the overall performance of the solver. We use a simple long
+     * array to store the masks for quick accesses and bitwise operations, and we pre-compute as much as
+     * we can to avoid redundant calculations during the {@link #satisfiesOddAdjacency(short[]) odd
+     * adjacency checks}.
+     * </p>
+     * 
+     * @param trueCells the array of initially true cells in {@link Grid.ValueFormat#Index index} format
+     * @since 2025.07.13 - Long Array Grid State Representation
+     * @threading Thread-safe due to double-checked locking.
+     * @performance O(n * m) where n is the number of clicks (109) and m is the number of true cells.
+     * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes). The
+     *         expected mask is a single long value, taking up 8 bytes.
+     * @algorithm Pre-computation of click masks for fast odd adjacency checks.
+     * @optimization Uses double-checked locking for thread-safe lazy initialization.
+     * @see #CLICK_TO_TRUE_CELL_MASK
+     * @see #EXPECTED_MASK
+     */
+    private static void initializeLookupTable(short[] trueCells) {
         // Double-checked locking for thread-safe lazy initialization
         if (CLICK_TO_TRUE_CELL_MASK == null)
         {
@@ -163,18 +342,112 @@ public class TestClickCombination extends Thread
         }
     }
 
+    /**
+     * The main execution loop for the TestClickCombination thread. This method continuously processes
+     * click combinations from {@link WorkBatch a batch} obtained from a {@link CombinationQueue queue},
+     * {@link #satisfiesOddAdjacency(short[]) checks} them for odd adjacency, and applies them
+     * to the {@link Grid puzzle grid} to see if they solve the puzzle.
+     * 
+     * <p>
+     * To operate as an independent worker, the monkey needs a core loop that can fetch work, process
+     * it, and handle termination conditions from other threads. This loop is designed to meet those
+     * needs while being efficient and responsive.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * After defining a local counter for failed attempts (to control logging frequency), we enter a
+     * loop that continues until a solution is found or all queues are empty. We first attempt to
+     * {@link #getWork() get a batch} of work from our own queue or from another monkey's queue by
+     * stealing. If no work is available, we check if the solution has been found or if generation is
+     * marked as complete (all generators have finished their work) and {@link #allQueuesEmpty() all
+     * queues are empty}. If so, we know that another thread has found the solution or that all work has
+     * been processed, and we can exit the loop. If those conditions aren't met, we
+     * {@link Thread#sleep(long) sleep} for a short time (1s) to avoid busy-waiting and give the
+     * generators time to catch up.
+     * </p>
+     * 
+     * <p>
+     * Once we have a batch of work, we process each combination in the batch. We
+     * {@link WorkBatch#poll() poll} from the batch and check if the combination satisfies the odd
+     * adjacency condition before applying it to the puzzle grid. If the combination passes the check
+     * and grants the solution, we {@link Logger#info(String, Object...) log} the solution and exit out
+     * of the thread. If the combination doesn't solve the puzzle, we reset the grid back to its initial
+     * state and increment the failed attempt counter, logging the attempt if it reaches the threshold
+     * defined by {@link #LOG_EVERY_N_FAILURES LOG_EVERY_N_FAILURES}.
+     * </p>
+     * 
+     * <p>
+     * Finally, after processing all combinations in the batch, we recycle the batch back to the
+     * {@link CombinationQueueArray queue array} for reuse by other threads and begin the next iteration
+     * of the loop.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This loop is designed to minimize contention and branching, allowing the JIT compiler to employ
+     * the most aggressive optimizations possible. We use a single loop to process all combinations and
+     * delegate certain tasks to helper methods to keep the main loop clean and focused.
+     * </p>
+     * 
+     * <p>
+     * Logging is controlled by a counter to avoid overwhelming the logs with debug messages, which can
+     * cause performance issues even with asynchronous logging. We also ensure that we only log when the
+     * odd adjacency condition is satisfied, which reduces unnecessary logging overhead of invalid
+     * combinations.
+     * </p>
+     * 
+     * <p>
+     * Some potential areas for future optimization include a shift towards an explicit cancellation
+     * mechanism for the monkeys similar to that of the generators. If the winning monkey can directly
+     * signal for all other monkeys to terminate, we can avoid the need for them to check the
+     * solutionFound flag on every iteration, which would reduce the overhead of constant volatile
+     * reads.
+     * </p>
+     * 
+     * <p>
+     * We could also rework the logging mechanism with {@link CombinationMessage} to try to allow for
+     * more efficient, GC-free logging of combinations rather than the current approach that creates a
+     * new CombinationMessage object for each log entry. This would reduce the memory overhead and help
+     * bring down the number of temporary objects created, but it would require a more complex approach
+     * to interface with {@link org.apache.logging.log4j.message.ReusableMessage} and
+     * {@link org.apache.logging.log4j.message.MessageFactory}. Previous attempts have been made to
+     * implement this, but it's going to take some clever design to avoid concurrent modification issues
+     * (since async logging can modify the message while we're trying to log it). However, this may be
+     * worth pursuing in the future to reduce the memory footprint of the logging system and allow for
+     * more efficient logging.
+     * </p>
+     * 
+     * @since 2025.04.01 - Monkey Thread Introduction
+     * @threading This method is executed by a single thread, which processes work from its own queue
+     *            and potentially steals from others. It is designed to be thread-safe with respect to
+     *            the shared {@link CombinationQueueArray} and uses its own {@link Grid} for safety.
+     * @performance O(n) per batch, where n is the number of combinations in the batch. The odd
+     *              adjacency check is O(m), where m is the combination length.
+     * @memory Other than logging overhead, this method does not allocate any objects in the hot path.
+     * @algorithm Brute force search with pruning based on odd adjacency checks.
+     * @optimization Avoids unnecessary branching and redundant checks by processing entire batches in a
+     *               single loop. Uses bitmasking for fast odd adjacency checks that prune invalid
+     *               combinations before they reach the grid.
+     * @see #satisfiesOddAdjacency(short[])
+     * @see #triggerGeneratorShutdown()
+     * @see #getWork()
+     * @see #allQueuesEmpty()
+     * @see CombinationQueue
+     * @see CombinationQueueArray
+     * @see WorkBatch
+     * @see Grid
+     */
     @Override
-    public void run()
-    {
+    public void run() {
         int failedCount = 0; // Count of failed attempts for logging
-        short[] trueCells = puzzleGrid.findTrueCells();
-
         while (!queueArray.solutionFound)
         {
             WorkBatch workBatch = getWork();
 
             if (workBatch == null)
             {
+                // TODO: Look at removing the redundant solutionFound check here
                 if (queueArray.solutionFound || (queueArray.generationComplete && allQueuesEmpty()))
                 {
                     break; // Exit if solution found or generation is done and all queues are empty
@@ -194,12 +467,14 @@ public class TestClickCombination extends Thread
 
             // OPTIMIZED: Process entire batch with reduced branching
             short[] combinationClicks;
+            // TODO: Look at removing the redundant solutionFound check here
             while ((combinationClicks = workBatch.poll()) != null && !queueArray.solutionFound)
             {
-                if (satisfiesOddAdjacency(combinationClicks, trueCells))
+                if (satisfiesOddAdjacency(combinationClicks))
                 {
                     puzzleGrid.click(combinationClicks); // Apply the click combination to the grid
 
+                    // TODO: Look at extracting this logic to a separate method
                     if (puzzleGrid.isSolved())
                     {
                         logger.info("Found the solution as the following click combination: {}",
@@ -208,6 +483,7 @@ public class TestClickCombination extends Thread
 
                         // Trigger immediate shutdown of generator pool
                         triggerGeneratorShutdown();
+                        // TODO: Look at finding a way to directly terminate all worker threads as well
 
                         // Don't recycle the winning batch
                         return;
@@ -233,11 +509,42 @@ public class TestClickCombination extends Thread
     }
 
     /**
-     * Triggers immediate shutdown of the generator pool when a solution is found.
-     * This eliminates the need for generators to check cancellation flags.
+     * Triggers an immediate shutdown of the {@link CombinationGeneratorTask#getForkJoinPool() generator
+     * pool} to stop all {@link CombinationGeneratorTask generators}.
+     * 
+     * <p>
+     * Since monkeys are the final step in the processing pipeline (and are independent of the
+     * generators), they are the only threads that can find a solution to the puzzle. Since our program
+     * is concerned only with finding a single solution to the puzzle, once a monkey finds a solution,
+     * we need a way to stop all other processing as soon as possible to avoid wasting extra time and
+     * CPU cycles.
+     * </p>
+     * 
+     * <p>
+     * Before this method was implemented, generators had explicit flags for termination and had to
+     * perform cancellation checks on every iteration of their processing loops. This was not ideal, as
+     * it added overhead to the generators and increased branching in the hot path. Since the generators
+     * are all part of a {@link java.util.concurrent.ForkJoinPool ForkJoinPool}, they already have
+     * functionality to handle shutdowns and cancellations in the form of
+     * {@link ForkJoinPool#shutdownNow() shutdownNow()}. This method leverages that functionality to
+     * provide a clean and efficient way to stop all generators when a solution is found.
+     * </p>
+     * 
+     * <p>
+     * We have to statically access the generator pool from the {@link CombinationGeneratorTask} class,
+     * as monkeys do not have direct access to the pool. This isn't perfect, but is simple for our needs
+     * and can be handled during the initialization of the pool in {@link StartYourMonkeys#main(String[])}.
+     * </p>
+     * 
+     * @since 2025.07.23 - Explicit Cancellation Checks Removal
+     * @threading This method is thread-safe as it accesses the ForkJoinPool in a safe manner.
+     * @performance O(1) operation to trigger the shutdown.
+     * @optimization Uses the built-in shutdown mechanism of ForkJoinPool to avoid adding overhead to
+     *               the generators.
+     * @see CombinationGeneratorTask
+     * @see java.util.concurrent.ForkJoinPool
      */
-    private void triggerGeneratorShutdown()
-    {
+    private void triggerGeneratorShutdown() {
         // Access the generator pool from CombinationGeneratorTask if stored there,
         // or use a different mechanism to signal shutdown
         ForkJoinPool generatorPool = CombinationGeneratorTask.getForkJoinPool();
@@ -249,10 +556,62 @@ public class TestClickCombination extends Thread
     }
 
     /**
-     * Gets a batch of work, first from the primary queue, then by stealing.
+     * Obtains a {@link WorkBatch} of combinations to process. It first tries to get a batch from its
+     * own {@link CombinationQueue}, and if that is empty, it attempts to steal a batch from other
+     * {@link CombinationQueue queues} in the {@link CombinationQueueArray queue array}.
+     * 
+     * <p>
+     * To take advantage of multi-threading, we need a way for the {@link CombinationGeneratorTask}
+     * threads to exchange work with the monkeys. Queues provide storage for combination exchanges and
+     * generators have {@link CombinationGeneratorTask#flushBatchFast(WorkBatch) a method} to quickly
+     * flush batches to a queue, but monkeys need a way to efficiently obtain work from these queues
+     * without blocking. This method serves that purpose.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * The method first attempts to {@link CombinationQueue#getWorkBatch() get a work batch} from the
+     * monkey's own queue. If that queue is empty, it attempts to steal a batch from another queue,
+     * iterating across the queues in increasing order of their indices. The method is short-circuiting,
+     * returning the first non-null batch it finds. If no batches are available in any queue, it returns
+     * <code>null</code>, indicating that there is no work to process at the moment.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be efficient and non-blocking, allowing monkeys to quickly obtain work
+     * without waiting for other threads. It is optimized to reduce contention and branching, and
+     * therefore has no sleeping mechanism built in. It is the responsibility of the caller to handle
+     * some sort of sleeping or waiting; this method is made simple to increase the chances of
+     * aggressive JIT optimizations.
+     * </p>
+     * 
+     * <p>
+     * We could potentially optimize this further by implementing a more sophisticated work-stealing
+     * algorithm that takes into account the load of each queue, but that would require extra logic that
+     * may be too high in overhead for the benefit it provides (since
+     * {@link org.jctools.queues.MpmcArrayQueue#size() size()} calls are not O(1)). Caching the
+     * reference to the array of queues could be beneficial as a micro-optimization, but it isn't likely
+     * to have a major impact since the compiler's profiling will likely determine that the array
+     * reference is stable and optimize accordingly.
+     * </p>
+     * 
+     * @return a {@link WorkBatch} of combinations to process, or <code>null</code> if no work is
+     *         available
+     * @since 2025.07.07 - Enqueueing Work Batches
+     * @performance O(1) to steal from the first available queue, or O(n) in the worst case where n is
+     *              the number of queues
+     * @memory Minimal memory impact as it only returns a reference to an existing WorkBatch object.
+     * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
+     *            thread-safe methods.
+     * @algorithm Work-stealing algorithm to obtain work batches from queues.
+     * @optimization Designed to minimize contention and branching, allowing for aggressive JIT
+     *               optimizations.
+     * @see CombinationQueueArray
+     * @see CombinationQueue
+     * @see WorkBatch
      */
-    private WorkBatch getWork()
-    {
+    private WorkBatch getWork() {
         // Try my own queue first
         WorkBatch batch = combinationQueue.getWorkBatch();
         if (batch != null)
@@ -274,9 +633,42 @@ public class TestClickCombination extends Thread
         return null; // No work found anywhere
     }
 
-    // FIX: Check queue size without consuming an item.
-    private boolean allQueuesEmpty()
-    {
+    /**
+     * Checks if all {@link CombinationQueue queues} in the {@link CombinationQueueArray queue array}
+     * are empty. This is used by {@link #run()} as part of the exit condition, determining if work is
+     * still available.
+     * 
+     * <p>
+     * Since monkeys and {@link CombinationGeneratorTask generators} operate independently and the program can be
+     * run on puzzle configurations without a solution, it is possible for all generators to finish generating
+     * combinations and exit before the monkeys have processed all available work. Monkeys can't just exit the second
+     * that {@link CombinationQueueArray#generationComplete generation is marked as complete}, since there may still be
+     * work left in the queues. On the other hand, monkeys can't just wait indefinitely for new work to be generated, since
+     * if the generators are done, no new work will ever arrive. Therefore, we need another component to our completed generation
+     * exit condition: all queues must be empty. This method checks that condition.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is not performance-critical, as it is only called when a monkey's own queue is empty and
+     * it is checking for exit conditions. Therefore, we can afford to use a simple loop to check each queue, performing
+     * an O(n) operation where n is the number of queues. However, we can't just attempt to poll from each queue for our
+     * check, since that could consume an item and interfere with the normal processing of the queues. Instead, we use the
+     * {@link CombinationQueue#isEmpty() isEmpty()} method, which is a non-destructive, constant-time check.
+     * </p>
+     * 
+     * @return <code>true</code> if all queues are empty, <code>false</code> otherwise.
+     * @since 2025.08.02 - Preallocate WorkBatches for Queues
+     * @threading This method is thread-safe as it accesses shared queues in a non-blocking manner using
+     *            thread-safe methods.
+     * @performance O(n) where n is the number of queues, but not performance-critical as it is only called
+     *              during exit condition checks.
+     * @memory Does not allocate any objects, only uses existing references.
+     * @see CombinationQueue
+     * @see CombinationQueue#isEmpty()
+     * @see CombinationQueueArray
+     */
+    private boolean allQueuesEmpty() {
         for (CombinationQueue q : queueArray.getAllQueues())
         {
             if (!q.isEmpty())
@@ -287,9 +679,120 @@ public class TestClickCombination extends Thread
         return true;
     }
 
-    // OPTIMIZED: JIT-friendly bitmask-based odd adjacency check with inlining hints
-    private final boolean satisfiesOddAdjacency(short[] combination, short[] trueCells)
-    {
+    /**
+     * Checks if the given combination satisfies the odd adjacency condition.
+     * 
+     * <p>
+     * While much work has been done to optimize click operations and reinitializations of the
+     * {@link Grid}, they are still expensive operations that can cause significant slowdowns if
+     * performed too often. Therefore, we need a way to quickly prune combinations in a {@link WorkBatch
+     * batch} that are not valid before they reach the grid. This method serves that purpose.
+     * </p>
+     * 
+     * <p>
+     * This method takes advantage of a few properties of the Lights Out puzzle:
+     * <ul>
+     * <li>Clicks toggle the state of the cells adjacent to the clicked cell.</li>
+     * <li>Since a cell can only be on or off (true or false), 2 clicks on a cell is the same as no
+     * clicks, and 3 clicks is the same as 1 click. This makes the puzzle mod-2.</li>
+     * <li>All initially true cells must therefore be toggled an odd number of times to be turned
+     * off.</li>
+     * </ul>
+     * Therefore, we can eliminate combinations that do not toggle each initially true cell an odd
+     * number of times.
+     * </p>
+     * 
+     * <h3>Algorithm Details</h3>
+     * <p>
+     * Since we only care about initially true cells in this check, we can simplify the grid state to a
+     * bitmask that is the same length as the number of initially true cells, and where each bit
+     * represents whether a true cell is toggled an odd (1) or even (0) number of times. We iterate over
+     * the clicks in the combination and, for each click, we XOR the bitmask of the true cells it
+     * affects (from {@link #CLICK_TO_TRUE_CELL_MASK}) with our running total. At the end, if the
+     * resulting bitmask is equal to the {@link #EXPECTED_MASK expected mask} (where all bits are 1),
+     * then the combination satisfies the odd adjacency condition. Otherwise, it does not meet the
+     * condition and can be discarded.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be as efficient as possible, with a focus on minimizing branching and
+     * redundant checks. We cache all array references and the length at the start of the method to
+     * avoid array dereferencing. By {@link #initializeLookupTable(short[]) precomputing} the necessary
+     * bitmasks for each click, we can reduce the complexity of the check to O(n) per combination, where
+     * n is the length of the combination. The use of bitwise operations (XOR) allows for extremely fast
+     * computations that are well-optimized by the JIT compiler, encouraging inlining and loop
+     * unrolling. The method is also marked as final to further encourage inlining by the JIT.
+     * </p>
+     * 
+     * <p>
+     * This method is crucial for performance, and optimizing it has a significant impact on the overall
+     * performance of the solver. The most tantalizing future optimization would be to leverage SIMD
+     * (Single Instruction, Multiple Data) CPU instructions to process multiple clicks in parallel, but
+     * this is more difficult than it seems. Java does not provide direct access to SIMD instructions,
+     * making the only realistic options being to use the Vector API, JNI (Java Native Interface), or
+     * JIT auto-vectorization.
+     * </p>
+     * 
+     * <p>
+     * The Vector API seems promising, but is utterly destroyed in feasibility by the significant
+     * allocation overhead it introduces (as each lanewise operation internally creates upwards of 4
+     * temporary objects that have no way of being reused). This overhead negates most of the
+     * performance benefits of SIMD, and until something like Project Valhalla is introduced (allowing
+     * for value types that allocate on the stack rather than the heap), it is not viable.
+     * </p>
+     * 
+     * <p>
+     * JNI would allow for direct use of SIMD instructions through C++ intrinsics, but it introduces
+     * heavy overhead in data marshalling between Java and native code, which negates most of the
+     * benefits. This could potentially be mitigated by batching multiple combinations into a single JNI
+     * call, but this then introduces problems regarding return values, since we'd need to return a
+     * boolean for each combination in the batch (and have some way for the Java side to associate
+     * results with combinations). I can't anticipate a clean way to do this without extreme overhead,
+     * so this option is also not viable.
+     * </p>
+     * 
+     * <p>
+     * Last but not least, JIT auto-vectorization is the most appealing option, as it would allow us to
+     * stay entirely within Java while still leveraging SIMD instructions. However, the JIT is very
+     * picky when it comes to auto-vectorization and requires very specific coding patterns to be able
+     * to apply it. Loop unrolling is crucial to this, as it allows the JIT to see a larger chunk of
+     * code at once. Worse, we have a data dependency in our loop (the XOR operation depends on the
+     * result of the previous iteration) and indirect array accesses (the click value is used as an
+     * index in another array), preventing the JIT from being able to vectorize the loop as-is.
+     * </p>
+     * 
+     * <p>
+     * Not all hope is lost though; we could manually unroll the loop for fixed combination lengths and
+     * create specialized methods, as well as using a switch statement to pick the proper method based
+     * on the combination length. This would sacrifice some code maintainability for performance, but it
+     * could be worth it if the JIT inlines the method appropriately. We could also create a long array
+     * for each thread to store the array masks that are XORed together, breaking the loop into a gather
+     * operation followed by a reduction operation. This would eliminate the data dependency and could
+     * allow for the JIT to vectorize the reduction step (as well as the gather step if we're lucky),
+     * but it would introduce complexity. This is still something worth exploring in the future if a
+     * monkey bottleneck arises.
+     * </p>
+     * 
+     * @param combination the combination of clicks to check, in {@link Grid.ValueFormat#Index index}
+     *                    format
+     * @return <code>true</code> if the combination satisfies the odd adjacency condition,
+     *         <code>false</code> otherwise
+     * @since 2025.06.06 - Odd Adjacency Pruning for Monkeys
+     * @performance O(n) where n is the length of the combination.
+     * @memory Minimal memory impact as it only uses existing arrays and a few primitive variables (that
+     *         allocate on the stack).
+     * @threading This method is thread-safe as it only reads from shared static data that is immutable
+     *            after initialization.
+     * @optimization Uses bitmasking and bitwise operations for fast checks. Designed to be JIT-friendly
+     *               with minimal branching and encourages inlining and loop unrolling.
+     * @see #CLICK_TO_TRUE_CELL_MASK
+     * @see #EXPECTED_MASK
+     * @see #initializeLookupTable(short[])
+     * @see Grid#areAdjacent(short, short)
+     * @see Grid#findTrueCells(com.github.mrgarbagegamer.Grid.ValueFormat)
+     */
+    private final boolean satisfiesOddAdjacency(short[] combination) {
         // JIT OPTIMIZATION: Cache array references and length to encourage optimization
         final long[] masks = CLICK_TO_TRUE_CELL_MASK;
         final int combinationLength = combination.length;

--- a/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
+++ b/src/main/java/com/github/mrgarbagegamer/TestClickCombination.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.Logger;
  * <h2>Performance Critical Paths</h2>
  * <p>[Identify hot paths and optimization focus areas. JIT considerations.]</p>
  * 
- * <h3>0/15 - 0% of documentation completed</h3>
+ * <h3>3/15 - 20% of documentation completed</h3>
  * 
  * @algorithm [Detailed algorithm description with complexity analysis]
  * @threading [Concurrency model and synchronization approach]
@@ -31,14 +31,89 @@ import org.apache.logging.log4j.Logger;
 public class TestClickCombination extends Thread
 {
     private static final Logger logger = LogManager.getLogger(TestClickCombination.class);
+    /**
+     * A constant defining how often to log failed attempts. After this many failed combinations per
+     * thread (not including combinations that fail the odd adjacency check), a debug log entry will be
+     * made. This helps monitor progress without overwhelming the logs.
+     * 
+     * <p>
+     * Logging is purely a diagnostic feature and does not affect the algorithm, but excessive logging
+     * can block threads and degrade performance, even with asynchronous logging. Therefore, we log
+     * only every N failures, where N is defined by this constant.
+     * </p>
+     * 
+     * @since 2025.05.31 - Logging Threshold Introduction
+     * @threading This constant is immutable and thread-safe.
+     * @performance O(1) check per failed combination.
+     * @memory Minimal memory impact as it's just a single integer.
+     * @see #run()
+     * @see CombinationMessage
+     */
     private static final int LOG_EVERY_N_FAILURES = 100_000; // Log every N failures to avoid flooding the logs
 
     private final CombinationQueue combinationQueue;
     private final CombinationQueueArray queueArray;
     private final Grid puzzleGrid;
 
-    // Static lookup table initialization with pre-computed masks
+    /**
+     * Lookup table mapping each possible click to a bitmask of true cells it affects. These are
+     * semantically similar to the adjacency masks in {@link Grid}, but only for the true cells in the
+     * current puzzle.
+     * 
+     * <p>
+     * While generators have their own pruning logic, the vast majority of combinations that make their
+     * way to monkeys are not valid due to odd adjacency violations, and we need to filter these out
+     * before they reach the grid. To do this, we need a mechanism to quickly check what true cells a
+     * click will affect, and we can use a bitmask for this purpose.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * We statically initialize this table once per puzzle in {@link #initializeLookupTable(short[])}
+     * using double-checked locking to ensure thread safety. This avoids redundant computation and
+     * allows all threads to share the same table without contention, which is crucial for performance.
+     * Bitmasks are used to efficiently represent the affected true cells, and while a long can only store
+     * 64 bits of data, all puzzles in this game have less than 64 initially true cells, letting us use
+     * just one long per cell (and perform one bitwise operation per click).
+     * </p>
+     * 
+     * @since 2025.06.30 - Bitmask Pre-computations
+     * @threading The lookup table is initialized once per puzzle in a thread-safe manner using
+     *             double-checked locking.
+     * @performance O(1) lookup time for each cell in the combination.
+     * @memory The lookup table is an array of 109 long values, taking up 872 bytes (109 * 8 bytes).
+     * @see EXPECTED_MASK
+     * @see #satisfiesOddAdjacency(short[], short[])
+     */
     private static volatile long[] CLICK_TO_TRUE_CELL_MASK = null;
+    /**
+     * The expected mask for a valid combination of clicks, which is the bitmask where all true cells
+     * are set to 1. This is computed once during initialization and used to validate combinations.
+     * 
+     * <p>
+     * As part of the odd adjacency check in monkey threads, we need to ensure that the number of clicks
+     * affecting each true cell is odd, which is done by XORing the mask for each click in
+     * {@link #CLICK_TO_TRUE_CELL_MASK}. A valid combination would have all 1s in the mask up to the
+     * number of true cells, but we can't know the value until we have the true cells. Recomputing the
+     * mask every time we perform a check would be inefficient, so we compute it once during
+     * initialization and store it here.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Bitmasks are used for their efficiency in representing the state of affected true cells as well
+     * as their fast operations. By making this variable static and volatile, we ensure that only one
+     * thread ever has to compute the mask, and all threads can read it without contention.
+     * </p>
+     * 
+     * @since 2025.06.30 - Bitmask Pre-computations
+     * @threading The expected mask is computed once per puzzle in a thread-safe manner using
+     *             double-checked locking.
+     * @performance O(1) lookup time.
+     * @memory The expected mask is a single long value, taking up just 8 bytes.
+     * @see CLICK_TO_TRUE_CELL_MASK
+     * @see #satisfiesOddAdjacency(short[], short[])
+     */
     private static volatile long EXPECTED_MASK = 0L;
 
     public TestClickCombination(String threadName, CombinationQueue combinationQueue,

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -18,7 +18,7 @@ import org.jctools.queues.MessagePassingQueue;
  * <h2>Memory Management</h2>
  * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
  * 
- * <h3>0/18 - 0% of documentation completed</h3>
+ * <h3>2/18 - ~11.1% of documentation completed</h3>
  * 
  * @performance [Specific performance characteristics and measurements]
  * @memory [Memory usage patterns and optimizations]
@@ -27,11 +27,70 @@ import org.jctools.queues.MessagePassingQueue;
  */
 public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, MessagePassingQueue.Supplier<short[]>
 {
+    /**
+     * Pre-allocated buffer to hold combinations.
+     * 
+     * <p>
+     * Even with the power of JCTools, queue operations still have overhead and can be expensive when
+     * performed at a high frequency. Amortizing this cost by batching multiple combinations is
+     * necessary to achieve the desired performance while adhering to the golden rule of JVM
+     * optimization: <b>Don't allocate.</b>
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a pre-allocated array avoids the overhead of dynamic memory allocation and garbage
+     * collection, which can introduce latency and degrade performance. Reusing the same arrays for
+     * multiple batches also creates the infrastructure for pooling combinations, drastically reducing
+     * the number of allocations and GC pressure.
+     * </p>
+     * 
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading The buffers are not thread-safe, as they are intended to be used within a single
+     *            thread context. Queues should be the only point of inter-thread communication.
+     * @performance O(1) for poll operations, O(numClicks) for add operations due to array copying.
+     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
+     *         dynamic allocations.
+     * @optimization Pre-allocation and reuse of arrays to minimize GC pressure.
+     * @see #add(short[])
+     * @see #poll()
+     * @see #WorkBatch(int)
+     */
     private final short[][] buffer;
     private final int capacity;
     private static int numClicks;
     private int head = 0;
     private int tail = 0;
+    /**
+     * An int to track the remaining capacity of the batch.
+     * 
+     * <p>
+     * The typical mechanism for tracking the number of elements in a circular buffer would be to use
+     * a size variable that increments on add operations and decrements on poll operations. However,
+     * size checks in those methods can lead to JVM deoptimizations due to the way the JIT compiler
+     * optimizes code paths and performs speculative optimizations. We need a more stable approach to
+     * tracking that avoids these pitfalls, can be branch predicted more easily, and doesn't require
+     * manual arithmetic computations. Tracking the remaining capacity provides this.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * By using remaining capacity, we can perform checks against a constant value (zero or full
+     * capacity) rather than a variable size. This reduces the likelihood of deoptimizations and
+     * improves branch prediction, leading to more consistent performance in high-frequency
+     * scenarios. 
+     * </p>
+     * 
+     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @threading The counter is not thread-safe, as it is intended to be used within a single
+     *            thread context. Queues should be the only point of inter-thread communication.
+     * @performance O(1) for capacity checks, avoiding deoptimizations associated with size tracking.
+     * @memory Minimal additional memory overhead (single int).
+     * @optimization Stable and predictable capacity tracking to enhance performance.
+     * @see #capacity
+     * @see #add(short[])
+     * @see #poll()
+     */
     private int remainingCapacity; // Replacement for size to avoid deoptimizations
 
     public WorkBatch(int capacity)

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -18,7 +18,7 @@ import org.jctools.queues.MessagePassingQueue;
  * <h2>Memory Management</h2>
  * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
  * 
- * <h3>2/18 - ~11.1% of documentation completed</h3>
+ * <h3>6/18 - ~33.3% of documentation completed</h3>
  * 
  * @performance [Specific performance characteristics and measurements]
  * @memory [Memory usage patterns and optimizations]
@@ -106,13 +106,37 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Adds a combination by copying its contents into the array at the tail of the buffer.
-     * This avoids the caller needing to clone and prevents allocation of temporary objects.
-     * @param source The source combination array.
-     * @return true if the element was added, false if the batch is full.
+     * Adds a combination to the batch. Returns <code>true</code> if the combination was added
+     * successfully or <code>false</code> if the batch is full.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be extremely efficient and allocation-free, allowing it to be called
+     * billions of times without introducing significant overhead. By
+     * {@link System#arraycopy(Object, int, Object, int, int) copying} the input array into a
+     * {@link #WorkBatch(int) pre-allocated} {@link #buffer}, we avoid the need for allocations and
+     * reduce GC pressure. The pre-allocated nature of the buffer ensures that the destination array is
+     * never <code>null</code>, eliminating the need for null checks in the destination. Finally, we use a
+     * simple remaining capacity check instead of a size check to improve branch prediction and avoid
+     * deoptimizations that can occur with size tracking.
+     * </p>
+     * 
+     * @param source the <b>non-<code>null</code></b> combination array to add to the batch.
+     * @return <code>true</code> if the combination was added successfully, <code>false</code> if the
+     *         batch is full.
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) array access in {@link #buffer}, O({@link #numClicks}) for copying the array to the
+     *              destination.
+     * @memory Does not allocate any new arrays, instead reusing the pre-allocated arrays in <code>buffer</code>.
+     * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
+     *               to minimize GC pressure and avoid temporary allocations.
+     * @see #isFull()
+     * @see #setNumClicks(int)
+     * @see CombinationGeneratorTask
      */
-    public boolean add(short[] source)
-    {
+    public boolean add(short[] source) {
         if (remainingCapacity == 0) // Check remaining capacity instead of size to avoid deoptimizations
         {
             return false;
@@ -124,11 +148,54 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * OPTIMIZED: Adds a combination by assembling it from a prefix and a final element.
-     * Made final for JIT inlining and removed null check since pre-allocation ensures dest is never null.
+     * Adds a combination with a specified prefix and last element to the {@link #tail} of the batch.
+     * 
+     * <p>
+     * With the help of previous optimizations in {@link #add(short[])}, {@link CombinationGeneratorTask
+     * generators} are already able to create combinations without any temporary allocations and only
+     * have to acquire a single array from {@link ArrayPool the pool} for each step of the process.
+     * However, the leaf nodes of the tree would still need to acquire an array to hold the final
+     * combination form, which adds slight overhead in the form of an additional array copy and element
+     * modification (with a time complexity of O(n) where n is numClicks - 1). This method seeks to
+     * eliminate that overhead, allowing the caller to directly add a prefix and its final element to
+     * the batch without needing to create a new array for that purpose.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be extremely efficient and allocation-free, allowing it to be called
+     * billions of times without introducing significant overhead. Similar to the previous
+     * <code>add</code> method, it copies the prefix into a pre-allocated buffer, avoiding the need for
+     * allocations and reducing GC pressure. The pre-allocated nature of the buffer ensures that the
+     * destination array is never <code>null</code>, eliminating the need for null checks in the
+     * destination. We assume that the caller has ensured that the <code>prefix</code> array is non-null
+     * and is of a valid length (i.e., <code>prefixLength</code> is within bounds) for similar reasons.
+     * Finally, we use a simple remaining capacity check instead of a size check to improve branch
+     * prediction and avoid deoptimizations that can occur with size tracking.
+     * </p>
+     * 
+     * @param prefix       the <b>non-<code>null</code></b> prefix array to copy from.
+     * @param prefixLength the length of the prefix to copy from the <code>prefix</code> array, assumed
+     *                     to be less than {@link #numClicks}.
+     * @param lastElement  the last element to append to the combination.
+     * @return <code>true</code> if the combination was added successfully, <code>false</code> if the
+     *         batch is full.
+     * @since 2025.07.19 - Assembling Combinations in the WorkBatch
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) array access in {@link #buffer}, O(<code>prefixLength</code>) for copying the
+     *              array to the destination.
+     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
+     *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
+     *         pre-allocated arrays in {@link #buffer}.
+     * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
+     *               and assembly to minimize GC pressure and avoid temporary allocations.
+     * @see #isFull()
+     * @see #setNumClicks(int)
+     * @see CombinationGeneratorTask
+     * @see CombinationGeneratorTask#computeLeafCombinations(CombinationGeneratorTask.GeneratorContext)
      */
-    public final boolean add(short[] prefix, int prefixLength, short lastElement)
-    {
+    public final boolean add(short[] prefix, int prefixLength, short lastElement) {
         if (remainingCapacity == 0) // Check remaining capacity instead of size to avoid deoptimizations
         {
             return false;
@@ -146,11 +213,36 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Remove and return next combination.
-     * @return result if there is a valid combination in the array, null if the batch is empty.
+     * Returns the next combination from the batch, or <code>null</code> if the batch is empty. This
+     * method does not null out the polled array, allowing it to be reused by subsequent add operations.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be constant time and allocation-free, allowing it to be called
+     * millions of times per second without introducing significant overhead. By simply incrementing the
+     * values of {@link #head} and {@link #remainingCapacity}, we avoid the need for
+     * {@link CombinationGeneratorTask generators} to create new arrays for each combination, bringing
+     * down the GC pressure during runtime. We use a simple <code>remainingCapacity</code> check instead
+     * of a size check to improve branch prediction and avoid deoptimizations that can occur with size
+     * tracking. Finally, we avoid null checks on the polled array, as it is guaranteed to be non-null
+     * if the batch is not empty (if <code>remainingCapacity</code> is not equal to {@link #capacity}).
+     * </p>
+     * 
+     * @return the next combination from the batch, or <code>null</code> if the batch is empty.
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) for polling operations.
+     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
+     *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
+     *         pre-allocated arrays in {@link #buffer}.
+     * @optimization Pre-allocated array reuse to minimize GC pressure and avoid temporary allocations.
+     * @see #buffer
+     * @see #add(short[], int, short)
+     * @see #clear()
+     * @see #isEmpty()
      */
-    public short[] poll()
-    {
+    public short[] poll() {
         if (remainingCapacity == capacity) // Check remaining capacity instead of size to avoid deoptimizations
         {
             return null;
@@ -179,10 +271,28 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * "Clears" the batch for reuse, making sure not to null the previous arrays (as this would force add() to create a new array).
+     * "Clears" the batch for reuse by resetting {@link #head}, {@link #tail}, and
+     * {@link #remainingCapacity remaining capacity.}
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * This method is designed to be constant time and allocation-free, allowing it to be called
+     * millions of times per second without introducing significant overhead. By simply resetting the
+     * values of {@link #head}, {@link #tail}, and {@link #remainingCapacity}, we avoid the need for
+     * any array manipulations or allocations, making it extremely efficient. This also allows future
+     * add operations to reuse the existing arrays in the {@link #buffer}, further reducing GC
+     * pressure during runtime.
+     * </p>
+     * 
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) for clear operations.
+     * @memory Does not deallocate or allocate any arrays, simply resets internal pointers.
+     * @optimization Efficient state reset to enable rapid reuse of the batch without additional overhead.
+     * @see #WorkBatch(int)
      */
-    public void clear()
-    {
+    public void clear() {
         head = 0;
         tail = 0;
         remainingCapacity = capacity; // Reset remaining capacity to full

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -3,117 +3,89 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MessagePassingQueue;
 
 /**
- * A high-performance, batch container for managing combinations of clicks.
+ * A high-performance, reusable container for batching puzzle combinations
  * 
  * <p>
- * Queue operations, even with the efficiency of JCTools, can introduce significant overhead when
- * performed at a high frequency. Adding multiple combinations at once into a queue using the
- * {@link org.jctools.queues.MessagePassingQueue.Consumer
- * MessagePassingQueue.Consumer&lt;short[]&gt;} interface and creating a queue for each
- * {@link TestClickCombination monkey} helps, but the overhead of queue operations can still be a
- * bottleneck. The WorkBatch class addresses this by batching multiple combinations into a single
- * structure, allowing for amortized queue operations and reducing the frequency of expensive queue
- * interactions.
+ * This class is a cornerstone for the solver's performance architecture. It functions as a custom,
+ * fixed-size circular buffer that groups thousands of individual {@code short[]} puzzle
+ * combinations into a single object. This batching strategy is crucial for reducing contention on
+ * {@link CombinationQueue combination queues} and minimizing synchronization overhead between
+ * {@link CombinationGeneratorTask generators} and {@link TestClickCombination monkeys}.
  * </p>
  * 
- * <h2>Optimization Strategy</h2>
+ * <h2>Architecture Role and Performance Impact</h2>
  * <p>
- * {@code WorkBatch} instances were originally designed just for holding combinations before
- * draining/filling them from/to queues, but we quickly realized that {@code WorkBatch} could also
- * be used as a container for pooling. By {@link #WorkBatch(int) pre-allocating} a {@link #capacity
- * fixed-size} {@link #buffer buffer} of combinations, and copying incoming combinations into that
- * buffer, we can avoid the need for new array allocations during runtime. Combined with the reuse
- * of WorkBatch instances themselves by {@link CombinationGeneratorTask generators}, this
- * drastically reduces the number of runtime allocations to ~0, minimizing GC pressure and improving
- * performance.
+ * In high-performance computing, frequent queue operations can become a major bottleneck. This was
+ * the case in earlier versions of this solver, where generators enqueued millions of individual
+ * combinations, consuming 30-40% of CPU time in queue management alone.
  * </p>
  * 
- * <h2>Usage Patterns</h2>
  * <p>
- * {@code WorkBatch} is designed to be used in high-frequency scenarios where combinations need to
- * be generated, processed, and queued rapidly. It is particularly well-suited for use with
- * {@link CombinationGeneratorTask combination generators} and {@link TestClickCombination monkeys}.
- * Combinations can be copied into an array on the {@link #tail} of the batch using
- * {@link #add(short[])} or {@link #add(short[], int, short)}, and polled from the {@link #head} of
- * the batch using {@link #poll()}. To avoid thread-safety issues, each {@code WorkBatch} instance
- * should be used by one thread at a time, with queues serving as the only point of inter-thread
- * communication. Never retain a reference to a {@code WorkBatch} instance after flushing it to a
- * queue, as the receiving thread may modify it at any time.
+ * {@code WorkBatch} fundamentally solves this problem by changing the unit of work transfer.
+ * Instead of individual arrays, generators now fill a {@code WorkBatch} and enqueue it once.
+ * Monkeys dequeue the entire batch and process its contents. This approach reduces the number of
+ * queue operations by several orders of magnitude (from millions to hundreds), effectively
+ * eliminating the queue as a bottleneck and dramatically improving cache locality.
  * </p>
  * 
  * <h2>Memory Management</h2>
  * <p>
- * {@code WorkBatch} instances manage their own memory through pre-allocation and reuse. The
- * {@link #buffer buffer} is allocated once at construction time based on the specified
- * {@link #capacity capacity} and {@link #numClicks number of clicks}, and is reused for the
- * lifetime of the {@code WorkBatch} instance. This approach minimizes dynamic memory allocations
- * and reduces GC pressure, leading to more consistent performance in high-frequency scenarios.
+ * To achieve near-zero garbage collection pressure in the hot-path, {@code WorkBatch} instances are
+ * designed to be reusable. The internal {@link #buffer} is pre-allocated once at construction.
+ * After a monkey finishes processing a batch, the batch object is returned to the a central pool
+ * managed by {@link CombinationQueueArray}, making it available for generators to use again. This
+ * pooling strategy, combined with the pre-allocated buffer, nearly eliminates runtime memory
+ * allocation for combination data.
  * </p>
  * 
+ * <h2>Thread Safety</h2>
  * <p>
- * Since {@code WorkBatch} objects are meant to hold many combinations, the size of the
- * {@link #buffer buffer} can be significant. Larger batch sizes reduce the frequency of queue
- * operations, potentially benefiting the generators, but come at the cost of increased memory usage
- * and potentially increased latency for monkeys. Smaller batch sizes reduce memory usage and
- * latency, but increase the frequency of queue operations. Care must be taken to balance these
- * trade-offs for the specific use case and performance requirements.
+ * This class is <strong>not</strong> thread-safe. An instance of {@code WorkBatch} must only be
+ * accessed by a single thread at a time. The architecture enforces this by design: a generator
+ * thread owns a batch while filling it, and a monkey owns it after dequeuing it. Queues are the
+ * sole mechanism for safely transferring ownership between threads.
  * </p>
  * 
- * @since 2025.07.01 - {@code WorkBatch} Introduction
- * @performance {@code O(1)} for poll operations and simple state checks,
- *              <code>O({@link #numClicks})</code> for add operations due to array copying.
+ * @see ArrayPool
+ * @see TaskPool
+ * @since 2025.07 - {@code WorkBatch} Introduction
+ * @performance {@code O(1)} for poll operations and simple state checks, {@code O(numClicks)} for
+ *              add operations due to array copying.
  * @memory Fixed memory usage based on the {@link #capacity capacity} and {@link #numClicks number
  *         of clicks}, minimizing dynamic allocations.
  * @threading This class is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
  *            intended to be used by one thread at a time. Queues should be the only point of
  *            inter-thread communication.
- * @see ArrayPool
- * @see CombinationGeneratorTask
- * @see CombinationQueue
- * @see TestClickCombination
  */
 public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, MessagePassingQueue.Supplier<short[]> {
     /**
-     * Pre-allocated buffer to hold combinations.
-     * 
+     * The pre-allocated circular buffer storing the {@code short[]} combinations.
+     *
      * <p>
-     * Even with the power of JCTools, queue operations still have overhead and can be expensive when
-     * performed at a high frequency. Amortizing this cost by batching multiple combinations is
-     * necessary to achieve the desired performance while adhering to the golden rule of JVM
-     * optimization: <b>Don't allocate.</b>
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a pre-allocated array avoids the overhead of dynamic memory allocation and garbage
-     * collection, which can introduce latency and degrade performance. Reusing the same arrays for
-     * multiple batches also creates the infrastructure for pooling combinations, drastically reducing
-     * the number of allocations and GC pressure.
+     * This buffer is the core of the {@code WorkBatch}. It is allocated once at construction and
+     * continuously reused to store combination data. This strategy is fundamental to the solver's
+     * low-allocation approach, as it avoids the immense garbage collection pressure that would result
+     * from creating new arrays for billions of combinations.
      * </p>
      * 
      * @see #WorkBatch(int)
      * @see #add(short[])
      * @see #poll()
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
-     * @performance {@code O(1)} for poll operations, <code>O({@link #numClicks})</code> for add
+     * @since 2025.07 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for {@code poll} operations, {@code O(numClicks)} for {@code add}
      *              operations due to array copying.
-     * @threading The buffers are not thread-safe, as they are intended to be used within a single
-     *            thread context. Queues should be the only point of inter-thread communication.
-     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
-     *         dynamic allocations.
-     * @optimization Pre-allocation and reuse of arrays to minimize GC pressure.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Fixed memory footprint of ~{@code capacity × numClicks × 2} bytes as a {@code short[][]}.
      */
     private final short[][] buffer;
     /**
-     * The maximum number of combinations the batch can hold.
-     * 
-     * <h3>Performance Considerations</h3>
+     * The maximum number of combinations this batch can hold.
+     *
      * <p>
-     * The capacity of the batch directly impacts its performance characteristics. A larger capacity
-     * reduces the frequency of queue operations, which can be expensive, but increases memory usage. A
-     * smaller capacity reduces memory usage but increases the frequency of queue operations. The
-     * optimal capacity balances these trade-offs based on the specific use case and performance
-     * requirements.
+     * Batch capacity is a critical tuning parameter. A larger capacity reduces the frequency of
+     * expensive queue operations but increases memory footprint and may introduce latency if batches
+     * take too long to fill. A smaller capacity has the opposite effect. The optimal value balances
+     * these trade-offs to maximize throughput.
      * </p>
      * 
      * @see #buffer
@@ -121,155 +93,102 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @see #add(short[])
      * @see #isFull()
      * @see CombinationGeneratorTask#BATCH_SIZE
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
-     * @performance {@code O(1)} for capacity checks.
-     * @threading The capacity is immutable and does not impact thread safety.
-     * @memory Fixed memory usage based on capacity and {@link #numClicks the number of clicks}.
+     * @since 2025.07 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} field access.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Fixed memory footprint of 4 bytes as an {@code int}.
      */
     private final int capacity;
     /**
-     * The number of clicks (elements) in each combination. This is static as it is consistent across
-     * all batches for a given puzzle, and is effectively a constant for the lifetime of the application
-     * (we can't set it as final though, because it is configured at runtime).
-     * 
+     * The number of clicks (elements) in each combination array.
+     *
      * <p>
-     * The number of clicks determines the size of each combination array, impacting the footprint of
-     * the {@link #WorkBatch(int) pre-allocated} {@link #buffer buffer} and the performance of
-     * {@link System#arraycopy(Object, int, Object, int, int) array copy} operations in
-     * {@link #add(short[])}.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Since we pre-allocate the buffer based on the number of clicks, it is crucial to
-     * {@link #setNumClicks(int) set this value} correctly before creating any WorkBatch instances. A
-     * value that is too large could lead to corrupted combinations (where the extra elements are just
-     * 0's), while a value that is too small could lead to
-     * {@link java.lang.ArrayIndexOutOfBoundsException ArrayIndexOutOfBoundsExceptions} during array
-     * copy operations. Ensuring that this value is accurate and consistent across the application is
-     * key to maintaining the integrity of the combinations and the performance of the batch operations.
+     * This {@code static} value determines the size of the inner arrays within the {@link #buffer}. It
+     * must be configured via {@link #setNumClicks(int)} once at application startup before any
+     * {@code WorkBatch} instances are created. This ensures that all pre-allocated buffers have the
+     * correct dimensions for the target puzzle.
      * </p>
      * 
      * @see #buffer
      * @see #add(short[], int, short)
      * @see #setNumClicks(int)
-     * @since 2025.07.25 - NPE in {@code WorkBatch} Operations Fix
+     * @since 2025.07 - NPE in {@code WorkBatch} Operations Fix
      * @performance {@code O(1)} for access.
-     * @threading The variable is static and does not impact thread safety.
-     * @memory Fixed memory usage based on the number of clicks and {@link #capacity}.
+     * @threading Thread-safe after initialization.
+     * @memory Fixed memory footprint of 4 bytes as an {@code int}.
      */
     private static int numClicks;
     /**
-     * The head index for {@link #poll() polling} combinations from the batch.
-     * 
+     * The index of the next combination to be read from the circular {@link #buffer}.
+     *
      * <p>
-     * The head index tracks where the next combination will be polled from the batch. It is incremented
-     * on each {@code poll} operation and wraps around to the beginning of the {@link #buffer} when it
-     * reaches the end, implementing a circular buffer.
+     * This pointer advances when {@link #poll()} is called and wraps around the buffer, enabling
+     * efficient, continuous reads without reallocating memory. Using separate {@code head} and
+     * {@link #tail} integer pointers is a deliberate choice for performance, as it avoids the
+     * arithmetic overhead that a single-pointer implementation would require on every
+     * {@code add}/{@code poll} operation.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast {@code add} and {@code poll} operations. The head index is
-     * updated in constant time, ensuring that {@code poll} operations remain efficient even as the
-     * batch fills up and empties out.
-     * </p>
-     * 
-     * <p>
-     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an {@code int} avoids potential overflow issues in
-     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
-     * could also use a single pointer for both {@code head} and {@link #tail}, but that would
-     * complicate the logic and force an extra arithmetic operation on each
-     * {@link #add(short[], int, short) add} and {@code poll} operation, which could impact performance.
-     * </p>
-     * 
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     *
+     * @since 2025.07 - {@code WorkBatch} Introduction
      * @performance {@code O(1)} for {@code poll} operations.
-     * @threading The index is not thread-safe, as it is intended to be used within a single thread
-     *            context. Queues should be the only point of inter-thread communication.
-     * @memory Minimal additional memory overhead (single {@code int}).
-     * @optimization Efficient circular buffer implementation for fast access.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Fixed memory footprint of 4 bytes as an {@code int}.
      */
     private int head = 0;
     /**
-     * The tail index for {@link #add(short[], int, short) adding} combinations to the batch.
-     * 
+     * The index of the next available slot for writing into the circular {@link #buffer}.
+     *
      * <p>
-     * The tail index tracks where the next combination will be added to the batch. It is incremented on
-     * each {@code add} operation and wraps around to the beginning of the {@link #buffer} when it
-     * reaches the end, implementing a circular buffer.
+     * This pointer advances when an item is added via {@link #add(short[])} or
+     * {@link #add(short[], int, short)} and wraps around the buffer. Using an {@code int} instead of a
+     * {@code short} avoids potential overflow issues and unusual JVM arithmetic handling for shorts,
+     * while the use of a separate tail pointer (from {@link #head}) minimizes computational overhead in
+     * the hot path.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast {@code add} and {@code poll} operations. The tail index is
-     * updated in constant time, ensuring that {@code add} operations remain efficient even as the batch
-     * fills up and empties out.
-     * </p>
-     * 
-     * <p>
-     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an {@code int} avoids potential overflow issues in
-     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
-     * could also use a single pointer for both {@link #head} and {@code tail}, but that would
-     * complicate the logic and force an extra arithmetic operation on each {@code add} and
-     * {@link #poll() poll} operation, which could impact performance.
-     * </p>
-     * 
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
-     * @performance {@code O(1)} for add operations.
-     * @threading The index is not thread-safe, as it is intended to be used within a single thread
-     *            context. Queues should be the only point of inter-thread communication.
-     * @memory Minimal additional memory overhead (single {@code int}).
-     * @optimization Efficient circular buffer implementation for fast access.
+     *
+     * @since 2025.07 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for {@code add} operations.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Fixed memory footprint of 4 bytes as an {@code int}.
      */
     private int tail = 0;
     /**
-     * An {@code int} to track the remaining capacity of the batch.
-     * 
+     * Tracks the number of available slots in the batch.
+     *
      * <p>
-     * The typical mechanism for tracking the number of elements in a circular buffer would be to use a
-     * {@code size} variable that increments on {@code add} operations and decrements on {@code poll}
-     * operations. However, {@code size} checks in those methods can lead to JVM deoptimizations due to
-     * the way the JIT compiler optimizes code paths and performs speculative optimizations. We need a
-     * more stable approach to tracking that avoids these pitfalls, can be branch predicted more easily,
-     * and doesn't require manual arithmetic computations. Tracking the remaining capacity provides
-     * this.
-     * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * By using remaining capacity, we can perform checks against a constant value (zero or full
-     * capacity) rather than a variable size. This reduces the likelihood of deoptimizations and
-     * improves branch prediction, leading to more consistent performance in high-frequency scenarios.
+     * This counter is used instead of a traditional {@code size} field. Checking against remaining
+     * capacity (e.g., {@code remainingCapacity == 0}) is often more favorable to JIT compiler
+     * optimizations and branch prediction than checking a variable size. It decrements on
+     * {@link #add(short[], int, short) add} and increments on {@link #poll() poll}.
      * </p>
      * 
      * @see #capacity
      * @see #add(short[])
      * @see #poll()
-     * @since 2025.07.28 - Remaining Capacity Tracking
-     * @performance {@code O(1)} for capacity checks, avoiding deoptimizations associated with size
-     *              tracking.
-     * @threading The counter is not thread-safe, as it is intended to be used within a single thread
-     *            context. Queues should be the only point of inter-thread communication.
-     * @memory Minimal additional memory overhead (single {@code int}).
-     * @optimization Stable and predictable capacity tracking to enhance performance.
+     * @since 2025.07 - Remaining Capacity Tracking
+     * @performance {@code O(1)} updates and comparisons.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Fixed memory footprint of 4 bytes as an {@code int}.
      */
     private int remainingCapacity; // Replacement for size to avoid deoptimizations
 
     /**
-     * Creates a new {@code WorkBatch} with the specified {@code capacity}. The buffer is pre-allocated
-     * based on the {@link #numClicks number of clicks}, which must be {@link #setNumClicks(int) set}
-     * before creating any {@code WorkBatch} instances.
-     * 
-     * @param capacity the maximum number of combinations the batch can hold.
-     * @throws IllegalArgumentException if the capacity is not a positive integer.
+     * Constructs a new {@code WorkBatch} with a pre-allocated {@link #buffer internal buffer}.
+     *
+     * <p>
+     * The {@code buffer} size is determined by the specified {@code capacity} and the static
+     * {@link #numClicks} value, which must be set via {@link #setNumClicks(int)} before calling this
+     * constructor.
+     * </p>
+     *
+     * @param capacity The maximum number of combinations the batch can hold.
+     * @throws IllegalArgumentException if capacity is not a positive integer.
      * @throws IllegalStateException    if {@link #numClicks} has not been set to a positive value.
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
-     * @threading Thread-safe by nature of construction, but the created instance is not.
+     * @since 2025.07 - {@code WorkBatch} Introduction
+     * @performance {@code O(capacity × numClicks)} for initial buffer allocation, {@code O(1)} for
+     *              construction.
+     * @threading Thread-safe during construction; the resulting instance is not thread-safe.
+     * @memory Allocates a {@code short[capacity][numClicks]}.
      */
     public WorkBatch(int capacity) {
         if (numClicks <= 0) {
@@ -286,54 +205,44 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Sets the {@link #numClicks number of clicks} (elements) in each combination. This must be set
-     * before creating any WorkBatch instances, as it determines the size of the {@link #buffer buffer}
-     * {@link #WorkBatch(int) pre-allocated} in the constructor.
-     * 
-     * @param numClicks the number of clicks (elements) in each combination.
-     * @since 2025.07.27 - Pre-allocation of {@code WorkBatch} Buffers
-     * @performance {@code O(1)} for setting the value.
-     * @threading This method is thread-safe since it modifies a static volatile variable. However, it
-     *            should be called during application initialization before any WorkBatch instances are
-     *            created to ensure consistency.
-     * @memory Minimal additional memory overhead (single {@code int}).
-     * @optimization Direct assignment to a {@code static} variable for efficient access.
+     * Sets the {@code static} {@link #numClicks number of clicks} for all {@code WorkBatch} instances.
+     *
+     * <p>
+     * This method must be called once during application initialization before any batches are created.
+     * It ensures all {@link #WorkBatch(int) pre-allocated} {@link #buffer buffers} have the correct
+     * dimensions for the puzzle being solved.
+     * </p>
+     *
+     * @param numClicks The number of elements in each combination array.
+     * @since 2025.07 - Pre-allocation of {@code WorkBatch} Buffers
+     * @performance {@code O(1)} for field assignment.
+     * @threading Not thread-safe (at the moment); must be called once before any instances are created.
+     * @memory Does not allocate.
      */
     public static void setNumClicks(int numClicks) {
         WorkBatch.numClicks = numClicks;
     }
 
     /**
-     * Adds a combination to the batch. Returns {@code true} if the combination was added successfully
-     * or {@code false} if the batch is full.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Adds a combination to the batch by {@link System#arraycopy(Object, int, Object, int, int)
+     * copying} it into the {@link #buffer internal buffer}.
+     *
      * <p>
-     * This method is designed to be extremely efficient and allocation-free, allowing it to be called
-     * billions of times without introducing significant overhead. By
-     * {@link System#arraycopy(Object, int, Object, int, int) copying} the input array into a
-     * {@link #WorkBatch(int) pre-allocated} {@link #buffer}, we avoid the need for allocations and
-     * reduce GC pressure. The pre-allocated nature of the buffer ensures that the destination array is
-     * never {@code null}, eliminating the need for {@code null} checks in the destination. Finally, we
-     * use a simple remaining capacity check instead of a {@code size} check to improve branch
-     * prediction and avoid deoptimizations that can occur with {@code size} tracking.
+     * This method is a hot path, optimized to be allocation-free. It uses {@code System.arraycopy()} to
+     * transfer the combination data into the {@link #WorkBatch(int) pre-allocated} {@code buffer},
+     * avoiding the overhead of creating new array objects.
      * </p>
-     * 
-     * @param source the <b>non-{@code null}</b> combination array to add to the batch.
-     * @return {@code true} if the combination was added successfully, {@code false} if the batch is
-     *         full.
+     *
+     * @param source The combination array to add. The caller must ensure this is not {@code null}.
+     * @return {@code true} if the combination was added, or {@code false} if the batch is full.
      * @see #isFull()
      * @see #setNumClicks(int)
      * @see CombinationGeneratorTask
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
-     * @performance {@code O(1)} array access in {@link #buffer}, <code>O({@link #numClicks})</code> for
-     *              copying the array to the destination.
-     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
-     *            intended to be used by one thread at a time.
-     * @memory Does not allocate any new arrays, instead reusing the pre-allocated arrays in
-     *         {@code buffer}.
-     * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
-     *               to minimize GC pressure and avoid temporary allocations.
+     * @since 2025.07 - {@code WorkBatch} Introduction
+     * @performance {@code O(numClicks)} array copying, {@code O(1)} capacity checks and pointer
+     *              updates.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate; reuses the pre-allocated arrays in {@code buffer}.
      */
     public boolean add(short[] source) {
         if (remainingCapacity == 0) // Check remaining capacity instead of size to avoid deoptimizations
@@ -347,53 +256,30 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Adds a combination with a specified {@code prefix} and {@code lastElement} to the {@link #tail}
-     * of the batch.
-     * 
+     * Adds a combination by assembling it directly into the {@link #buffer internal buffer} from a
+     * {@code prefix} and a final element.
+     *
      * <p>
-     * With the help of previous optimizations in {@link #add(short[])}, {@link CombinationGeneratorTask
-     * generators} are already able to create combinations without any temporary allocations and only
-     * have to acquire a single array from {@link ArrayPool the pool} for each step of the process.
-     * However, the leaf nodes of the tree would still need to acquire an array to hold the final
-     * combination form, which adds slight overhead in the form of an additional array copy and element
-     * modification (with a time complexity of <code>O({@link #numClicks} - 1)</code>). This method
-     * seeks to eliminate that overhead, allowing the caller to directly add a {@code prefix} and its
-     * final element to the batch without needing to create a new array for that purpose.
+     * This highly optimized method is a critical performance enhancement for the
+     * {@link CombinationGeneratorTask}. It allows the generator to construct the final combination at
+     * the leaf nodes of its recursion tree without allocating a temporary array. Instead, the
+     * {@code prefix} is {@link System#arraycopy(Object, int, Object, int, int) copied} and the last
+     * element is appended directly into the target slot in the {@code buffer}, eliminating an
+     * intermediate array copy and allocation.
      * </p>
-     * 
-     * <h3>Performance Considerations</h3>
-     * <p>
-     * This method is designed to be extremely efficient and allocation-free, allowing it to be called
-     * billions of times without introducing significant overhead. Similar to the previous {@code add}
-     * method, it copies {@code prefix} into a pre-allocated buffer, avoiding the need for allocations
-     * and reducing GC pressure. The pre-allocated nature of the buffer ensures that the destination
-     * array is never {@code null}, eliminating the need for {@code null} checks in the destination. We
-     * assume that the caller has ensured that the {@code prefix} array is non-{@code null} and is of a
-     * valid length (i.e., {@code prefixLength} is within bounds) for similar reasons. Finally, we use a
-     * simple remaining capacity check instead of a {@code size} check to improve branch prediction and
-     * avoid deoptimizations that can occur with {@code size} tracking.
-     * </p>
-     * 
-     * @param prefix       the <b>non-{@code null}</b> prefix array to copy from.
-     * @param prefixLength the length of the prefix to copy from the {@code prefix} array, assumed to be
-     *                     less than {@link #numClicks}.
-     * @param lastElement  the last element to append to the combination.
-     * @return {@code true} if the combination was added successfully, {@code false} if the batch is
-     *         full.
+     *
+     * @param prefix       The prefix of the combination. The caller must ensure this is not
+     *                     {@code null}.
+     * @param prefixLength The length of the prefix to copy.
+     * @param lastElement  The final element to append to the combination.
+     * @return {@code true} if the combination was added, or {@code false} if the batch is full.
      * @see #isFull()
      * @see #setNumClicks(int)
      * @see CombinationGeneratorTask
-     * @see CombinationGeneratorTask#computeLeafCombinations(CombinationGeneratorTask.GeneratorContext)
-     * @since 2025.07.19 - Assembling Combinations in the {@code WorkBatch}
-     * @performance {@code O(1)} array access in {@link #buffer}, {@code O(prefixLength)} for copying
-     *              the array to the destination.
-     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
-     *            intended to be used by one thread at a time.
-     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
-     *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
-     *         pre-allocated arrays in {@link #buffer}.
-     * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
-     *               and assembly to minimize GC pressure and avoid temporary allocations.
+     * @since 2025.07 - Assembling Combinations in the {@code WorkBatch}
+     * @performance {@code O(1)} array access in {@link #buffer}, {@code O(prefixLength)} array copy.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate; reuses the pre-allocated arrays in {@code buffer}.
      */
     public final boolean add(short[] prefix, int prefixLength, short lastElement) {
         if (remainingCapacity == 0) // Check remaining capacity instead of size to avoid deoptimizations
@@ -413,35 +299,28 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Returns the next combination from the batch, or {@code null} if the batch is empty. This method
-     * does not null out the polled array, allowing it to be reused by subsequent add operations.
-     * 
-     * <h3>Performance Considerations</h3>
+     * Retrieves the next combination from the batch without allocating a new array.
+     *
      * <p>
-     * This method is designed to be constant time and allocation-free, allowing it to be called
-     * millions of times per second without introducing significant overhead. By simply incrementing the
-     * values of {@link #head} and {@link #remainingCapacity}, we avoid the need for
-     * {@link CombinationGeneratorTask generators} to create new arrays for each combination, bringing
-     * down the GC pressure during runtime. We use a simple {@code remainingCapacity} check instead of a
-     * {@code size} check to improve branch prediction and avoid deoptimizations that can occur with
-     * size tracking. Finally, we avoid null checks on the polled array, as it is guaranteed to be
-     * non-null if the batch is not empty (if {@code remainingCapacity} is not equal to
-     * {@link #capacity}).
+     * This method returns a direct reference to the array within the internal {@link #buffer}. The
+     * returned array is not {@code null}ed out in the buffer and will be overwritten by subsequent
+     * {@link #add(short[], int, short) add} operations once the circular buffer wraps around. This is a
+     * key performance feature, but it means the caller must process the returned array before it is
+     * overwritten.
      * </p>
-     * 
-     * @return the next combination from the batch, or {@code null} if the batch is empty.
+     *
+     * @return The next combination array, or {@code null} if the batch is empty.
      * @see #buffer
      * @see #add(short[], int, short)
      * @see #clear()
      * @see #isEmpty()
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @since 2025.07 - {@code WorkBatch} Introduction
      * @performance {@code O(1)} for polling operations.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
      *            used by one thread at a time.
      * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
      *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
      *         pre-allocated arrays in {@link #buffer}.
-     * @optimization Pre-allocated array reuse to minimize GC pressure and avoid temporary allocations.
      */
     public short[] poll() {
         if (remainingCapacity == capacity) // Check remaining capacity instead of size to avoid deoptimizations
@@ -456,66 +335,56 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Checks if the batch is empty.
-     * 
+     * Checks if the batch contains no combinations.
+     *
      * @return {@code true} if the batch is empty, {@code false} otherwise.
      * @see #capacity
      * @see #remainingCapacity
      * @see #isFull()
      * @see #size()
-     * @since 2025.07.01 - WorkBatch Introduction
+     * @since 2025.07 - {@code WorkBatch} Introduction
      * @performance {@code O(1)} retrievals and comparison.
-     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
-     *            intended to be used by one thread at a time.
-     * @memory Minimal additional memory overhead (single {@code int} comparison).
-     * @optimization Efficient state check to quickly determine if the batch is empty, using
-     *               {@link #remainingCapacity} for improved branch prediction.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate.
      */
     public boolean isEmpty() {
         return remainingCapacity == capacity;
     }
 
     /**
-     * Returns the current number of combinations in the batch. This is calculated based on the
-     * {@link #capacity} and {@link #remainingCapacity}, avoiding the need for a separate size variable
-     * that could lead to deoptimizations.
-     * 
-     * @return the current number of combinations in the batch.
+     * Returns the number of combinations currently stored in the batch.
+     *
+     * <p>
+     * This is calculated from the {@link #capacity} and {@link #remainingCapacity} to avoid the
+     * potential for JIT deoptimizations associated with a separate, mutable {@code size} field.
+     * </p>
+     *
+     * @return The number of combinations in the batch.
      * @see #isEmpty()
      * @see #isFull()
-     * @since 2025.07.28 - Remaining Capacity Tracking
-     * @performance {@code O(1)} for size calculations.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @memory Minimal additional memory overhead (single {@code int} calculation).
-     * @optimization Efficient size calculation using existing state variables to avoid deoptimizations.
+     * @since 2025.07 - Remaining Capacity Tracking
+     * @performance {@code O(1)} calculation.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate.
      */
     public int size() {
         return capacity - remainingCapacity; // Calculate size based on remaining capacity
     }
 
     /**
-     * "Clears" the batch for reuse by resetting {@link #head}, {@link #tail}, and
-     * {@link #remainingCapacity remaining capacity.}
-     * 
-     * <h3>Performance Considerations</h3>
+     * Resets the batch to an empty state, making it ready for reuse.
+     *
      * <p>
-     * This method is designed to be constant time and allocation-free, allowing it to be called
-     * millions of times per second without introducing significant overhead. By simply resetting the
-     * values of {@link #head}, {@link #tail}, and {@link #remainingCapacity}, we avoid the need for any
-     * array manipulations or allocations, making it extremely efficient. This also allows future add
-     * operations to reuse the existing arrays in the {@link #buffer}, further reducing GC pressure
-     * during runtime.
+     * This {@code O(1)} operation simply resets the internal pointers and counters. It does not modify
+     * the underlying {@link #buffer} array, allowing the batch to be efficiently recycled without any
+     * deallocation or reallocation.
      * </p>
      * 
      * @see #WorkBatch(int)
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
-     * @performance {@code O(1)} for clear operations.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @memory Does not deallocate or allocate any arrays, simply resets internal pointers.
-     * @optimization Efficient state reset to enable rapid reuse of the batch without additional
-     *               overhead.
+     * @since 2025.07 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} resets.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate or deallocate.
      */
     public void clear() {
         head = 0;
@@ -524,28 +393,23 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * {@link org.jctools.queues.MessagePassingQueue.Consumer MessagePassingQueue.Consumer}
-     * implementation for JCTools integration.
-     * 
+     * Legacy JCTools integration method.
+     *
      * <p>
-     * This method simply delegates to {@link #add(short[])} to add the combination to the batch. When
-     * {@link TestClickCombination monkeys} drained combinations from queues into {@code WorkBatch}es,
-     * they used this method as the consumer function.
+     * This was used in a previous architecture where individual combinations were drained from a queue
+     * into a {@code WorkBatch}. It is now unused since entire {@code WorkBatch} objects are enqueued
+     * directly.
      * </p>
-     * 
-     * <p>
-     * Now that we directly enqueue {@code WorkBatch}es instead of individual combinations, this method
-     * is no longer used by the monkeys. We could remove the {@code Consumer} interface from this class,
-     * though we've left it here, mainly from forgetting to remove it.
-     * </p>
-     * 
-     * @param combination the {@code short[]} to add to the batch.
+     *
+     * @param combination The combination to add.
+     * @deprecated This method is no longer used in the current batch-based queuing architecture.
      * @see org.jctools.queues.MessagePassingQueue
+     * @see org.jctools.queues.MessagePassingQueue.Consumer
      * @see org.jctools.queues.MessagePassingQueue.Consumer#accept(Object)
-     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @since 2025.07 - {@code WorkBatch} Introduction
      * @performance {@code O(1)} call to {@link #add(short[])}.
-     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
-     *            intended to be used by one thread at a time.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate; reuses the pre-allocated arrays in {@link #buffer}.
      */
     @Override
     public void accept(short[] combination) {
@@ -554,29 +418,23 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * {@link org.jctools.queues.MessagePassingQueue.Supplier MessagePassingQueue.Supplier}
-     * implementation for JCTools integration.
-     * 
+     * Legacy JCTools integration method.
+     *
      * <p>
-     * This method simply delegates to {@link #poll()} to retrieve the next combination from the batch.
-     * When {@link CombinationGeneratorTask generators} filled queues from {@code WorkBatch}es, they
-     * used this method as the supplier function.
+     * This was used in a previous architecture where a {@code WorkBatch} was used to fill a queue with
+     * individual combinations. It is now unused since entire {@code WorkBatch} objects are enqueued
+     * directly.
      * </p>
-     * 
-     * <p>
-     * Now that we directly enqueue {@code WorkBatch}es instead of individual combinations, this method
-     * is no longer used by the generators. We could remove the {@code Supplier} interface from this
-     * class, though we've left it here, mainly from forgetting to remove it.
-     * </p>
-     * 
-     * @return the next {@code short[]} (combination) from the batch, or {@code null} if the batch is
-     *         empty.
+     *
+     * @return The next combination from the batch.
+     * @deprecated This method is no longer used in the current batch-based queuing architecture.
      * @see org.jctools.queues.MessagePassingQueue
+     * @see org.jctools.queues.MessagePassingQueue.Supplier
      * @see org.jctools.queues.MessagePassingQueue.Supplier#get()
-     * @since 2025.07.01 - {@code WorkBatch} Integration in Generators
+     * @since 2025.07 - {@code WorkBatch} Integration in Generators
      * @performance {@code O(1)} call to {@link #poll()}.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate; reuses the pre-allocated arrays in {@link #buffer}.
      */
     @Override
     public short[] get() {
@@ -585,20 +443,16 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Checks if the batch is full. This is determined by checking if the {@link #remainingCapacity} is
-     * zero.
-     * 
+     * Checks if the batch has reached its {@link #capacity maximum capacity}.
+     *
      * @return {@code true} if the batch is full, {@code false} otherwise.
      * @see #capacity
      * @see #isEmpty()
      * @see #size()
-     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @since 2025.07 - Remaining Capacity Tracking
      * @performance {@code O(1)} retrievals and comparison.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @memory Minimal additional memory overhead (single {@code int} comparison).
-     * @optimization Efficient state check to quickly determine if the batch is full, using
-     *               {@link #remainingCapacity} for improved branch prediction.
+     * @threading Not thread-safe; must be accessed by only one thread at a time.
+     * @memory Does not allocate.
      */
     public boolean isFull() {
         return remainingCapacity == 0;

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -3,30 +3,77 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MessagePassingQueue;
 
 /**
- * WorkBatch - [Performance Purpose - e.g., "High-performance memory pool"]
+ * WorkBatch - A high-performance, batch container for managing combinations of clicks.
  * 
- * <p>[Detailed description of the performance problem this class solves.
- * Include before/after metrics where applicable.]</p>
+ * <p>
+ * Queue operations, even with the efficiency of JCTools, can introduce significant overhead when
+ * performed at a high frequency. Adding multiple combinations at once into a queue using the
+ * {@link org.jctools.queues.MessagePassingQueue.Consumer MessagePassingQueue.Consumer&lt;short[]&gt;}
+ * interface and creating a queue for each {@link TestClickCombination monkey} helps, but the
+ * overhead of queue operations can still be a bottleneck. The WorkBatch class addresses this by
+ * batching multiple combinations into a single structure, allowing for amortized queue operations
+ * and reducing the frequency of expensive queue interactions.
+ * </p>
  * 
  * <h2>Optimization Strategy</h2>
- * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
- * Explain trade-offs made for performance gains.]</p>
+ * <p>
+ * WorkBatch instances were originally designed just for holding combinations before
+ * draining/filling them from/to queues, but we quickly realized that WorkBatch could also be used
+ * as a container for pooling. By {@link #WorkBatch(int) pre-allocating} a {@link #capacity
+ * fixed-size} {@link #buffer buffer} of combinations, and copying incoming combinations into that
+ * buffer, we can avoid the need for new array allocations during runtime. Combined with the reuse
+ * of WorkBatch instances themselves by {@link CombinationGeneratorTask generators}, this
+ * drastically reduces the number of runtime allocations to ~0, minimizing GC pressure and improving
+ * performance.
+ * </p>
  * 
  * <h2>Usage Patterns</h2>
- * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * <p>
+ * WorkBatch is designed to be used in high-frequency scenarios where combinations need to be
+ * generated, processed, and queued rapidly. It is particularly well-suited for use with
+ * {@link CombinationGeneratorTask combination generators} and {@link TestClickCombination monkeys}.
+ * Combinations can be copied into an array on the {@link #tail} of the batch using
+ * {@link #add(short[]) add(short[])} or {@link #add(short[], int, short) add(short[], int, short)},
+ * and polled from the {@link #head} of the batch using {@link #poll() poll()}. To avoid
+ * thread-safety issues, each WorkBatch instance should be used by one thread at a time, with queues
+ * serving as the only point of inter-thread communication. Never retain a reference to a WorkBatch
+ * instance after flushing it to a queue, as the receiving thread may modify it at any time.
+ * </p>
  * 
  * <h2>Memory Management</h2>
- * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * <p>
+ * WorkBatch instances manage their own memory through pre-allocation and reuse. The {@link #buffer
+ * buffer} is allocated once at construction time based on the specified {@link #capacity capacity}
+ * and {@link #numClicks number of clicks}, and is reused for the lifetime of the WorkBatch
+ * instance. This approach minimizes dynamic memory allocations and reduces GC pressure, leading to
+ * more consistent performance in high-frequency scenarios.
+ * </p>
  * 
- * <h3>6/18 - ~33.3% of documentation completed</h3>
+ * <p>
+ * Since WorkBatch objects are meant to hold many combinations, the size of the {@link #buffer
+ * buffer} can be significant. Larger batch sizes reduce the frequency of queue operations,
+ * potentially benefiting the generators, but come at the cost of increased memory usage and
+ * potentially increased latency for monkeys. Smaller batch sizes reduce memory usage and latency,
+ * but increase the frequency of queue operations. Care must be taken to balance these trade-offs
+ * for the specific use case and performance requirements.
+ * </p>
  * 
- * @performance [Specific performance characteristics and measurements]
- * @memory [Memory usage patterns and optimizations]
- * @threading [Thread safety model]
- * @since [When introduced and why]
+ * <h3>11/18 - ~61.1% of documentation completed</h3>
+ * 
+ * @since 2025.07.01 - WorkBatch Introduction
+ * @performance O(1) for poll operations and simple state checks, O(numClicks) for add operations
+ *              due to array copying.
+ * @memory Fixed memory usage based on the {@link #capacity capacity} and {@link #numClicks number
+ *         of clicks}, minimizing dynamic allocations.
+ * @threading This class is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+ *            used by one thread at a time. Queues should be the only point of inter-thread
+ *            communication.
+ * @see ArrayPool
+ * @see CombinationGeneratorTask
+ * @see CombinationQueue
+ * @see TestClickCombination
  */
-public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, MessagePassingQueue.Supplier<short[]>
-{
+public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, MessagePassingQueue.Supplier<short[]> {
     /**
      * Pre-allocated buffer to hold combinations.
      * 
@@ -57,9 +104,128 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @see #WorkBatch(int)
      */
     private final short[][] buffer;
+    /**
+     * The maximum number of combinations the batch can hold.
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * The capacity of the batch directly impacts its performance characteristics. A larger capacity
+     * reduces the frequency of queue operations, which can be expensive, but increases memory usage. A
+     * smaller capacity reduces memory usage but increases the frequency of queue operations. The
+     * optimal capacity balances these trade-offs based on the specific use case and performance
+     * requirements.
+     * </p>
+     * 
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading The capacity is immutable and does not impact thread safety.
+     * @performance O(1) for capacity checks.
+     * @memory Fixed memory usage based on capacity and {@link #numClicks the number of clicks}.
+     * @see #buffer
+     * @see #add(short[])
+     * @see #isFull()
+     * @see #WorkBatch(int)
+     * @see CombinationGeneratorTask#BATCH_SIZE
+     */
     private final int capacity;
+    /**
+     * The number of clicks (elements) in each combination. This is static as it is consistent across
+     * all batches for a given puzzle, and is effectively a constant for the lifetime of the application
+     * (we can't set it as final though, because it is configured at runtime).
+     * 
+     * <p>
+     * The number of clicks determines the size of each combination array, impacting the footprint of
+     * the {@link #WorkBatch(int) pre-allocated} {@link #buffer buffer} and the performance of
+     * {@link System#arraycopy(Object, int, Object, int, int) array copy} operations in
+     * {@link #add(short[])}.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Since we pre-allocate the buffer based on the number of clicks, it is crucial to
+     * {@link #setNumClicks(int) set this value} correctly before creating any WorkBatch instances. A
+     * value that is too large could lead to corrupted combinations (where the extra elements are just
+     * 0's), while a value that is too small could lead to
+     * {@link java.lang.ArrayIndexOutOfBoundsException ArrayIndexOutOfBoundsExceptions} during array
+     * copy operations. Ensuring that this value is accurate and consistent across the application is
+     * key to maintaining the integrity of the combinations and the performance of the batch operations.
+     * </p>
+     * 
+     * @since 2025.07.25 - NPE in WorkBatch Operations Fix
+     * @threading The variable is static and does not impact thread safety.
+     * @performance O(1) for access.
+     * @memory Fixed memory usage based on the number of clicks and {@link #capacity}.
+     * @see #buffer
+     * @see #add(short[], int, short)
+     * @see #setNumClicks(int)
+     */
     private static int numClicks;
+    /**
+     * The head index for {@link #poll() polling} combinations from the batch.
+     * 
+     * <p>
+     * The head index tracks where the next combination will be polled from the batch. It is incremented
+     * on each poll operation and wraps around to the beginning of the {@link #buffer} when it reaches
+     * the end, implementing a circular buffer.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
+     * usage while still allowing for fast add and poll operations. The head index is updated in
+     * constant time, ensuring that poll operations remain efficient even as the batch fills up and
+     * empties out.
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an int avoids potential overflow issues in long-running
+     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
+     * pointer for both head and {@link #tail}, but that would complicate the logic and force an extra arithmetic
+     * operation on each {@link #add(short[], int, short) add} and poll operation, which could impact
+     * performance.
+     * </p>
+     * 
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading The index is not thread-safe, as it is intended to be used within a single
+     *            thread context. Queues should be the only point of inter-thread communication.
+     * @performance O(1) for poll operations.
+     * @optimization Efficient circular buffer implementation for fast access.
+     * @memory Minimal additional memory overhead (single int).
+     */
     private int head = 0;
+    /**
+     * The tail index for {@link #add(short[], int, short) adding} combinations to the batch.
+     * 
+     * <p>
+     * The tail index tracks where the next combination will be added to the batch. It is incremented on
+     * each add operation and wraps around to the beginning of the {@link #buffer} when it reaches the
+     * end, implementing a circular buffer.
+     * </p>
+     * 
+     * <h3>Performance Considerations</h3>
+     * <p>
+     * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
+     * usage while still allowing for fast add and poll operations. The tail index is updated in
+     * constant time, ensuring that add operations remain efficient even as the batch fills up and
+     * empties out.
+     * </p>
+     * 
+     * <p>
+     * We could use a short for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an int avoids potential overflow issues in long-running
+     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
+     * pointer for both {@link #head} and tail, but that would complicate the logic and force an extra
+     * arithmetic operation on each add and {@link #poll() poll} operation, which could impact
+     * performance.
+     * </p>
+     * 
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading The index is not thread-safe, as it is intended to be used within a single
+     *       thread context. Queues should be the only point of inter-thread communication.
+     * @performance O(1) for add operations.
+     * @optimization Efficient circular buffer implementation for fast access.
+     * @memory Minimal additional memory overhead (single int).
+     */
     private int tail = 0;
     /**
      * An int to track the remaining capacity of the batch.

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -3,23 +3,24 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MessagePassingQueue;
 
 /**
- * WorkBatch - A high-performance, batch container for managing combinations of clicks.
+ * A high-performance, batch container for managing combinations of clicks.
  * 
  * <p>
  * Queue operations, even with the efficiency of JCTools, can introduce significant overhead when
  * performed at a high frequency. Adding multiple combinations at once into a queue using the
- * {@link org.jctools.queues.MessagePassingQueue.Consumer MessagePassingQueue.Consumer&lt;short[]&gt;}
- * interface and creating a queue for each {@link TestClickCombination monkey} helps, but the
- * overhead of queue operations can still be a bottleneck. The WorkBatch class addresses this by
- * batching multiple combinations into a single structure, allowing for amortized queue operations
- * and reducing the frequency of expensive queue interactions.
+ * {@link org.jctools.queues.MessagePassingQueue.Consumer
+ * MessagePassingQueue.Consumer&lt;short[]&gt;} interface and creating a queue for each
+ * {@link TestClickCombination monkey} helps, but the overhead of queue operations can still be a
+ * bottleneck. The WorkBatch class addresses this by batching multiple combinations into a single
+ * structure, allowing for amortized queue operations and reducing the frequency of expensive queue
+ * interactions.
  * </p>
  * 
  * <h2>Optimization Strategy</h2>
  * <p>
- * WorkBatch instances were originally designed just for holding combinations before
- * draining/filling them from/to queues, but we quickly realized that WorkBatch could also be used
- * as a container for pooling. By {@link #WorkBatch(int) pre-allocating} a {@link #capacity
+ * {@code WorkBatch} instances were originally designed just for holding combinations before
+ * draining/filling them from/to queues, but we quickly realized that {@code WorkBatch} could also
+ * be used as a container for pooling. By {@link #WorkBatch(int) pre-allocating} a {@link #capacity
  * fixed-size} {@link #buffer buffer} of combinations, and copying incoming combinations into that
  * buffer, we can avoid the need for new array allocations during runtime. Combined with the reuse
  * of WorkBatch instances themselves by {@link CombinationGeneratorTask generators}, this
@@ -29,43 +30,43 @@ import org.jctools.queues.MessagePassingQueue;
  * 
  * <h2>Usage Patterns</h2>
  * <p>
- * WorkBatch is designed to be used in high-frequency scenarios where combinations need to be
- * generated, processed, and queued rapidly. It is particularly well-suited for use with
+ * {@code WorkBatch} is designed to be used in high-frequency scenarios where combinations need to
+ * be generated, processed, and queued rapidly. It is particularly well-suited for use with
  * {@link CombinationGeneratorTask combination generators} and {@link TestClickCombination monkeys}.
  * Combinations can be copied into an array on the {@link #tail} of the batch using
- * {@link #add(short[]) add(short[])} or {@link #add(short[], int, short) add(short[], int, short)},
- * and polled from the {@link #head} of the batch using {@link #poll() poll()}. To avoid
- * thread-safety issues, each WorkBatch instance should be used by one thread at a time, with queues
- * serving as the only point of inter-thread communication. Never retain a reference to a WorkBatch
- * instance after flushing it to a queue, as the receiving thread may modify it at any time.
+ * {@link #add(short[])} or {@link #add(short[], int, short)}, and polled from the {@link #head} of
+ * the batch using {@link #poll()}. To avoid thread-safety issues, each {@code WorkBatch} instance
+ * should be used by one thread at a time, with queues serving as the only point of inter-thread
+ * communication. Never retain a reference to a {@code WorkBatch} instance after flushing it to a
+ * queue, as the receiving thread may modify it at any time.
  * </p>
  * 
  * <h2>Memory Management</h2>
  * <p>
- * WorkBatch instances manage their own memory through pre-allocation and reuse. The {@link #buffer
- * buffer} is allocated once at construction time based on the specified {@link #capacity capacity}
- * and {@link #numClicks number of clicks}, and is reused for the lifetime of the WorkBatch
- * instance. This approach minimizes dynamic memory allocations and reduces GC pressure, leading to
- * more consistent performance in high-frequency scenarios.
+ * {@code WorkBatch} instances manage their own memory through pre-allocation and reuse. The
+ * {@link #buffer buffer} is allocated once at construction time based on the specified
+ * {@link #capacity capacity} and {@link #numClicks number of clicks}, and is reused for the
+ * lifetime of the {@code WorkBatch} instance. This approach minimizes dynamic memory allocations
+ * and reduces GC pressure, leading to more consistent performance in high-frequency scenarios.
  * </p>
  * 
  * <p>
- * Since WorkBatch objects are meant to hold many combinations, the size of the {@link #buffer
- * buffer} can be significant. Larger batch sizes reduce the frequency of queue operations,
- * potentially benefiting the generators, but come at the cost of increased memory usage and
- * potentially increased latency for monkeys. Smaller batch sizes reduce memory usage and latency,
- * but increase the frequency of queue operations. Care must be taken to balance these trade-offs
- * for the specific use case and performance requirements.
+ * Since {@code WorkBatch} objects are meant to hold many combinations, the size of the
+ * {@link #buffer buffer} can be significant. Larger batch sizes reduce the frequency of queue
+ * operations, potentially benefiting the generators, but come at the cost of increased memory usage
+ * and potentially increased latency for monkeys. Smaller batch sizes reduce memory usage and
+ * latency, but increase the frequency of queue operations. Care must be taken to balance these
+ * trade-offs for the specific use case and performance requirements.
  * </p>
  * 
- * @since 2025.07.01 - WorkBatch Introduction
- * @performance O(1) for poll operations and simple state checks, O(numClicks) for add operations
- *              due to array copying.
+ * @since 2025.07.01 - {@code WorkBatch} Introduction
+ * @performance {@code O(1)} for poll operations and simple state checks,
+ *              <code>O({@link #numClicks})</code> for add operations due to array copying.
  * @memory Fixed memory usage based on the {@link #capacity capacity} and {@link #numClicks number
  *         of clicks}, minimizing dynamic allocations.
- * @threading This class is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
- *            used by one thread at a time. Queues should be the only point of inter-thread
- *            communication.
+ * @threading This class is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
+ *            intended to be used by one thread at a time. Queues should be the only point of
+ *            inter-thread communication.
  * @see ArrayPool
  * @see CombinationGeneratorTask
  * @see CombinationQueue
@@ -93,8 +94,9 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @see #WorkBatch(int)
      * @see #add(short[])
      * @see #poll()
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) for poll operations, O(numClicks) for add operations due to array copying.
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for poll operations, <code>O({@link #numClicks})</code> for add
+     *              operations due to array copying.
      * @threading The buffers are not thread-safe, as they are intended to be used within a single
      *            thread context. Queues should be the only point of inter-thread communication.
      * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
@@ -119,8 +121,8 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @see #add(short[])
      * @see #isFull()
      * @see CombinationGeneratorTask#BATCH_SIZE
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) for capacity checks.
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for capacity checks.
      * @threading The capacity is immutable and does not impact thread safety.
      * @memory Fixed memory usage based on capacity and {@link #numClicks the number of clicks}.
      */
@@ -151,8 +153,8 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @see #buffer
      * @see #add(short[], int, short)
      * @see #setNumClicks(int)
-     * @since 2025.07.25 - NPE in WorkBatch Operations Fix
-     * @performance O(1) for access.
+     * @since 2025.07.25 - NPE in {@code WorkBatch} Operations Fix
+     * @performance {@code O(1)} for access.
      * @threading The variable is static and does not impact thread safety.
      * @memory Fixed memory usage based on the number of clicks and {@link #capacity}.
      */
@@ -162,32 +164,32 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * 
      * <p>
      * The head index tracks where the next combination will be polled from the batch. It is incremented
-     * on each poll operation and wraps around to the beginning of the {@link #buffer} when it reaches
-     * the end, implementing a circular buffer.
+     * on each {@code poll} operation and wraps around to the beginning of the {@link #buffer} when it
+     * reaches the end, implementing a circular buffer.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast add and poll operations. The head index is updated in
-     * constant time, ensuring that poll operations remain efficient even as the batch fills up and
-     * empties out.
+     * usage while still allowing for fast {@code add} and {@code poll} operations. The head index is
+     * updated in constant time, ensuring that {@code poll} operations remain efficient even as the
+     * batch fills up and empties out.
      * </p>
      * 
      * <p>
-     * We could use a short for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an int avoids potential overflow issues in long-running
-     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
-     * pointer for both head and {@link #tail}, but that would complicate the logic and force an extra arithmetic
-     * operation on each {@link #add(short[], int, short) add} and poll operation, which could impact
-     * performance.
+     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could also use a single pointer for both {@code head} and {@link #tail}, but that would
+     * complicate the logic and force an extra arithmetic operation on each
+     * {@link #add(short[], int, short) add} and {@code poll} operation, which could impact performance.
      * </p>
      * 
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) for poll operations.
-     * @threading The index is not thread-safe, as it is intended to be used within a single
-     *            thread context. Queues should be the only point of inter-thread communication.
-     * @memory Minimal additional memory overhead (single int).
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for {@code poll} operations.
+     * @threading The index is not thread-safe, as it is intended to be used within a single thread
+     *            context. Queues should be the only point of inter-thread communication.
+     * @memory Minimal additional memory overhead (single {@code int}).
      * @optimization Efficient circular buffer implementation for fast access.
      */
     private int head = 0;
@@ -196,76 +198,77 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * 
      * <p>
      * The tail index tracks where the next combination will be added to the batch. It is incremented on
-     * each add operation and wraps around to the beginning of the {@link #buffer} when it reaches the
-     * end, implementing a circular buffer.
+     * each {@code add} operation and wraps around to the beginning of the {@link #buffer} when it
+     * reaches the end, implementing a circular buffer.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * Using a circular buffer allows for efficient use of the pre-allocated array, minimizing memory
-     * usage while still allowing for fast add and poll operations. The tail index is updated in
-     * constant time, ensuring that add operations remain efficient even as the batch fills up and
-     * empties out.
+     * usage while still allowing for fast {@code add} and {@code poll} operations. The tail index is
+     * updated in constant time, ensuring that {@code add} operations remain efficient even as the batch
+     * fills up and empties out.
      * </p>
      * 
      * <p>
-     * We could use a short for the indices to save a few bytes of memory, but the performance
-     * difference is negligible and using an int avoids potential overflow issues in long-running
-     * applications (plus, Java treats arithmetic with short values weirdly). We could also use a single
-     * pointer for both {@link #head} and tail, but that would complicate the logic and force an extra
-     * arithmetic operation on each add and {@link #poll() poll} operation, which could impact
-     * performance.
+     * We could use a {@code short} for the indices to save a few bytes of memory, but the performance
+     * difference is negligible and using an {@code int} avoids potential overflow issues in
+     * long-running applications (plus, Java treats arithmetic with {@code short} values weirdly). We
+     * could also use a single pointer for both {@link #head} and {@code tail}, but that would
+     * complicate the logic and force an extra arithmetic operation on each {@code add} and
+     * {@link #poll() poll} operation, which could impact performance.
      * </p>
      * 
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) for add operations.
-     * @threading The index is not thread-safe, as it is intended to be used within a single
-     *       thread context. Queues should be the only point of inter-thread communication.
-     * @memory Minimal additional memory overhead (single int).
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for add operations.
+     * @threading The index is not thread-safe, as it is intended to be used within a single thread
+     *            context. Queues should be the only point of inter-thread communication.
+     * @memory Minimal additional memory overhead (single {@code int}).
      * @optimization Efficient circular buffer implementation for fast access.
      */
     private int tail = 0;
     /**
-     * An int to track the remaining capacity of the batch.
+     * An {@code int} to track the remaining capacity of the batch.
      * 
      * <p>
-     * The typical mechanism for tracking the number of elements in a circular buffer would be to use
-     * a size variable that increments on add operations and decrements on poll operations. However,
-     * size checks in those methods can lead to JVM deoptimizations due to the way the JIT compiler
-     * optimizes code paths and performs speculative optimizations. We need a more stable approach to
-     * tracking that avoids these pitfalls, can be branch predicted more easily, and doesn't require
-     * manual arithmetic computations. Tracking the remaining capacity provides this.
+     * The typical mechanism for tracking the number of elements in a circular buffer would be to use a
+     * {@code size} variable that increments on {@code add} operations and decrements on {@code poll}
+     * operations. However, {@code size} checks in those methods can lead to JVM deoptimizations due to
+     * the way the JIT compiler optimizes code paths and performs speculative optimizations. We need a
+     * more stable approach to tracking that avoids these pitfalls, can be branch predicted more easily,
+     * and doesn't require manual arithmetic computations. Tracking the remaining capacity provides
+     * this.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * By using remaining capacity, we can perform checks against a constant value (zero or full
      * capacity) rather than a variable size. This reduces the likelihood of deoptimizations and
-     * improves branch prediction, leading to more consistent performance in high-frequency
-     * scenarios. 
+     * improves branch prediction, leading to more consistent performance in high-frequency scenarios.
      * </p>
      * 
      * @see #capacity
      * @see #add(short[])
      * @see #poll()
      * @since 2025.07.28 - Remaining Capacity Tracking
-     * @performance O(1) for capacity checks, avoiding deoptimizations associated with size tracking.
-     * @threading The counter is not thread-safe, as it is intended to be used within a single
-     *            thread context. Queues should be the only point of inter-thread communication.
-     * @memory Minimal additional memory overhead (single int).
+     * @performance {@code O(1)} for capacity checks, avoiding deoptimizations associated with size
+     *              tracking.
+     * @threading The counter is not thread-safe, as it is intended to be used within a single thread
+     *            context. Queues should be the only point of inter-thread communication.
+     * @memory Minimal additional memory overhead (single {@code int}).
      * @optimization Stable and predictable capacity tracking to enhance performance.
      */
     private int remainingCapacity; // Replacement for size to avoid deoptimizations
 
     /**
-     * Creates a new WorkBatch with the specified capacity. The buffer is pre-allocated based on the
-     * {@link #numClicks number of clicks}, which must be {@link #setNumClicks(int) set} before creating
-     * any WorkBatch instances.
+     * Creates a new {@code WorkBatch} with the specified {@code capacity}. The buffer is pre-allocated
+     * based on the {@link #numClicks number of clicks}, which must be {@link #setNumClicks(int) set}
+     * before creating any {@code WorkBatch} instances.
      * 
      * @param capacity the maximum number of combinations the batch can hold.
      * @throws IllegalArgumentException if the capacity is not a positive integer.
      * @throws IllegalStateException    if {@link #numClicks} has not been set to a positive value.
-     * @since 2025.07.01 - WorkBatch Introduction
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
      * @threading Thread-safe by nature of construction, but the created instance is not.
      */
     public WorkBatch(int capacity) {
@@ -288,21 +291,21 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * {@link #WorkBatch(int) pre-allocated} in the constructor.
      * 
      * @param numClicks the number of clicks (elements) in each combination.
-     * @since 2025.07.27 - Pre-allocation of WorkBatch Buffers
-     * @performance O(1) for setting the value.
+     * @since 2025.07.27 - Pre-allocation of {@code WorkBatch} Buffers
+     * @performance {@code O(1)} for setting the value.
      * @threading This method is thread-safe since it modifies a static volatile variable. However, it
      *            should be called during application initialization before any WorkBatch instances are
      *            created to ensure consistency.
-     * @memory Minimal additional memory overhead (single int).
-     * @optimization Direct assignment to a static variable for efficient access.
+     * @memory Minimal additional memory overhead (single {@code int}).
+     * @optimization Direct assignment to a {@code static} variable for efficient access.
      */
     public static void setNumClicks(int numClicks) {
         WorkBatch.numClicks = numClicks;
     }
 
     /**
-     * Adds a combination to the batch. Returns <code>true</code> if the combination was added
-     * successfully or <code>false</code> if the batch is full.
+     * Adds a combination to the batch. Returns {@code true} if the combination was added successfully
+     * or {@code false} if the batch is full.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
@@ -311,23 +314,24 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * {@link System#arraycopy(Object, int, Object, int, int) copying} the input array into a
      * {@link #WorkBatch(int) pre-allocated} {@link #buffer}, we avoid the need for allocations and
      * reduce GC pressure. The pre-allocated nature of the buffer ensures that the destination array is
-     * never <code>null</code>, eliminating the need for null checks in the destination. Finally, we use a
-     * simple remaining capacity check instead of a size check to improve branch prediction and avoid
-     * deoptimizations that can occur with size tracking.
+     * never {@code null}, eliminating the need for {@code null} checks in the destination. Finally, we
+     * use a simple remaining capacity check instead of a {@code size} check to improve branch
+     * prediction and avoid deoptimizations that can occur with {@code size} tracking.
      * </p>
      * 
-     * @param source the <b>non-<code>null</code></b> combination array to add to the batch.
-     * @return <code>true</code> if the combination was added successfully, <code>false</code> if the
-     *         batch is full.
+     * @param source the <b>non-{@code null}</b> combination array to add to the batch.
+     * @return {@code true} if the combination was added successfully, {@code false} if the batch is
+     *         full.
      * @see #isFull()
      * @see #setNumClicks(int)
      * @see CombinationGeneratorTask
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) array access in {@link #buffer}, O({@link #numClicks}) for copying the array to the
-     *              destination.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @memory Does not allocate any new arrays, instead reusing the pre-allocated arrays in <code>buffer</code>.
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} array access in {@link #buffer}, <code>O({@link #numClicks})</code> for
+     *              copying the array to the destination.
+     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
+     *            intended to be used by one thread at a time.
+     * @memory Does not allocate any new arrays, instead reusing the pre-allocated arrays in
+     *         {@code buffer}.
      * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
      *               to minimize GC pressure and avoid temporary allocations.
      */
@@ -343,7 +347,8 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Adds a combination with a specified prefix and last element to the {@link #tail} of the batch.
+     * Adds a combination with a specified {@code prefix} and {@code lastElement} to the {@link #tail}
+     * of the batch.
      * 
      * <p>
      * With the help of previous optimizations in {@link #add(short[])}, {@link CombinationGeneratorTask
@@ -351,39 +356,39 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * have to acquire a single array from {@link ArrayPool the pool} for each step of the process.
      * However, the leaf nodes of the tree would still need to acquire an array to hold the final
      * combination form, which adds slight overhead in the form of an additional array copy and element
-     * modification (with a time complexity of O(n) where n is numClicks - 1). This method seeks to
-     * eliminate that overhead, allowing the caller to directly add a prefix and its final element to
-     * the batch without needing to create a new array for that purpose.
+     * modification (with a time complexity of <code>O({@link #numClicks} - 1)</code>). This method
+     * seeks to eliminate that overhead, allowing the caller to directly add a {@code prefix} and its
+     * final element to the batch without needing to create a new array for that purpose.
      * </p>
      * 
      * <h3>Performance Considerations</h3>
      * <p>
      * This method is designed to be extremely efficient and allocation-free, allowing it to be called
-     * billions of times without introducing significant overhead. Similar to the previous
-     * <code>add</code> method, it copies the prefix into a pre-allocated buffer, avoiding the need for
-     * allocations and reducing GC pressure. The pre-allocated nature of the buffer ensures that the
-     * destination array is never <code>null</code>, eliminating the need for null checks in the
-     * destination. We assume that the caller has ensured that the <code>prefix</code> array is non-null
-     * and is of a valid length (i.e., <code>prefixLength</code> is within bounds) for similar reasons.
-     * Finally, we use a simple remaining capacity check instead of a size check to improve branch
-     * prediction and avoid deoptimizations that can occur with size tracking.
+     * billions of times without introducing significant overhead. Similar to the previous {@code add}
+     * method, it copies {@code prefix} into a pre-allocated buffer, avoiding the need for allocations
+     * and reducing GC pressure. The pre-allocated nature of the buffer ensures that the destination
+     * array is never {@code null}, eliminating the need for {@code null} checks in the destination. We
+     * assume that the caller has ensured that the {@code prefix} array is non-{@code null} and is of a
+     * valid length (i.e., {@code prefixLength} is within bounds) for similar reasons. Finally, we use a
+     * simple remaining capacity check instead of a {@code size} check to improve branch prediction and
+     * avoid deoptimizations that can occur with {@code size} tracking.
      * </p>
      * 
-     * @param prefix       the <b>non-<code>null</code></b> prefix array to copy from.
-     * @param prefixLength the length of the prefix to copy from the <code>prefix</code> array, assumed
-     *                     to be less than {@link #numClicks}.
+     * @param prefix       the <b>non-{@code null}</b> prefix array to copy from.
+     * @param prefixLength the length of the prefix to copy from the {@code prefix} array, assumed to be
+     *                     less than {@link #numClicks}.
      * @param lastElement  the last element to append to the combination.
-     * @return <code>true</code> if the combination was added successfully, <code>false</code> if the
-     *         batch is full.
+     * @return {@code true} if the combination was added successfully, {@code false} if the batch is
+     *         full.
      * @see #isFull()
      * @see #setNumClicks(int)
      * @see CombinationGeneratorTask
      * @see CombinationGeneratorTask#computeLeafCombinations(CombinationGeneratorTask.GeneratorContext)
-     * @since 2025.07.19 - Assembling Combinations in the WorkBatch
-     * @performance O(1) array access in {@link #buffer}, O(<code>prefixLength</code>) for copying the
-     *              array to the destination.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
+     * @since 2025.07.19 - Assembling Combinations in the {@code WorkBatch}
+     * @performance {@code O(1)} array access in {@link #buffer}, {@code O(prefixLength)} for copying
+     *              the array to the destination.
+     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
+     *            intended to be used by one thread at a time.
      * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
      *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
      *         pre-allocated arrays in {@link #buffer}.
@@ -408,8 +413,8 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Returns the next combination from the batch, or <code>null</code> if the batch is empty. This
-     * method does not null out the polled array, allowing it to be reused by subsequent add operations.
+     * Returns the next combination from the batch, or {@code null} if the batch is empty. This method
+     * does not null out the polled array, allowing it to be reused by subsequent add operations.
      * 
      * <h3>Performance Considerations</h3>
      * <p>
@@ -417,19 +422,20 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * millions of times per second without introducing significant overhead. By simply incrementing the
      * values of {@link #head} and {@link #remainingCapacity}, we avoid the need for
      * {@link CombinationGeneratorTask generators} to create new arrays for each combination, bringing
-     * down the GC pressure during runtime. We use a simple <code>remainingCapacity</code> check instead
-     * of a size check to improve branch prediction and avoid deoptimizations that can occur with size
-     * tracking. Finally, we avoid null checks on the polled array, as it is guaranteed to be non-null
-     * if the batch is not empty (if <code>remainingCapacity</code> is not equal to {@link #capacity}).
+     * down the GC pressure during runtime. We use a simple {@code remainingCapacity} check instead of a
+     * {@code size} check to improve branch prediction and avoid deoptimizations that can occur with
+     * size tracking. Finally, we avoid null checks on the polled array, as it is guaranteed to be
+     * non-null if the batch is not empty (if {@code remainingCapacity} is not equal to
+     * {@link #capacity}).
      * </p>
      * 
-     * @return the next combination from the batch, or <code>null</code> if the batch is empty.
+     * @return the next combination from the batch, or {@code null} if the batch is empty.
      * @see #buffer
      * @see #add(short[], int, short)
      * @see #clear()
      * @see #isEmpty()
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) for polling operations.
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for polling operations.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
      *            used by one thread at a time.
      * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
@@ -452,16 +458,16 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     /**
      * Checks if the batch is empty.
      * 
-     * @return <code>true</code> if the batch is empty, <code>false</code> otherwise.
+     * @return {@code true} if the batch is empty, {@code false} otherwise.
      * @see #capacity
      * @see #remainingCapacity
      * @see #isFull()
      * @see #size()
      * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) retrievals and comparison.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @memory Minimal additional memory overhead (single int comparison).
+     * @performance {@code O(1)} retrievals and comparison.
+     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
+     *            intended to be used by one thread at a time.
+     * @memory Minimal additional memory overhead (single {@code int} comparison).
      * @optimization Efficient state check to quickly determine if the batch is empty, using
      *               {@link #remainingCapacity} for improved branch prediction.
      */
@@ -471,16 +477,17 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
 
     /**
      * Returns the current number of combinations in the batch. This is calculated based on the
-     * {@link #capacity} and {@link #remainingCapacity}, avoiding the need for a separate size
-     * variable that could lead to deoptimizations.
+     * {@link #capacity} and {@link #remainingCapacity}, avoiding the need for a separate size variable
+     * that could lead to deoptimizations.
+     * 
      * @return the current number of combinations in the batch.
      * @see #isEmpty()
      * @see #isFull()
      * @since 2025.07.28 - Remaining Capacity Tracking
-     * @performance O(1) for size calculations.
+     * @performance {@code O(1)} for size calculations.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
      *            used by one thread at a time.
-     * @memory Minimal additional memory overhead (single int calculation).
+     * @memory Minimal additional memory overhead (single {@code int} calculation).
      * @optimization Efficient size calculation using existing state variables to avoid deoptimizations.
      */
     public int size() {
@@ -495,19 +502,20 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * <p>
      * This method is designed to be constant time and allocation-free, allowing it to be called
      * millions of times per second without introducing significant overhead. By simply resetting the
-     * values of {@link #head}, {@link #tail}, and {@link #remainingCapacity}, we avoid the need for
-     * any array manipulations or allocations, making it extremely efficient. This also allows future
-     * add operations to reuse the existing arrays in the {@link #buffer}, further reducing GC
-     * pressure during runtime.
+     * values of {@link #head}, {@link #tail}, and {@link #remainingCapacity}, we avoid the need for any
+     * array manipulations or allocations, making it extremely efficient. This also allows future add
+     * operations to reuse the existing arrays in the {@link #buffer}, further reducing GC pressure
+     * during runtime.
      * </p>
      * 
      * @see #WorkBatch(int)
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) for clear operations.
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} for clear operations.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
      *            used by one thread at a time.
      * @memory Does not deallocate or allocate any arrays, simply resets internal pointers.
-     * @optimization Efficient state reset to enable rapid reuse of the batch without additional overhead.
+     * @optimization Efficient state reset to enable rapid reuse of the batch without additional
+     *               overhead.
      */
     public void clear() {
         head = 0;
@@ -521,23 +529,23 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * 
      * <p>
      * This method simply delegates to {@link #add(short[])} to add the combination to the batch. When
-     * {@link TestClickCombination monkeys} drained combinations from queues into
-     * <code>WorkBatch</code>es, they used this method as the consumer function.
+     * {@link TestClickCombination monkeys} drained combinations from queues into {@code WorkBatch}es,
+     * they used this method as the consumer function.
      * </p>
      * 
      * <p>
-     * Now that we directly enqueue <code>WorkBatch</code>es instead of individual combinations, this
-     * method is no longer used by the monkeys. We could remove the <code>Consumer</code> interface from
-     * this class, though we've left it here, mainly from forgetting to remove it.
+     * Now that we directly enqueue {@code WorkBatch}es instead of individual combinations, this method
+     * is no longer used by the monkeys. We could remove the {@code Consumer} interface from this class,
+     * though we've left it here, mainly from forgetting to remove it.
      * </p>
      * 
-     * @param combination the <code>short[]</code> to add to the batch.
+     * @param combination the {@code short[]} to add to the batch.
      * @see org.jctools.queues.MessagePassingQueue
      * @see org.jctools.queues.MessagePassingQueue.Consumer#accept(Object)
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @performance O(1) call to {@link #add(short[])}.
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
+     * @since 2025.07.01 - {@code WorkBatch} Introduction
+     * @performance {@code O(1)} call to {@link #add(short[])}.
+     * @threading This method is <b>not</b> thread-safe, as each instance of {@code WorkBatch} is
+     *            intended to be used by one thread at a time.
      */
     @Override
     public void accept(short[] combination) {
@@ -551,21 +559,22 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * 
      * <p>
      * This method simply delegates to {@link #poll()} to retrieve the next combination from the batch.
-     * When {@link CombinationGeneratorTask generators} filled queues from <code>WorkBatch</code>es, they
+     * When {@link CombinationGeneratorTask generators} filled queues from {@code WorkBatch}es, they
      * used this method as the supplier function.
      * </p>
      * 
      * <p>
-     * Now that we directly enqueue <code>WorkBatch</code>es instead of individual combinations, this
-     * method is no longer used by the generators. We could remove the <code>Supplier</code> interface from
-     * this class, though we've left it here, mainly from forgetting to remove it.
+     * Now that we directly enqueue {@code WorkBatch}es instead of individual combinations, this method
+     * is no longer used by the generators. We could remove the {@code Supplier} interface from this
+     * class, though we've left it here, mainly from forgetting to remove it.
      * </p>
      * 
-     * @return the next <code>short[]</code> (combination) from the batch, or <code>null</code> if the batch is empty.
+     * @return the next {@code short[]} (combination) from the batch, or {@code null} if the batch is
+     *         empty.
      * @see org.jctools.queues.MessagePassingQueue
      * @see org.jctools.queues.MessagePassingQueue.Supplier#get()
-     * @since 2025.07.01 - WorkBatch Integration in Generators
-     * @performance O(1) call to {@link #poll()}.
+     * @since 2025.07.01 - {@code WorkBatch} Integration in Generators
+     * @performance {@code O(1)} call to {@link #poll()}.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
      *            used by one thread at a time.
      */
@@ -576,17 +585,18 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Checks if the batch is full. This is determined by checking if the {@link #remainingCapacity}
-     * is zero.
-     * @return <code>true</code> if the batch is full, <code>false</code> otherwise.
+     * Checks if the batch is full. This is determined by checking if the {@link #remainingCapacity} is
+     * zero.
+     * 
+     * @return {@code true} if the batch is full, {@code false} otherwise.
      * @see #capacity
      * @see #isEmpty()
      * @see #size()
      * @since 2025.07.28 - Remaining Capacity Tracking
-     * @performance O(1) retrievals and comparison.
+     * @performance {@code O(1)} retrievals and comparison.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *       used by one thread at a time.
-     * @memory Minimal additional memory overhead (single int comparison).
+     *            used by one thread at a time.
+     * @memory Minimal additional memory overhead (single {@code int} comparison).
      * @optimization Efficient state check to quickly determine if the batch is full, using
      *               {@link #remainingCapacity} for improved branch prediction.
      */

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -90,16 +90,16 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * the number of allocations and GC pressure.
      * </p>
      * 
+     * @see #WorkBatch(int)
+     * @see #add(short[])
+     * @see #poll()
      * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) for poll operations, O(numClicks) for add operations due to array copying.
      * @threading The buffers are not thread-safe, as they are intended to be used within a single
      *            thread context. Queues should be the only point of inter-thread communication.
-     * @performance O(1) for poll operations, O(numClicks) for add operations due to array copying.
      * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
      *         dynamic allocations.
      * @optimization Pre-allocation and reuse of arrays to minimize GC pressure.
-     * @see #add(short[])
-     * @see #poll()
-     * @see #WorkBatch(int)
      */
     private final short[][] buffer;
     /**
@@ -114,15 +114,15 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * requirements.
      * </p>
      * 
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @threading The capacity is immutable and does not impact thread safety.
-     * @performance O(1) for capacity checks.
-     * @memory Fixed memory usage based on capacity and {@link #numClicks the number of clicks}.
      * @see #buffer
+     * @see #WorkBatch(int)
      * @see #add(short[])
      * @see #isFull()
-     * @see #WorkBatch(int)
      * @see CombinationGeneratorTask#BATCH_SIZE
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) for capacity checks.
+     * @threading The capacity is immutable and does not impact thread safety.
+     * @memory Fixed memory usage based on capacity and {@link #numClicks the number of clicks}.
      */
     private final int capacity;
     /**
@@ -148,13 +148,13 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * key to maintaining the integrity of the combinations and the performance of the batch operations.
      * </p>
      * 
-     * @since 2025.07.25 - NPE in WorkBatch Operations Fix
-     * @threading The variable is static and does not impact thread safety.
-     * @performance O(1) for access.
-     * @memory Fixed memory usage based on the number of clicks and {@link #capacity}.
      * @see #buffer
      * @see #add(short[], int, short)
      * @see #setNumClicks(int)
+     * @since 2025.07.25 - NPE in WorkBatch Operations Fix
+     * @performance O(1) for access.
+     * @threading The variable is static and does not impact thread safety.
+     * @memory Fixed memory usage based on the number of clicks and {@link #capacity}.
      */
     private static int numClicks;
     /**
@@ -184,11 +184,11 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * </p>
      * 
      * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) for poll operations.
      * @threading The index is not thread-safe, as it is intended to be used within a single
      *            thread context. Queues should be the only point of inter-thread communication.
-     * @performance O(1) for poll operations.
-     * @optimization Efficient circular buffer implementation for fast access.
      * @memory Minimal additional memory overhead (single int).
+     * @optimization Efficient circular buffer implementation for fast access.
      */
     private int head = 0;
     /**
@@ -218,11 +218,11 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * </p>
      * 
      * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) for add operations.
      * @threading The index is not thread-safe, as it is intended to be used within a single
      *       thread context. Queues should be the only point of inter-thread communication.
-     * @performance O(1) for add operations.
-     * @optimization Efficient circular buffer implementation for fast access.
      * @memory Minimal additional memory overhead (single int).
+     * @optimization Efficient circular buffer implementation for fast access.
      */
     private int tail = 0;
     /**
@@ -245,15 +245,15 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * scenarios. 
      * </p>
      * 
-     * @since 2025.07.28 - Remaining Capacity Tracking
-     * @threading The counter is not thread-safe, as it is intended to be used within a single
-     *            thread context. Queues should be the only point of inter-thread communication.
-     * @performance O(1) for capacity checks, avoiding deoptimizations associated with size tracking.
-     * @memory Minimal additional memory overhead (single int).
-     * @optimization Stable and predictable capacity tracking to enhance performance.
      * @see #capacity
      * @see #add(short[])
      * @see #poll()
+     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @performance O(1) for capacity checks, avoiding deoptimizations associated with size tracking.
+     * @threading The counter is not thread-safe, as it is intended to be used within a single
+     *            thread context. Queues should be the only point of inter-thread communication.
+     * @memory Minimal additional memory overhead (single int).
+     * @optimization Stable and predictable capacity tracking to enhance performance.
      */
     private int remainingCapacity; // Replacement for size to avoid deoptimizations
 
@@ -289,10 +289,10 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * 
      * @param numClicks the number of clicks (elements) in each combination.
      * @since 2025.07.27 - Pre-allocation of WorkBatch Buffers
+     * @performance O(1) for setting the value.
      * @threading This method is thread-safe since it modifies a static volatile variable. However, it
      *            should be called during application initialization before any WorkBatch instances are
      *            created to ensure consistency.
-     * @performance O(1) for setting the value.
      * @memory Minimal additional memory overhead (single int).
      * @optimization Direct assignment to a static variable for efficient access.
      */
@@ -319,17 +319,17 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @param source the <b>non-<code>null</code></b> combination array to add to the batch.
      * @return <code>true</code> if the combination was added successfully, <code>false</code> if the
      *         batch is full.
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @performance O(1) array access in {@link #buffer}, O({@link #numClicks}) for copying the array to the
-     *              destination.
-     * @memory Does not allocate any new arrays, instead reusing the pre-allocated arrays in <code>buffer</code>.
-     * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
-     *               to minimize GC pressure and avoid temporary allocations.
      * @see #isFull()
      * @see #setNumClicks(int)
      * @see CombinationGeneratorTask
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) array access in {@link #buffer}, O({@link #numClicks}) for copying the array to the
+     *              destination.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @memory Does not allocate any new arrays, instead reusing the pre-allocated arrays in <code>buffer</code>.
+     * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
+     *               to minimize GC pressure and avoid temporary allocations.
      */
     public boolean add(short[] source) {
         if (remainingCapacity == 0) // Check remaining capacity instead of size to avoid deoptimizations
@@ -375,20 +375,20 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * @param lastElement  the last element to append to the combination.
      * @return <code>true</code> if the combination was added successfully, <code>false</code> if the
      *         batch is full.
+     * @see #isFull()
+     * @see #setNumClicks(int)
+     * @see CombinationGeneratorTask
+     * @see CombinationGeneratorTask#computeLeafCombinations(CombinationGeneratorTask.GeneratorContext)
      * @since 2025.07.19 - Assembling Combinations in the WorkBatch
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
      * @performance O(1) array access in {@link #buffer}, O(<code>prefixLength</code>) for copying the
      *              array to the destination.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
      * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
      *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
      *         pre-allocated arrays in {@link #buffer}.
      * @optimization Pre-allocated array {@link System#arraycopy(Object, int, Object, int, int) copying}
      *               and assembly to minimize GC pressure and avoid temporary allocations.
-     * @see #isFull()
-     * @see #setNumClicks(int)
-     * @see CombinationGeneratorTask
-     * @see CombinationGeneratorTask#computeLeafCombinations(CombinationGeneratorTask.GeneratorContext)
      */
     public final boolean add(short[] prefix, int prefixLength, short lastElement) {
         if (remainingCapacity == 0) // Check remaining capacity instead of size to avoid deoptimizations
@@ -424,18 +424,18 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * </p>
      * 
      * @return the next combination from the batch, or <code>null</code> if the batch is empty.
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @performance O(1) for polling operations.
-     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
-     *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
-     *         pre-allocated arrays in {@link #buffer}.
-     * @optimization Pre-allocated array reuse to minimize GC pressure and avoid temporary allocations.
      * @see #buffer
      * @see #add(short[], int, short)
      * @see #clear()
      * @see #isEmpty()
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) for polling operations.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @memory The memory footprint is fixed based on the capacity and {@link #numClicks}, minimizing
+     *         dynamic allocations. The method does not allocate any new arrays, instead reusing the
+     *         pre-allocated arrays in {@link #buffer}.
+     * @optimization Pre-allocated array reuse to minimize GC pressure and avoid temporary allocations.
      */
     public short[] poll() {
         if (remainingCapacity == capacity) // Check remaining capacity instead of size to avoid deoptimizations
@@ -453,17 +453,17 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * Checks if the batch is empty.
      * 
      * @return <code>true</code> if the batch is empty, <code>false</code> otherwise.
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @performance O(1) retrievals and comparison.
-     * @memory Minimal additional memory overhead (single int comparison).
-     * @optimization Efficient state check to quickly determine if the batch is empty, using
-     *               {@link #remainingCapacity} for improved branch prediction.
      * @see #capacity
      * @see #remainingCapacity
      * @see #isFull()
      * @see #size()
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) retrievals and comparison.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @memory Minimal additional memory overhead (single int comparison).
+     * @optimization Efficient state check to quickly determine if the batch is empty, using
+     *               {@link #remainingCapacity} for improved branch prediction.
      */
     public boolean isEmpty() {
         return remainingCapacity == capacity;
@@ -474,14 +474,14 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * {@link #capacity} and {@link #remainingCapacity}, avoiding the need for a separate size
      * variable that could lead to deoptimizations.
      * @return the current number of combinations in the batch.
-     * @since 2025.07.28 - Remaining Capacity Tracking
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @performance O(1) for size calculations.
-     * @memory Minimal additional memory overhead (single int calculation).
-     * @optimization Efficient size calculation using existing state variables to avoid deoptimizations.
      * @see #isEmpty()
      * @see #isFull()
+     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @performance O(1) for size calculations.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @memory Minimal additional memory overhead (single int calculation).
+     * @optimization Efficient size calculation using existing state variables to avoid deoptimizations.
      */
     public int size() {
         return capacity - remainingCapacity; // Calculate size based on remaining capacity
@@ -501,13 +501,13 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * pressure during runtime.
      * </p>
      * 
+     * @see #WorkBatch(int)
      * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) for clear operations.
      * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
      *            used by one thread at a time.
-     * @performance O(1) for clear operations.
      * @memory Does not deallocate or allocate any arrays, simply resets internal pointers.
      * @optimization Efficient state reset to enable rapid reuse of the batch without additional overhead.
-     * @see #WorkBatch(int)
      */
     public void clear() {
         head = 0;
@@ -532,12 +532,12 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * </p>
      * 
      * @param combination the <code>short[]</code> to add to the batch.
-     * @since 2025.07.01 - WorkBatch Introduction
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @performance O(1) call to {@link #add(short[])}.
      * @see org.jctools.queues.MessagePassingQueue
      * @see org.jctools.queues.MessagePassingQueue.Consumer#accept(Object)
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @performance O(1) call to {@link #add(short[])}.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
      */
     @Override
     public void accept(short[] combination) {
@@ -562,12 +562,12 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * </p>
      * 
      * @return the next <code>short[]</code> (combination) from the batch, or <code>null</code> if the batch is empty.
-     * @since 2025.07.01 - WorkBatch Integration in Generators
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *            used by one thread at a time.
-     * @performance O(1) call to {@link #poll()}.
      * @see org.jctools.queues.MessagePassingQueue
      * @see org.jctools.queues.MessagePassingQueue.Supplier#get()
+     * @since 2025.07.01 - WorkBatch Integration in Generators
+     * @performance O(1) call to {@link #poll()}.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
      */
     @Override
     public short[] get() {
@@ -579,16 +579,16 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      * Checks if the batch is full. This is determined by checking if the {@link #remainingCapacity}
      * is zero.
      * @return <code>true</code> if the batch is full, <code>false</code> otherwise.
-     * @since 2025.07.28 - Remaining Capacity Tracking
-     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
-     *       used by one thread at a time.
-     * @performance O(1) retrievals and comparison.
-     * @memory Minimal additional memory overhead (single int comparison).
-     * @optimization Efficient state check to quickly determine if the batch is full, using
-     *               {@link #remainingCapacity} for improved branch prediction.
      * @see #capacity
      * @see #isEmpty()
      * @see #size()
+     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @performance O(1) retrievals and comparison.
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *       used by one thread at a time.
+     * @memory Minimal additional memory overhead (single int comparison).
+     * @optimization Efficient state check to quickly determine if the batch is full, using
+     *               {@link #remainingCapacity} for improved branch prediction.
      */
     public boolean isFull() {
         return remainingCapacity == 0;

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -58,8 +58,6 @@ import org.jctools.queues.MessagePassingQueue;
  * for the specific use case and performance requirements.
  * </p>
  * 
- * <h3>16/18 - ~88.9% of documentation completed</h3>
- * 
  * @since 2025.07.01 - WorkBatch Introduction
  * @performance O(1) for poll operations and simple state checks, O(numClicks) for add operations
  *              due to array copying.
@@ -518,20 +516,62 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * MessagePassingQueue.Consumer implementation for JCTools integration.
+     * {@link org.jctools.queues.MessagePassingQueue.Consumer MessagePassingQueue.Consumer}
+     * implementation for JCTools integration.
+     * 
+     * <p>
+     * This method simply delegates to {@link #add(short[])} to add the combination to the batch. When
+     * {@link TestClickCombination monkeys} drained combinations from queues into
+     * <code>WorkBatch</code>es, they used this method as the consumer function.
+     * </p>
+     * 
+     * <p>
+     * Now that we directly enqueue <code>WorkBatch</code>es instead of individual combinations, this
+     * method is no longer used by the monkeys. We could remove the <code>Consumer</code> interface from
+     * this class, though we've left it here, mainly from forgetting to remove it.
+     * </p>
+     * 
+     * @param combination the <code>short[]</code> to add to the batch.
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) call to {@link #add(short[])}.
+     * @see org.jctools.queues.MessagePassingQueue
+     * @see org.jctools.queues.MessagePassingQueue.Consumer#accept(Object)
      */
     @Override
-    public void accept(short[] combination)
-    {
+    public void accept(short[] combination) {
+        // TODO: Remove Consumer interface and this method from the class, since it is no longer used.
         add(combination);
     }
 
     /**
-     * MessagePassingQueue.Supplier implementation for JCTools integration.
+     * {@link org.jctools.queues.MessagePassingQueue.Supplier MessagePassingQueue.Supplier}
+     * implementation for JCTools integration.
+     * 
+     * <p>
+     * This method simply delegates to {@link #poll()} to retrieve the next combination from the batch.
+     * When {@link CombinationGeneratorTask generators} filled queues from <code>WorkBatch</code>es, they
+     * used this method as the supplier function.
+     * </p>
+     * 
+     * <p>
+     * Now that we directly enqueue <code>WorkBatch</code>es instead of individual combinations, this
+     * method is no longer used by the generators. We could remove the <code>Supplier</code> interface from
+     * this class, though we've left it here, mainly from forgetting to remove it.
+     * </p>
+     * 
+     * @return the next <code>short[]</code> (combination) from the batch, or <code>null</code> if the batch is empty.
+     * @since 2025.07.01 - WorkBatch Integration in Generators
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) call to {@link #poll()}.
+     * @see org.jctools.queues.MessagePassingQueue
+     * @see org.jctools.queues.MessagePassingQueue.Supplier#get()
      */
     @Override
-    public short[] get()
-    {
+    public short[] get() {
+        // TODO: Remove Supplier interface and this method from the class, since it is no longer used.
         return poll();
     }
 

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -58,7 +58,7 @@ import org.jctools.queues.MessagePassingQueue;
  * for the specific use case and performance requirements.
  * </p>
  * 
- * <h3>11/18 - ~61.1% of documentation completed</h3>
+ * <h3>16/18 - ~88.9% of documentation completed</h3>
  * 
  * @since 2025.07.01 - WorkBatch Introduction
  * @performance O(1) for poll operations and simple state checks, O(numClicks) for add operations
@@ -259,15 +259,46 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
      */
     private int remainingCapacity; // Replacement for size to avoid deoptimizations
 
-    public WorkBatch(int capacity)
-    {
+    /**
+     * Creates a new WorkBatch with the specified capacity. The buffer is pre-allocated based on the
+     * {@link #numClicks number of clicks}, which must be {@link #setNumClicks(int) set} before creating
+     * any WorkBatch instances.
+     * 
+     * @param capacity the maximum number of combinations the batch can hold.
+     * @throws IllegalArgumentException if the capacity is not a positive integer.
+     * @throws IllegalStateException    if {@link #numClicks} has not been set to a positive value.
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading Thread-safe by nature of construction, but the created instance is not.
+     */
+    public WorkBatch(int capacity) {
+        if (numClicks <= 0) {
+            throw new IllegalStateException("numClicks must be set to a positive value before creating WorkBatch instances.");
+        }
+
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Capacity must be a positive integer.");
+        }
+
         this.capacity = capacity;
         this.remainingCapacity = capacity;
         this.buffer = new short[capacity][numClicks];
     }
 
-    public static void setNumClicks(int numClicks)
-    {
+    /**
+     * Sets the {@link #numClicks number of clicks} (elements) in each combination. This must be set
+     * before creating any WorkBatch instances, as it determines the size of the {@link #buffer buffer}
+     * {@link #WorkBatch(int) pre-allocated} in the constructor.
+     * 
+     * @param numClicks the number of clicks (elements) in each combination.
+     * @since 2025.07.27 - Pre-allocation of WorkBatch Buffers
+     * @threading This method is thread-safe since it modifies a static volatile variable. However, it
+     *            should be called during application initialization before any WorkBatch instances are
+     *            created to ensure consistency.
+     * @performance O(1) for setting the value.
+     * @memory Minimal additional memory overhead (single int).
+     * @optimization Direct assignment to a static variable for efficient access.
+     */
+    public static void setNumClicks(int numClicks) {
         WorkBatch.numClicks = numClicks;
     }
 
@@ -421,18 +452,40 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Check if batch is empty.
+     * Checks if the batch is empty.
+     * 
+     * @return <code>true</code> if the batch is empty, <code>false</code> otherwise.
+     * @since 2025.07.01 - WorkBatch Introduction
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) retrievals and comparison.
+     * @memory Minimal additional memory overhead (single int comparison).
+     * @optimization Efficient state check to quickly determine if the batch is empty, using
+     *               {@link #remainingCapacity} for improved branch prediction.
+     * @see #capacity
+     * @see #remainingCapacity
+     * @see #isFull()
+     * @see #size()
      */
-    public boolean isEmpty()
-    {
+    public boolean isEmpty() {
         return remainingCapacity == capacity;
     }
 
     /**
-     * Get current batch size.
+     * Returns the current number of combinations in the batch. This is calculated based on the
+     * {@link #capacity} and {@link #remainingCapacity}, avoiding the need for a separate size
+     * variable that could lead to deoptimizations.
+     * @return the current number of combinations in the batch.
+     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *            used by one thread at a time.
+     * @performance O(1) for size calculations.
+     * @memory Minimal additional memory overhead (single int calculation).
+     * @optimization Efficient size calculation using existing state variables to avoid deoptimizations.
+     * @see #isEmpty()
+     * @see #isFull()
      */
-    public int size()
-    {
+    public int size() {
         return capacity - remainingCapacity; // Calculate size based on remaining capacity
     }
 
@@ -483,10 +536,21 @@ public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, M
     }
 
     /**
-     * Check if batch is full.
+     * Checks if the batch is full. This is determined by checking if the {@link #remainingCapacity}
+     * is zero.
+     * @return <code>true</code> if the batch is full, <code>false</code> otherwise.
+     * @since 2025.07.28 - Remaining Capacity Tracking
+     * @threading This method is <b>not</b> thread-safe, as each instance of WorkBatch is intended to be
+     *       used by one thread at a time.
+     * @performance O(1) retrievals and comparison.
+     * @memory Minimal additional memory overhead (single int comparison).
+     * @optimization Efficient state check to quickly determine if the batch is full, using
+     *               {@link #remainingCapacity} for improved branch prediction.
+     * @see #capacity
+     * @see #isEmpty()
+     * @see #size()
      */
-    public boolean isFull()
-    {
+    public boolean isFull() {
         return remainingCapacity == 0;
     }
 }

--- a/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
+++ b/src/main/java/com/github/mrgarbagegamer/WorkBatch.java
@@ -3,9 +3,27 @@ package com.github.mrgarbagegamer;
 import org.jctools.queues.MessagePassingQueue;
 
 /**
- * High-performance circular buffer for worker thread batching.
- * Eliminates ArrayDeque overhead while maintaining the same semantics.
- * This object is now pooled and recycled, with the assumption that only one thread will have access to the object at a time.
+ * WorkBatch - [Performance Purpose - e.g., "High-performance memory pool"]
+ * 
+ * <p>[Detailed description of the performance problem this class solves.
+ * Include before/after metrics where applicable.]</p>
+ * 
+ * <h2>Optimization Strategy</h2>
+ * <p>[Specific optimization techniques used - pooling, caching, lock-free, etc.
+ * Explain trade-offs made for performance gains.]</p>
+ * 
+ * <h2>Usage Patterns</h2>
+ * <p>[How and when to use this utility. Common usage patterns and anti-patterns.]</p>
+ * 
+ * <h2>Memory Management</h2>
+ * <p>[Memory allocation patterns, GC implications, sizing considerations.]</p>
+ * 
+ * <h3>0/18 - 0% of documentation completed</h3>
+ * 
+ * @performance [Specific performance characteristics and measurements]
+ * @memory [Memory usage patterns and optimizations]
+ * @threading [Thread safety model]
+ * @since [When introduced and why]
  */
 public final class WorkBatch implements MessagePassingQueue.Consumer<short[]>, MessagePassingQueue.Supplier<short[]>
 {

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -2,7 +2,7 @@
  * This package contains the main classes and interfaces for the high performance hexagonal Lights
  * Out brute force solver.
  * 
- * <h3>181/194 - ~93.3% of documentation completed (including this package documentation and the
+ * <h3>182/194 - ~93.8% of documentation completed (including this package documentation and the
  * enums for Grid's ValueFormat)</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -1,5 +1,51 @@
 /**
- * This package contains the main classes and interfaces for the high performance hexagonal Lights
- * Out brute force solver.
+ * Provides a high-performance, brute-force solver for a hexagonal Lights Out-style puzzle.
+ *
+ * <h2>Package Architecture</h2>
+ * <p>
+ * This package implements a highly optimized producer-consumer architecture designed for solving a
+ * complex combinatorial problem. The core components work together to generate, distribute, and
+ * validate potential solutions with maximum efficiency.
+ * </p>
+ *
+ * <p>
+ * The primary components are:
+ * </p>
+ * <ul>
+ * <li><b>Generator ({@link com.github.mrgarbagegamer.CombinationGeneratorTask})</b>: A recursive
+ * {@link java.util.concurrent.ForkJoinTask} that explores the solution space. It generates
+ * permutations of clicks and bundles them into batches for consumers.</li>
+ *
+ * <li><b>Monkey ({@link com.github.mrgarbagegamer.TestClickCombination})</b>: A worker thread (or
+ * "monkey") that receives batches of combinations, applies them to a grid instance, and validates
+ * the outcome.</li>
+ *
+ * <li><b>Orchestrator ({@link com.github.mrgarbagegamer.StartYourMonkeys})</b>: The main entry
+ * point that initializes and manages the entire system, including the
+ * {@link java.util.concurrent.ForkJoinPool} for producers and the queue array for consumers.</li>
+ * </ul>
+ *
+ * <h2>High-Performance Concurrency and Data Structures</h2>
+ * <p>
+ * The solver's performance relies on several key design patterns:
+ * </p>
+ * <ul>
+ * <li><b>Batching System</b>: The {@link com.github.mrgarbagegamer.WorkBatch} class is central to
+ * performance. By bundling thousands of combinations into a single batch, it dramatically reduces
+ * queue contention and synchronization overhead between producers and consumers.</li>
+ *
+ * <li><b>Centralized Queue</b>: The {@link com.github.mrgarbagegamer.CombinationQueueArray} acts as
+ * a high-performance, multi-lane queue that distributes {@code WorkBatch} objects to available
+ * consumer threads.</li>
+ *
+ * <li><b>Bitmask Grid</b>: The puzzle state is managed by the
+ * {@link com.github.mrgarbagegamer.Grid} class, which uses a {@code long[2]} bitmask for
+ * ultra-fast, {@code O(1)} click operations and state validation.</li>
+ *
+ * <li><b>Aggressive Pooling</b>: To minimize GC overhead, the system uses extensive object pooling,
+ * including an {@link com.github.mrgarbagegamer.ArrayPool} for combination arrays, a
+ * {@link com.github.mrgarbagegamer.TaskPool} for generator tasks, and centralized recycling of
+ * {@code WorkBatch} objects.</li>
+ * </ul>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -2,6 +2,6 @@
  * This package contains the main classes and interfaces for the high performance
  * hexagonal Lights Out brute force solver.
  * 
- * <h3>35/197 - ~17.8% of documentation completed</h3>
+ * <h3>45/197 - ~22.8% of documentation completed</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -2,7 +2,7 @@
  * This package contains the main classes and interfaces for the high performance hexagonal Lights
  * Out brute force solver.
  * 
- * <h3>141/194 - ~72.7% of documentation completed (including this package documentation and the
+ * <h3>144/194 - ~74.2% of documentation completed (including this package documentation and the
  * enums for Grid's ValueFormat)</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -2,6 +2,6 @@
  * This package contains the main classes and interfaces for the high performance
  * hexagonal Lights Out brute force solver.
  * 
- * <h3>25/197 - ~12.7% of documentation completed</h3>
+ * <h3>35/197 - ~17.8% of documentation completed</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -1,7 +1,8 @@
 /**
- * This package contains the main classes and interfaces for the high performance
- * hexagonal Lights Out brute force solver.
+ * This package contains the main classes and interfaces for the high performance hexagonal Lights
+ * Out brute force solver.
  * 
- * <h3>45/197 - ~22.8% of documentation completed</h3>
+ * <h3>116/194 - ~60.3% of documentation completed (including this package documentation and the
+ * enums for Grid's ValueFormat)</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package contains the main classes and interfaces for the high performance
+ * hexagonal Lights Out brute force solver.
+ * 
+ * <h3>25/197 - ~12.7% of documentation completed</h3>
+ */
+package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -2,7 +2,7 @@
  * This package contains the main classes and interfaces for the high performance hexagonal Lights
  * Out brute force solver.
  * 
- * <h3>116/194 - ~60.3% of documentation completed (including this package documentation and the
+ * <h3>141/194 - ~72.7% of documentation completed (including this package documentation and the
  * enums for Grid's ValueFormat)</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -1,8 +1,5 @@
 /**
  * This package contains the main classes and interfaces for the high performance hexagonal Lights
  * Out brute force solver.
- * 
- * <h3>182/194 - ~93.8% of documentation completed (including this package documentation and the
- * enums for Grid's ValueFormat)</h3>
  */
 package com.github.mrgarbagegamer;

--- a/src/main/java/com/github/mrgarbagegamer/package-info.java
+++ b/src/main/java/com/github/mrgarbagegamer/package-info.java
@@ -2,7 +2,7 @@
  * This package contains the main classes and interfaces for the high performance hexagonal Lights
  * Out brute force solver.
  * 
- * <h3>144/194 - ~74.2% of documentation completed (including this package documentation and the
+ * <h3>181/194 - ~93.3% of documentation completed (including this package documentation and the
  * enums for Grid's ValueFormat)</h3>
  */
 package com.github.mrgarbagegamer;


### PR DESCRIPTION
Improve documentation across the codebase by adding comprehensive Javadocs for classes, methods, and fields, while removing the unused GridType enumeration. This effort increases documentation coverage to 100% and enhances code maintainability and readability. Additionally, update the Maven configuration for Javadoc generation.